### PR TITLE
Update plotter input widgets

### DIFF
--- a/src/napari_phasors/_synthetic_generator.py
+++ b/src/napari_phasors/_synthetic_generator.py
@@ -1,17 +1,53 @@
-
-
-
-def make_raw_flim_data(n_time_bins=1000, shape=(2, 5), time_constants = [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50]):
+def make_raw_flim_data(n_time_bins=1000, shape=(2, 5), time_constants = [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50], laser_frequency=40.0):
     """Generate a synthetic FLIM data with exponential decay for each pixel.
+
+    Parameters
+    ----------
+    n_time_bins : int
+        Number of time bins.
+    shape : tuple (int, int)
+        Shape of the synthetic FLIM data.
+    time_constants : list of float
+        Time constants for the exponential decay.
+    laser_frequency : float
+        Frequency of the laser in MHz
+
+    Returns
+    -------
+    raw_flim_data : np.ndarray
+        A synthetic FLIM data with exponential decay for each pixel. The shape of the array is (n_time_bins, shape[0], shape[1]).
     """
     import numpy as np
-    n_samples = shape[0] * shape[1]   
-    # make a 1d array exponential decay for each time constant
-    raw_flim_data = np.moveaxis(np.array([np.exp(-(1/time_constant) * np.linspace(0, 10, n_time_bins)) for time_constant in time_constants]).reshape((*shape, n_time_bins)), -1, 0)
+    n_pixels = np.prod(shape)
+    # Ensure time_constants length matches the number of samples by repeating the whole list
+    time_constants = np.tile(time_constants, int(np.ceil(n_pixels / len(time_constants))))
+    time_constants = time_constants[:n_pixels]
+    # Make time array
+    time_window_ns = 1e9 / (laser_frequency * 1e6)
+    time_step = time_window_ns / n_time_bins  # ns
+    time_array = np.arange(0, n_time_bins) * time_step
+    # Make a 1d array exponential decay for each time constant
+    raw_flim_data = np.moveaxis(np.array([np.exp(-(1/time_constant) * time_array) for time_constant in time_constants]).reshape((*shape, n_time_bins)), -1, 0)
     return raw_flim_data
 
-def make_intensity_layer_with_phasors(raw_flim_data, axis=0, harmonic=None, filename='FLIM data'):
+def make_intensity_layer_with_phasors(raw_flim_data, axis=0, harmonic=None, name='FLIM data'):
     """Generate an intensity image layer with phasor features.
+
+    Parameters
+    ----------
+    raw_flim_data : np.ndarray
+        A synthetic FLIM data with exponential decay for each pixel.
+    axis : int
+        Axis of the time bins.
+    harmonic : int or list of int
+        The harmonic number(s) to calculate the phasor. If None, the default is 1.
+    name : str
+        Name of the layer.
+
+    Returns
+    -------
+    mean_intensity_image_layer : napari.layers.Image
+        A napari Image layer with a Labels layer in the metadata, which stores the phasors table in its features attribute.
     """
     import numpy as np
     from phasorpy.phasor import phasor_from_signal
