### PR TITLE
Add writer widget to export phasor data to OME-TIF.

### DIFF
--- a/src/napari_phasors/__init__.py
+++ b/src/napari_phasors/__init__.py
@@ -2,7 +2,7 @@ __version__ = "0.0.1"
 
 from ._reader import napari_get_reader
 from ._sample_data import make_sample_data
-from ._widget import CalibrationWidget, PhasorTransform
+from ._widget import CalibrationWidget, PhasorTransform, WriterWidget
 from ._writer import write_ome_tiff
 from .plotter import PlotterWidget
 
@@ -13,4 +13,5 @@ __all__ = (
     "PhasorTransform",
     "PlotterWidget",
     "CalibrationWidget",
+    "WriterWidget",
 )

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union
 
+from napari.layers import Image
 import numpy as np
 from phasorpy.io import phasor_to_ometiff
 
@@ -24,8 +25,8 @@ def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
     path : str
         A string path indicating where to save the image file.
     image_layer : napari.layers.Image
-        Napari image layer. Must contain as first element the mean
-        intensity image and as second element a dict with `metadata` as key.
+        Napari image layer or a list with the mean intensity image as the
+        first element and as second element a dict with `metadata` as key.
         The value associated to 'metadata' must be a dict with
         `phasor_features_labels_layer` as key which contains as value a Labels
         layer with a Dataframe with `G`, `S`  and 'harmonic' columns.
@@ -34,8 +35,12 @@ def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
     -------
     A list containing the string path to the saved file.
     """
-    mean = image_layer[0][0]
-    phasor_data = image_layer[0][1]["metadata"]["phasor_features_labels_layer"]
+    if isinstance(image_layer, Image):
+        mean = image_layer.data
+        phasor_data = image_layer.metadata["phasor_features_labels_layer"]
+    else:
+        mean = image_layer[0][0]
+        phasor_data = image_layer[0][1]["metadata"]["phasor_features_labels_layer"]
     harmonics = phasor_data.features["harmonic"].unique()
     G = np.reshape(phasor_data.features["G"], (len(harmonics), *mean.shape))
     S = np.reshape(phasor_data.features["S"], (len(harmonics), *mean.shape))

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union
 
-from napari.layers import Image
 import numpy as np
+from napari.layers import Image
 from phasorpy.io import phasor_to_ometiff
 
 if TYPE_CHECKING:
@@ -40,7 +40,9 @@ def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
         phasor_data = image_layer.metadata["phasor_features_labels_layer"]
     else:
         mean = image_layer[0][0]
-        phasor_data = image_layer[0][1]["metadata"]["phasor_features_labels_layer"]
+        phasor_data = image_layer[0][1]["metadata"][
+            "phasor_features_labels_layer"
+        ]
     harmonics = phasor_data.features["harmonic"].unique()
     G = np.reshape(phasor_data.features["G"], (len(harmonics), *mean.shape))
     S = np.reshape(phasor_data.features["S"], (len(harmonics), *mean.shape))

--- a/src/napari_phasors/napari.yaml
+++ b/src/napari_phasors/napari.yaml
@@ -24,6 +24,9 @@ contributions:
     - id: napari-phasors.CalibrationWidget
       python_name: napari_phasors:CalibrationWidget
       title: Calibration Widget
+    - id: napari-phasors.WriterWidget
+      python_name: napari_phasors:WriterWidget
+      title: Export to OME-TIF Widget
   readers:
     - command: napari-phasors.get_reader
       accepts_directories: false
@@ -44,3 +47,5 @@ contributions:
       display_name: Phasor Transform
     - command: napari-phasors.CalibrationWidget
       display_name: Calibration Widget
+    - command: napari-phasors.WriterWidget
+      display_name: Export to OME-TIF Widget


### PR DESCRIPTION
This PR adds a writer widget to select location and file name to export an Image Layer that contains phasor data to 'OME-TIF' using the writer function `write_ome_tif` which uses `phasorpy.io.phasor_to_ometiff` function.