### PR TITLE
Implement filtering and thresholding for plotter

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -165,7 +165,10 @@ def raw_file_reader(
         )
         add_kwargs = {
             "name": f"{filename} Intensity Image",
-            "metadata": {"phasor_features_labels_layer": labels_layer, "original_mean": mean_intensity_image},
+            "metadata": {
+                "phasor_features_labels_layer": labels_layer,
+                "original_mean": mean_intensity_image,
+            },
         }
         layers.append((mean_intensity_image, add_kwargs))
     else:
@@ -186,7 +189,10 @@ def raw_file_reader(
             )
             add_kwargs = {
                 "name": f"{filename} Intensity Image: Channel {channel}",
-                "metadata": {"phasor_features_labels_layer": labels_layer, "original_mean": mean_intensity_image},
+                "metadata": {
+                    "phasor_features_labels_layer": labels_layer,
+                    "original_mean": mean_intensity_image,
+                },
             }
             layers.append((mean_intensity_image, add_kwargs))
     return layers
@@ -299,7 +305,7 @@ def make_phasors_labels_layer(
             harmonic_value = harmonics if harmonics is not None else 1
         table = pd.DataFrame(
             {
-                "label": pixel_id,                
+                "label": pixel_id,
                 "G_original": G_image.ravel(),
                 "S_original": S_image.ravel(),
                 "G": G_image.ravel(),

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -165,7 +165,7 @@ def raw_file_reader(
         )
         add_kwargs = {
             "name": f"{filename} Intensity Image",
-            "metadata": {"phasor_features_labels_layer": labels_layer},
+            "metadata": {"phasor_features_labels_layer": labels_layer, "original_mean": mean_intensity_image},
         }
         layers.append((mean_intensity_image, add_kwargs))
     else:
@@ -186,7 +186,7 @@ def raw_file_reader(
             )
             add_kwargs = {
                 "name": f"{filename} Intensity Image: Channel {channel}",
-                "metadata": {"phasor_features_labels_layer": labels_layer},
+                "metadata": {"phasor_features_labels_layer": labels_layer, "original_mean": mean_intensity_image},
             }
             layers.append((mean_intensity_image, add_kwargs))
     return layers
@@ -239,6 +239,7 @@ def processed_file_reader(
         "name": filename + " Intensity Image",
         "metadata": {
             "phasor_features_labels_layer": labels_layer,
+            "original_mean": mean_intensity_image,
             "attrs": attrs,
         },
     }
@@ -283,6 +284,8 @@ def make_phasors_labels_layer(
             sub_table = pd.DataFrame(
                 {
                     "label": pixel_id,
+                    "G_original": G_image[i].ravel(),
+                    "S_original": S_image[i].ravel(),
                     "G": G_image[i].ravel(),
                     "S": S_image[i].ravel(),
                     "harmonic": harmonic_value,
@@ -296,7 +299,9 @@ def make_phasors_labels_layer(
             harmonic_value = harmonics if harmonics is not None else 1
         table = pd.DataFrame(
             {
-                "label": pixel_id,
+                "label": pixel_id,                
+                "G_original": G_image.ravel(),
+                "S_original": S_image.ravel(),
                 "G": G_image.ravel(),
                 "S": S_image.ravel(),
                 "harmonic": harmonic_value,

--- a/src/napari_phasors/_synthetic_generator.py
+++ b/src/napari_phasors/_synthetic_generator.py
@@ -86,7 +86,9 @@ def make_intensity_layer_with_phasors(
             sub_table = pd.DataFrame(
                 {
                     "label": pixel_id,
-                    "Average Image": mean_intensity_image.ravel(),
+                    # "Average Image": mean_intensity_image.ravel(),
+                    "G_original": G_image[i].ravel(),
+                    "S_original": S_image[i].ravel(),
                     "G": G_image[i].ravel(),
                     "S": S_image[i].ravel(),
                     "harmonic": harmonic[i],
@@ -97,7 +99,9 @@ def make_intensity_layer_with_phasors(
         table = pd.DataFrame(
             {
                 "label": pixel_id,
-                "Average Image": mean_intensity_image.ravel(),
+                # "Average Image": mean_intensity_image.ravel(),
+                "G_original": G_image[i].ravel(),
+                "S_original": S_image[i].ravel(),
                 "G": G_image.ravel(),
                 "S": S_image.ravel(),
                 "harmonic": harmonic,
@@ -113,6 +117,6 @@ def make_intensity_layer_with_phasors(
     mean_intensity_image_layer = Image(
         mean_intensity_image,
         name=name + " Intensity Image",
-        metadata={"phasor_features_labels_layer": labels_layer},
+        metadata={"phasor_features_labels_layer": labels_layer, "original_mean": mean_intensity_image},
     )
     return mean_intensity_image_layer

--- a/src/napari_phasors/_synthetic_generator.py
+++ b/src/napari_phasors/_synthetic_generator.py
@@ -117,6 +117,9 @@ def make_intensity_layer_with_phasors(
     mean_intensity_image_layer = Image(
         mean_intensity_image,
         name=name + " Intensity Image",
-        metadata={"phasor_features_labels_layer": labels_layer, "original_mean": mean_intensity_image},
+        metadata={
+            "phasor_features_labels_layer": labels_layer,
+            "original_mean": mean_intensity_image,
+        },
     )
     return mean_intensity_image_layer

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -34,7 +34,14 @@ def test_reader_ptu():
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (65536, 6)
-    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
+    expected_columns = [
+        "label",
+        "G_original",
+        "S_original",
+        "G",
+        "S",
+        "harmonic",
+    ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 
@@ -69,7 +76,14 @@ def test_reader_fbd():
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (65536, 6)
-    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
+    expected_columns = [
+        "label",
+        "G_original",
+        "S_original",
+        "G",
+        "S",
+        "harmonic",
+    ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
     # Second Channel
@@ -95,7 +109,14 @@ def test_reader_fbd():
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (65536, 6)
-    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
+    expected_columns = [
+        "label",
+        "G_original",
+        "S_original",
+        "G",
+        "S",
+        "harmonic",
+    ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 
@@ -126,7 +147,14 @@ def test_reader_lsm():
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (262144, 6)
-    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
+    expected_columns = [
+        "label",
+        "G_original",
+        "S_original",
+        "G",
+        "S",
+        "harmonic",
+    ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 
@@ -158,7 +186,14 @@ def test_reader_ometif():
     assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (65536, 6)
-    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
+    expected_columns = [
+        "label",
+        "G_original",
+        "S_original",
+        "G",
+        "S",
+        "harmonic",
+    ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -33,8 +33,8 @@ def test_reader_ptu():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 4)
-    expected_columns = ["label", "G", "S", "harmonic"]
+    assert phasor_features.features.shape == (65536, 6)
+    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 
@@ -68,8 +68,8 @@ def test_reader_fbd():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 4)
-    expected_columns = ["label", "G", "S", "harmonic"]
+    assert phasor_features.features.shape == (65536, 6)
+    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
     # Second Channel
@@ -94,8 +94,8 @@ def test_reader_fbd():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 4)
-    expected_columns = ["label", "G", "S", "harmonic"]
+    assert phasor_features.features.shape == (65536, 6)
+    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 
@@ -125,8 +125,8 @@ def test_reader_lsm():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 4)
-    expected_columns = ["label", "G", "S", "harmonic"]
+    assert phasor_features.features.shape == (262144, 6)
+    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 
@@ -157,8 +157,8 @@ def test_reader_ometif():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 4)
-    expected_columns = ["label", "G", "S", "harmonic"]
+    assert phasor_features.features.shape == (65536, 6)
+    expected_columns = ["label", "G_original", "S_original", "G", "S", "harmonic"]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
 

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -24,8 +24,9 @@ def test_reader_ptu():
         layer_data_tuple[1]["name"] == "test_file Intensity Image: Channel 0"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 1
+        len(layer_data_tuple[1]["metadata"]) == 2
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
+        and "original_mean" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -66,8 +67,9 @@ def test_reader_fbd():
         == "test_file$EI0S Intensity Image: Channel 0"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 1
+        len(layer_data_tuple[1]["metadata"]) == 2
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
+        and "original_mean" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -99,8 +101,9 @@ def test_reader_fbd():
         == "test_file$EI0S Intensity Image: Channel 1"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 1
+        len(layer_data_tuple[1]["metadata"]) == 2
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
+        and "original_mean" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -137,8 +140,9 @@ def test_reader_lsm():
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert layer_data_tuple[1]["name"] == "test_file Intensity Image"
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 1
+        len(layer_data_tuple[1]["metadata"]) == 2
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
+        and "original_mean" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -175,9 +179,10 @@ def test_reader_ometif():
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert layer_data_tuple[1]["name"] == "test_file Intensity Image"
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "attrs" in layer_data_tuple[1]["metadata"]
+        and "original_mean" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -1,0 +1,65 @@
+import numpy as np
+from phasorpy.phasor import phasor_filter, phasor_threshold
+
+from napari_phasors._synthetic_generator import (
+    make_intensity_layer_with_phasors,
+    make_raw_flim_data,
+)
+from napari_phasors._utils import apply_filter_and_threshold
+
+
+def test_apply_filter_and_threshold(make_napari_viewer):
+    """Test apply_filter_and_threshold function."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    harmonic = [1, 2]
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+    original_mean = intensity_image_layer.metadata['original_mean']
+    original_g = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['G']
+    original_s = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['S']
+    assert np.all(
+        intensity_image_layer.data
+        == intensity_image_layer.metadata['original_mean']
+    )
+    assert not np.any(np.isnan(intensity_image_layer.data))
+    viewer = make_napari_viewer()
+    viewer.add_layer(intensity_image_layer)
+    threshold = 0.02
+    apply_filter_and_threshold(intensity_image_layer, threshold=threshold)
+    assert np.all(
+        intensity_image_layer.metadata['original_mean'] == original_mean
+    )
+    assert intensity_image_layer.data.shape == (5, 5)
+    assert np.isnan(intensity_image_layer.data[0][0])
+    assert not np.isnan(intensity_image_layer.data[0][4])
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features
+    assert np.all(phasor_features['G_original'] == original_g)
+    assert np.all(phasor_features['S_original'] == original_s)
+    harmonics = np.unique(phasor_features['harmonic'])
+    original_g = np.reshape(
+        original_g, (len(harmonics),) + original_mean.data.shape
+    )
+    original_s = np.reshape(
+        original_s, (len(harmonics),) + original_mean.data.shape
+    )
+    original_g, original_s = phasor_filter(
+        original_g, original_s, repeat=1, size=3, axes=(1, 2)
+    )
+    mean, original_g, original_s = phasor_threshold(
+        original_mean, original_g, original_s, threshold
+    )
+    filtered_thresholded_g = np.reshape(
+        phasor_features['G'], (len(harmonics),) + original_mean.data.shape
+    )
+    filtered_thresholded_s = np.reshape(
+        phasor_features['S'], (len(harmonics),) + original_mean.data.shape
+    )
+    assert np.allclose(original_g, filtered_thresholded_g, equal_nan=True)
+    assert np.allclose(original_s, filtered_thresholded_s, equal_nan=True)

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -52,7 +52,7 @@ def test_apply_filter_and_threshold(make_napari_viewer):
     original_g, original_s = phasor_filter(
         original_g, original_s, repeat=1, size=3, axes=(1, 2)
     )
-    mean, original_g, original_s = phasor_threshold(
+    _, original_g, original_s = phasor_threshold(
         original_mean, original_g, original_s, threshold
     )
     filtered_thresholded_g = np.reshape(

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -55,8 +55,15 @@ def test_write_ometif(tmp_path):
     np.testing.assert_array_equal(
         phasor_features.data, [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
     )
-    assert phasor_features.features.shape == (30, 4)
-    expected_columns = ["label", "G", "S", "harmonic"]
+    assert phasor_features.features.shape == (30, 6)
+    expected_columns = [
+        "label",
+        "G_original",
+        "S_original",
+        "G",
+        "S",
+        "harmonic",
+    ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
     assert phasor_features.features["harmonic"].unique().tolist() == [1, 2, 3]

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -44,14 +44,15 @@ def apply_filter_and_threshold(
     )
     real = np.reshape(real, (len(harmonics),) + mean.shape)
     imag = np.reshape(imag, (len(harmonics),) + mean.shape)
-    real, imag = phasor_filter(
-        real,
-        imag,
-        method=method,
-        repeat=repeat,
-        size=size,
-        axes=tuple(range(1, real.ndim)),
-    )
+    if repeat > 1:
+        real, imag = phasor_filter(
+            real,
+            imag,
+            method=method,
+            repeat=repeat,
+            size=size,
+            axes=tuple(range(1, real.ndim)),
+        )
     mean, real, imag = phasor_threshold(mean, real, imag, threshold)
     (
         layer.metadata['phasor_features_labels_layer'].features['G'],

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2,12 +2,23 @@
 This module contains utility functions used by other modules.
 
 """
+
+import warnings
+
+import numpy as np
 from napari.layers import Image
 from phasorpy.phasor import phasor_filter, phasor_threshold
-import numpy as np
 
 
-def apply_filter_and_threshold(layer: Image, /, *, threshold: float = 0, method: str = 'median', size: int = 3, repeat: int = 3):
+def apply_filter_and_threshold(
+    layer: Image,
+    /,
+    *,
+    threshold: float = 0,
+    method: str = 'median',
+    size: int = 3,
+    repeat: int = 1,
+):
     """Apply filter to an image layer.
 
     Parameters
@@ -27,17 +38,33 @@ def apply_filter_and_threshold(layer: Image, /, *, threshold: float = 0, method:
     mean = layer.metadata['original_mean'].copy()
     phasor_features = layer.metadata['phasor_features_labels_layer'].features
     harmonics = np.unique(phasor_features['harmonic'])
-    real, imag = phasor_features['G_original'].copy(), phasor_features['S_original'].copy()
+    real, imag = (
+        phasor_features['G_original'].copy(),
+        phasor_features['S_original'].copy(),
+    )
     real = np.reshape(real, (len(harmonics),) + mean.shape)
     imag = np.reshape(imag, (len(harmonics),) + mean.shape)
-    real, imag = phasor_filter(real, imag, method=method, repeat=repeat, size=size, axes=tuple(range(real.ndim-2, real.ndim)))
+    real, imag = phasor_filter(
+        real,
+        imag,
+        method=method,
+        repeat=repeat,
+        size=size,
+        axes=tuple(range(1, real.ndim)),
+    )
     mean, real, imag = phasor_threshold(mean, real, imag, threshold)
-    layer.metadata['phasor_features_labels_layer'].features['G'], layer.metadata['phasor_features_labels_layer'].features['S'] = real.flatten(), imag.flatten()
-    if len(harmonics)>1:
-        #TODO: remove this when `phasor_threshold` handles multiple harmonics.
-        merged_mean = np.nanmax(mean, axis=0)
-        merged_mean[np.isnan(np.nanmin(mean, axis=0))] = np.nan
-        mean = merged_mean
+    (
+        layer.metadata['phasor_features_labels_layer'].features['G'],
+        layer.metadata['phasor_features_labels_layer'].features['S'],
+    ) = (real.flatten(), imag.flatten())
+    if len(harmonics) > 1:
+        # TODO: remove this when `phasor_threshold` handles multiple harmonics.
+        # Catch the RuntimeWarning for all-NaN slices
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            merged_mean = np.nanmax(mean, axis=0)
+            merged_mean[np.isnan(np.nanmin(mean, axis=0))] = np.nan
+            mean = merged_mean
     layer.data = mean
     layer.refresh()
     return

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -1,0 +1,43 @@
+"""
+This module contains utility functions used by other modules.
+
+"""
+from napari.layers import Image
+from phasorpy.phasor import phasor_filter, phasor_threshold
+import numpy as np
+
+
+def apply_filter_and_threshold(layer: Image, /, *, threshold: float = 0, method: str = 'median', size: int = 3, repeat: int = 3):
+    """Apply filter to an image layer.
+
+    Parameters
+    ----------
+    layer : napari.layers.Image
+        Napari image layer with phasor features.
+    threshold : float
+        Threshold value for the mean value to be applied to G and S.
+    method : str
+        Filter method. Options are 'median'.
+    size : int
+        Size of the filter.
+    repeat : int
+        Number of times to apply the filter.
+
+    """
+    mean = layer.metadata['original_mean'].copy()
+    phasor_features = layer.metadata['phasor_features_labels_layer'].features
+    harmonics = np.unique(phasor_features['harmonic'])
+    real, imag = phasor_features['G_original'].copy(), phasor_features['S_original'].copy()
+    real = np.reshape(real, (len(harmonics),) + mean.shape)
+    imag = np.reshape(imag, (len(harmonics),) + mean.shape)
+    real, imag = phasor_filter(real, imag, method=method, repeat=repeat, size=size, axes=tuple(range(real.ndim-2, real.ndim)))
+    mean, real, imag = phasor_threshold(mean, real, imag, threshold)
+    layer.metadata['phasor_features_labels_layer'].features['G'], layer.metadata['phasor_features_labels_layer'].features['S'] = real.flatten(), imag.flatten()
+    if len(harmonics)>1:
+        #TODO: remove this when `phasor_threshold` handles multiple harmonics.
+        merged_mean = np.nanmax(mean, axis=0)
+        merged_mean[np.isnan(np.nanmin(mean, axis=0))] = np.nan
+        mean = merged_mean
+    layer.data = mean
+    layer.refresh()
+    return

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -44,7 +44,7 @@ def apply_filter_and_threshold(
     )
     real = np.reshape(real, (len(harmonics),) + mean.shape)
     imag = np.reshape(imag, (len(harmonics),) + mean.shape)
-    if repeat > 1:
+    if repeat > 0:
         real, imag = phasor_filter(
             real,
             imag,

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -8,8 +8,8 @@ This module contains widgets to:
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
-import numpy as np
 
+import numpy as np
 from napari.layers import Image
 from napari.utils.notifications import show_error, show_info
 from phasorpy.phasor import phasor_calibrate

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -563,6 +563,8 @@ class PlotterWidget(QWidget):
 
         # if active artist is histogram, add a colorbar
         if self.plot_type == ArtistType.HISTOGRAM2D.name:
+            if self.colorbar is not None:
+                self.colorbar.remove()
             # creat cax for colorbar on the right side of the histogram
             self.cax = self.canvas_widget.artists[
                 ArtistType.HISTOGRAM2D
@@ -578,6 +580,7 @@ class PlotterWidget(QWidget):
                 .norm,
             )
             # self.colorbar = self.canvas_widget.figure.colorbar(self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[-1], ax=self.canvas_widget.artists[ArtistType.HISTOGRAM2D].ax, use_gridspec=True)
+
             # set colorbar tick color
             self.colorbar.ax.yaxis.set_tick_params(color="white")
             # set colorbar edgecolor
@@ -642,7 +645,7 @@ class PlotterWidget(QWidget):
 
     def on_threshold_slider_change(self):
         self.plotter_inputs_widget.label_3.setText(
-            'Threshold: '
+            'Intensity threshold: '
             + str(self.plotter_inputs_widget.threshold_slider.value() / 10)
         )
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1,11 +1,12 @@
+from math import ceil, log10
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import matplotlib.ticker as ticker
 import numpy as np
 from biaplotter.plotter import ArtistType, CanvasWidget
 from matplotlib.colorbar import Colorbar
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, Normalize
-import matplotlib.ticker as ticker
 from napari.layers import Image, Labels
 from napari.utils import DirectLabelColormap, colormaps, notifications
 from qtpy import uic
@@ -18,7 +19,6 @@ from qtpy.QtWidgets import (
 )
 from skimage.util import map_array
 from superqt import QCollapsible
-from math import ceil, log10
 
 from napari_phasors._synthetic_generator import (
     make_intensity_layer_with_phasors,
@@ -400,13 +400,18 @@ class PlotterWidget(QWidget):
             return
         column = self.selection_id
         # Update the manual selection in the labels layer with phasor features for each harmonic
-        harmonics = np.unique(self._labels_layer_with_phasor_features.features["harmonic"])
+        harmonics = np.unique(
+            self._labels_layer_with_phasor_features.features["harmonic"]
+        )
         self._labels_layer_with_phasor_features.features[column] = 0
         # Filter rows where 'G' is not NaN
-        valid_rows = ~self._labels_layer_with_phasor_features.features["G"].isna() & ~self._labels_layer_with_phasor_features.features["S"].isna()
+        valid_rows = (
+            ~self._labels_layer_with_phasor_features.features["G"].isna()
+            & ~self._labels_layer_with_phasor_features.features["S"].isna()
+        )
         self._labels_layer_with_phasor_features.features.loc[
             valid_rows, column
-        ] = np.tile(manual_selection, len(harmonics))[:valid_rows.sum()]
+        ] = np.tile(manual_selection, len(harmonics))[: valid_rows.sum()]
         self.create_phasors_selected_layer()
 
     def reset_layer_choices(self):
@@ -449,17 +454,23 @@ class PlotterWidget(QWidget):
         self.plotter_inputs_widget.harmonic_spinbox.setMaximum(
             self._labels_layer_with_phasor_features.features["harmonic"].max()
         )
-        max_mean_value = self.viewer.layers[
-            labels_layer_name
-        ].metadata["original_mean"].max()
+        max_mean_value = (
+            self.viewer.layers[labels_layer_name]
+            .metadata["original_mean"]
+            .max()
+        )
         # Determine the threshold factor based on max_mean_value using logarithmic scaling
         if max_mean_value > 0:
             magnitude = int(log10(max_mean_value))
-            self.threshold_factor = 10 ** (2 - magnitude) if magnitude <= 2 else 1
+            self.threshold_factor = (
+                10 ** (2 - magnitude) if magnitude <= 2 else 1
+            )
         else:
             self.threshold_factor = 1  # Default case for values less than 1
         # Set harmonic spinbox maximum value based on maximum mean
-        self.plotter_inputs_widget.threshold_slider.setMaximum(ceil(max_mean_value*self.threshold_factor))
+        self.plotter_inputs_widget.threshold_slider.setMaximum(
+            ceil(max_mean_value * self.threshold_factor)
+        )
 
     def get_features(self):
         """Get the G and S features for the selected harmonic and selection id.
@@ -520,7 +531,8 @@ class PlotterWidget(QWidget):
         )
         apply_filter_and_threshold(
             self.viewer.layers[labels_layer_name],
-            threshold=self.plotter_inputs_widget.threshold_slider.value() / self.threshold_factor,
+            threshold=self.plotter_inputs_widget.threshold_slider.value()
+            / self.threshold_factor,
             method='median',
             size=self.plotter_inputs_widget.median_filter_spinbox.value(),
             repeat=self.plotter_inputs_widget.median_filter_repetition_spinbox.value(),
@@ -599,7 +611,9 @@ class PlotterWidget(QWidget):
             ticks = self.colorbar.ax.get_yticks()
 
             # Set the ticks using a FixedLocator
-            self.colorbar.ax.yaxis.set_major_locator(ticker.FixedLocator(ticks))
+            self.colorbar.ax.yaxis.set_major_locator(
+                ticker.FixedLocator(ticks)
+            )
             # set colorbar ticklabels
             self.colorbar.ax.set_yticklabels(
                 self.colorbar.ax.get_yticklabels(), color="white"
@@ -661,7 +675,10 @@ class PlotterWidget(QWidget):
     def on_threshold_slider_change(self):
         self.plotter_inputs_widget.label_3.setText(
             'Intensity threshold: '
-            + str(self.plotter_inputs_widget.threshold_slider.value() / self.threshold_factor)
+            + str(
+                self.plotter_inputs_widget.threshold_slider.value()
+                / self.threshold_factor
+            )
         )
 
     def on_kernel_size_change(self):

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     import napari
 
 #: The columns in the phasor features table that should not be used as selection id.
-DATA_COLUMNS = ["label", "Average Image", "G", "S", "harmonic"]
+DATA_COLUMNS = ["label", "G_original", "S_original", "G", "S", "harmonic"]
 
 
 def colormap_to_dict(colormap, num_colors=10, exclude_first=True):

--- a/src/napari_phasors/ui/plotter_inputs_widget.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget.ui
@@ -131,10 +131,10 @@
        <item row="4" column="1">
         <widget class="QSpinBox" name="median_filter_repetition_spinbox">
          <property name="minimum">
-          <number>1</number>
+          <number>0</number>
          </property>
          <property name="value">
-          <number>1</number>
+          <number>0</number>
          </property>
         </widget>
        </item>

--- a/src/napari_phasors/ui/plotter_inputs_widget.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
@@ -30,15 +30,49 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>571</width>
-        <height>545</height>
+        <width>565</width>
+        <height>539</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="2" column="1">
-        <widget class="QSpinBox" name="harmonic_spinbox">
-         <property name="minimum">
-          <number>1</number>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Image Layer with Phasor Features:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="image_layer_with_phasor_features_combobox"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Phasor Selection ID:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Number of times to apply median filter:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QSlider" name="threshold_slider">
+         <property name="maximum">
+          <number>200</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Universal Semi-Circle / Full Polar Plot:</string>
          </property>
         </widget>
        </item>
@@ -56,52 +90,31 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Image Layer with Phasor Features:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="image_layer_with_phasor_features_combobox"/>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Threshold:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Median Filter Kernel Size:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Phasor Selection ID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QSlider" name="threshold_slider">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QSpinBox" name="median_filter_spinbox">
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="harmonic_spinbox">
          <property name="minimum">
-          <number>2</number>
+          <number>1</number>
          </property>
         </widget>
        </item>
        <item row="5" column="1">
+        <widget class="QSpinBox" name="median_filter_spinbox">
+         <property name="minimum">
+          <number>2</number>
+         </property>
+         <property name="value">
+          <number>3</number>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Threshold: 0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
         <widget class="QCheckBox" name="semi_circle_checkbox">
          <property name="text">
           <string/>
@@ -109,9 +122,19 @@
         </widget>
        </item>
        <item row="5" column="0">
-        <widget class="QLabel" name="label_5">
+        <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Universal Semi-Circle / Full Polar Plot:</string>
+          <string>Median Filter Kernel Size: 3x3</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QSpinBox" name="median_filter_repetition_spinbox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="value">
+          <number>1</number>
          </property>
         </widget>
        </item>

--- a/src/napari_phasors/ui/plotter_inputs_widget.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget.ui
@@ -110,7 +110,7 @@
        <item row="3" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Threshold: 0</string>
+          <string>Intensity threshold: 0.0</string>
          </property>
         </widget>
        </item>
@@ -124,7 +124,7 @@
        <item row="5" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Median Filter Kernel Size: 3x3</string>
+          <string>Median Filter Kernel Size: 3 x 3</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This PR proposes the implementation of filtering and thresholding functions from PhasorPy. 

The `phasor_features` table has been updated, adding 2 more columns "G_original" and "S_original", in order to keep the original coordinates so that the filtering and thresholding can be undone if needed. This creates the issue of duplication of information and can be problematic for large images, so we may need to test this.

This features were proposed in #18, and are part of #16.

This PR also fixes some issues with the CalibrationWidget, which had several bugs when calibrating multiple harmonics.