@@ -29,6 +65,6 @@ def make_intensity_layer_with_phasors(raw_flim_data, axis=0, harmonic=None, file
     else:
         table = pd.DataFrame({'label': pixel_id, 'Average Image': mean_intensity_image.ravel(), 'G': G_image.ravel(), 'S': S_image.ravel(), 'harmonic': harmonic})
     labels_data = pixel_id.reshape(mean_intensity_image.shape)
-    labels_layer = Labels(labels_data, name=filename + ' Phasor Features Layer', scale=(1, 1), features=table)
-    mean_intensity_image_layer = Image(mean_intensity_image, name=filename + ' Intensity Image', metadata={'phasor_features_labels_layer': labels_layer})
+    labels_layer = Labels(labels_data, name=name + ' Phasor Features Layer', scale=(1, 1), features=table)
+    mean_intensity_image_layer = Image(mean_intensity_image, name=name + ' Intensity Image', metadata={'phasor_features_labels_layer': labels_layer})
     return mean_intensity_image_layer

--- a/src/napari_phasors/_synthetic_generator.py
+++ b/src/napari_phasors/_synthetic_generator.py
@@ -1,0 +1,34 @@
+
+
+
+def make_raw_flim_data(n_time_bins=1000, shape=(2, 5), time_constants = [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50]):
+    """Generate a synthetic FLIM data with exponential decay for each pixel.
+    """
+    import numpy as np
+    n_samples = shape[0] * shape[1]   
+    # make a 1d array exponential decay for each time constant
+    raw_flim_data = np.moveaxis(np.array([np.exp(-(1/time_constant) * np.linspace(0, 10, n_time_bins)) for time_constant in time_constants]).reshape((*shape, n_time_bins)), -1, 0)
+    return raw_flim_data
+
+def make_intensity_layer_with_phasors(raw_flim_data, axis=0, harmonic=None, filename='FLIM data'):
+    """Generate an intensity image layer with phasor features.
+    """
+    import numpy as np
+    from phasorpy.phasor import phasor_from_signal
+    from napari.layers import Labels, Image
+    import pandas as pd
+    if harmonic is None:
+        harmonic = 1
+    mean_intensity_image, G_image, S_image = phasor_from_signal(raw_flim_data, axis=axis, harmonic=harmonic)
+    pixel_id = np.arange(1, mean_intensity_image.size + 1)
+    if len(harmonic) > 1:
+        table = pd.DataFrame([])
+        for i in range(G_image.shape[0]):
+            sub_table = pd.DataFrame({'label': pixel_id, 'Average Image': mean_intensity_image.ravel(), 'G': G_image[i].ravel(), 'S': S_image[i].ravel(), 'harmonic': harmonic[i]})
+            table = pd.concat([table, sub_table])
+    else:
+        table = pd.DataFrame({'label': pixel_id, 'Average Image': mean_intensity_image.ravel(), 'G': G_image.ravel(), 'S': S_image.ravel(), 'harmonic': harmonic})
+    labels_data = pixel_id.reshape(mean_intensity_image.shape)
+    labels_layer = Labels(labels_data, name=filename + ' Phasor Features Layer', scale=(1, 1), features=table)
+    mean_intensity_image_layer = Image(mean_intensity_image, name=filename + ' Intensity Image', metadata={'phasor_features_labels_layer': labels_layer})
+    return mean_intensity_image_layer

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1,0 +1,56 @@
+from napari_phasors.plotter import PlotterWidget
+from napari_phasors._synthetic_generator import make_raw_flim_data, make_intensity_layer_with_phasors
+from biaplotter.plotter import ArtistType
+import numpy as np
+
+# Create a synthetic FLIM data and an intensity image layer with phasors for testing
+raw_flim_data = make_raw_flim_data()
+harmonic = [1, 2, 3]
+intensity_image_layer = make_intensity_layer_with_phasors(raw_flim_data, harmonic=harmonic)
+
+def test_phasor_plotter(make_napari_viewer):
+    # Intialize viewer and add intensity image layer with phasors data
+    viewer = make_napari_viewer()
+    viewer.add_layer(intensity_image_layer)
+    phasors_table = intensity_image_layer.metadata['phasor_features_labels_layer'].features
+    assert phasors_table.shape == (30, 5) # rows: 10 pixels (2x5 image) x 3 harmonics; columns: 5
+
+    # Create Plotter widget
+    plotter = PlotterWidget(viewer)
+
+    # Call the plot method
+    plotter.plot()
+    # Check that new layer is created
+    assert len(viewer.layers) == 2
+    # Check that 'Phasors Selected' Labels layer is empty
+    assert viewer.layers['Phasors Selected'].data.any() == False
+
+    # Check that Image layer with phasors is in the plotter combobox
+    image_layer_combobox_items = [plotter.plotter_inputs_widget.image_layer_with_phasor_features_combobox.itemText(i)
+                                  for i in range(plotter.plotter_inputs_widget.image_layer_with_phasor_features_combobox.count())]
+    assert intensity_image_layer.name in image_layer_combobox_items
+
+    # Update input parameters
+    plotter.harmonic = 2
+    plotter.histogram_colormap = 'viridis'
+    plotter.histogram_bins = 5
+    plotter.histogram_log_scale = True
+    plotter.plot_type = ArtistType.SCATTER.name
+    plotter.plot()
+
+    # Add new phasor selection id
+    plotter.selection_id = 'selection_1'
+    # Check that table contains new column
+    phasors_table = intensity_image_layer.metadata['phasor_features_labels_layer'].features
+    assert phasors_table.shape == (30, 6)
+    assert 'selection_1' in phasors_table.columns
+
+    # Select first 3 points
+    manual_selection = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 0])
+    plotter.canvas_widget.active_artist.color_indices = manual_selection
+    # Check that 'Phasors Selected' Labels layer contains selection
+    assert viewer.layers['Phasors Selected'].data.ravel().tolist() == manual_selection.tolist()
+    # Check that new column in phasors_table contains selection for each harmonic
+    for h in harmonic:
+        h_mask = phasors_table['harmonic'] == h
+        assert phasors_table.loc[h_mask, 'selection_1'].values.tolist() == manual_selection.tolist()

--- a/src/napari_phasors/_tests/test_synthetic_generator.py
+++ b/src/napari_phasors/_tests/test_synthetic_generator.py
@@ -1,0 +1,20 @@
+def test_synthetic_generator():
+    from napari_phasors._synthetic_generator import make_raw_flim_data, make_intensity_layer_with_phasors
+    from napari_phasors.plotter import DATA_COLUMNS
+    from napari.layers import Labels
+
+    # Create a synthetic FLIM data and an intensity image layer with phasors
+    raw_flim_data = make_raw_flim_data()
+    harmonic = [1, 2, 3]
+    intensity_image_layer = make_intensity_layer_with_phasors(raw_flim_data, harmonic=harmonic)
+
+    # Check that Image layer contains Labels layer in metadata
+    assert 'phasor_features_labels_layer' in intensity_image_layer.metadata
+    assert isinstance(intensity_image_layer.metadata['phasor_features_labels_layer'], Labels)
+    assert hasattr(intensity_image_layer.metadata['phasor_features_labels_layer'], 'features')
+
+    # Check phasors_table generation
+    phasors_table = intensity_image_layer.metadata['phasor_features_labels_layer'].features
+    # Ensure all items in DATA_COLUMNS are columns in the phasors_table
+    for column in DATA_COLUMNS:
+        assert column in phasors_table

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -36,19 +36,26 @@ from napari_phasors._synthetic_generator import (
 if TYPE_CHECKING:
     import napari
 
+#: The columns in the phasor features table that should not be used as selection id.
 DATA_COLUMNS = ['label', 'Average Image', 'G', 'S', 'harmonic']
 
 def colormap_to_dict(colormap, num_colors=10, exclude_first=True):
     """
     Converts a matplotlib colormap into a dictionary of RGBA colors.
 
-    Parameters:
-        colormap (matplotlib.colors.Colormap): The colormap to convert.
-        num_colors (int): The number of discrete colors to extract from the colormap.
-        exclude_first (bool): Whether to exclude the first color in the colormap.
+    Parameters
+    ----------
+    colormap : matplotlib.colors.Colormap
+        The colormap to convert.
+    num_colors : int, optional
+        The number of colors in the colormap, by default 10.
+    exclude_first : bool, optional
+        Whether to exclude the first color in the colormap, by default True.
 
-    Returns:
-        dict: A dictionary with keys as positive integers and values as RGBA colors.
+    Returns
+    -------
+    color_dict: dict
+        A dictionary with keys as positive integers and values as RGBA colors.
     """
     color_dict = {}
     start = 0

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -135,7 +135,6 @@ class PlotterWidget(QWidget):
                 self._labels_layer_with_phasor_features.features['label']).astype(int)
         # Populate comboboxes
         for column in self._labels_layer_with_phasor_features.features.columns:
-            print(column)
             hue_combobox_items = [self.plotter_inputs_widget.hue_combobox.itemText(i) 
                         for i in range(self.plotter_inputs_widget.hue_combobox.count())]
             x_axis_combobox_items = [self.plotter_inputs_widget.x_axis_combobox.itemText(i) 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -186,6 +186,8 @@ class PlotterWidget(QWidget):
         self._phasors_selected_layer = None
         self._colormap = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].categorical_colormap
         self._histogram_colormap = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_colormap
+        # Start with the histogram2d plot type
+        self.plot_type = ArtistType.HISTOGRAM2D.name
 
         # Populate labels layer combobox
         self.reset_layer_choices()
@@ -216,6 +218,8 @@ class PlotterWidget(QWidget):
             notifications.WarningNotification(f"{new_selection_id} is not a valid selection column. It must not be one of {DATA_COLUMNS}.")
             return
         else:
+            if new_selection_id not in [self.plotter_inputs_widget.phasor_selection_id_combobox.itemText(i) for i in range(self.plotter_inputs_widget.phasor_selection_id_combobox.count())]:
+                self.plotter_inputs_widget.phasor_selection_id_combobox.addItem(new_selection_id)
             self.plotter_inputs_widget.phasor_selection_id_combobox.setCurrentText(new_selection_id)
             # If column_name is not in features, add it with zeros
             if new_selection_id not in self._labels_layer_with_phasor_features.features.columns:
@@ -451,7 +455,8 @@ class PlotterWidget(QWidget):
 
 if __name__ == "__main__":
     import napari
-    raw_flim_data = make_raw_flim_data()
+    time_constants = [0.1, 1, 10]
+    raw_flim_data = make_raw_flim_data(time_constants=time_constants)
     harmonic = [1, 2, 3]
     intensity_image_layer = make_intensity_layer_with_phasors(raw_flim_data, harmonic=harmonic)
     viewer = napari.Viewer()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -135,11 +135,20 @@ class PlotterWidget(QWidget):
                 self._labels_layer_with_phasor_features.features['label']).astype(int)
         # Populate comboboxes
         for column in self._labels_layer_with_phasor_features.features.columns:
-            if 'SELECTION' in column:
-                self.plotter_inputs_widget.hue_combobox.addItem(column)
-            elif column != 'label' and column != 'frame':
-                self.plotter_inputs_widget.x_axis_combobox.addItem(column)
-                self.plotter_inputs_widget.y_axis_combobox.addItem(column)
+            print(column)
+            hue_combobox_items = [self.plotter_inputs_widget.hue_combobox.itemText(i) 
+                        for i in range(self.plotter_inputs_widget.hue_combobox.count())]
+            x_axis_combobox_items = [self.plotter_inputs_widget.x_axis_combobox.itemText(i) 
+                        for i in range(self.plotter_inputs_widget.x_axis_combobox.count())]
+            y_axis_combobox_items = [self.plotter_inputs_widget.y_axis_combobox.itemText(i)
+                        for i in range(self.plotter_inputs_widget.y_axis_combobox.count())]
+            all_items = hue_combobox_items + x_axis_combobox_items + y_axis_combobox_items
+            if column not in all_items:
+                if 'SELECTION' in column:
+                    self.plotter_inputs_widget.hue_combobox.addItem(column)
+                elif column != 'label' and column != 'frame':
+                    self.plotter_inputs_widget.x_axis_combobox.addItem(column)
+                    self.plotter_inputs_widget.y_axis_combobox.addItem(column)
 
         # Set initial comboboxes default choices
         for i in range(self.plotter_inputs_widget.x_axis_combobox.count()):

--- a/src/napari_phasors/ui/plotter_inputs_widget.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget.ui
@@ -6,83 +6,118 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>592</width>
-    <height>609</height>
+    <width>591</width>
+    <height>565</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="1">
-    <widget class="QComboBox" name="y_axis_combobox"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="hue_label_widget">
-     <property name="text">
-      <string>Hue:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="image_layer_with_phasor_features_combobox"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="x_axis_combobox"/>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="plot_type_combobox"/>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QPushButton" name="plot_pushbutton">
-     <property name="text">
-      <string>Plot</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="plot_type_label_widget">
-     <property name="text">
-      <string>Plot Type:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="x_axis_label_widget">
-     <property name="text">
-      <string>X-axis:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="hue_combobox"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="image_layer_with_phasor_features_label_widget">
-     <property name="text">
-      <string>Image Layer with Phasor Features:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="y_axis_label_widget">
-     <property name="text">
-      <string>Y-axis:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="minimumSize">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>410</width>
+       <height>200</height>
       </size>
      </property>
-    </spacer>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>571</width>
+        <height>545</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="harmonic_spinbox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="phasor_selection_id_combobox">
+         <property name="editable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Harmonic:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Image Layer with Phasor Features:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="image_layer_with_phasor_features_combobox"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Threshold:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Median Filter Kernel Size:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Phasor Selection ID:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QSlider" name="threshold_slider">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QSpinBox" name="median_filter_spinbox">
+         <property name="minimum">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="semi_circle_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Universal Semi-Circle / Full Polar Plot:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
@@ -70,7 +70,17 @@
         </widget>
        </item>
        <item row="3" column="1">
-        <widget class="QSpinBox" name="number_of_bins_spinbox"/>
+        <widget class="QSpinBox" name="number_of_bins_spinbox">
+         <property name="minimum">
+          <number>2</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>10</number>
+         </property>
+        </widget>
        </item>
        <item row="3" column="0">
         <widget class="QLabel" name="label_3">

--- a/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>590</width>
+    <height>398</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>570</width>
+        <height>378</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="log_scale_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Colors in Log Scale:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="plot_type_combobox"/>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Plot Type:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="colormap_combobox"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Colormap:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QSpinBox" name="number_of_bins_spinbox"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Number of Histogram 2D Bins:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR adds a new layout to the PlotterWidget generated with Qt designer.
It introduces:
- an editable `Phasor Selection ID` ComboBox (**functional**)
- a `Harmonic` SpinBox (**functional**)
- a `Threshold` Slider (**non-functional**)
- a `Median Filter Kernel Size` SpinBox (**non-functional**)
- a `Universal Semi-Circle / Full Polar Plot` CheckBox (**non-functional**)
Plus a Collapsible field with more widgets that control some plotter display options:
- `Plot Type` ComboBox was moved here (**functional**)
- `Colormap` ComboBox (**functional**)
- `Number of Histogram 2D Bins` SpinBox (**functional**)
- `Colors in Log Scale` CheckBox (**functional, but needs more tests with larger data**)

It also add a new module called `_synthetic_generator` with a few functions to generate synthetic FLIM data.

It adds tests for `_synthetic_generator` and `plotter` modules.

This should close #8  and close #20.