### PR TITLE
Add circles

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -69,7 +69,8 @@ def test_phasor_plotter(make_napari_viewer):
     phasors_table = intensity_image_layer.metadata[
         "phasor_features_labels_layer"
     ].features
-    assert phasors_table.shape == (30, 7) # table now has 5 DATA columns + 2 SELECTION columns
+    # table now has 5 DATA columns + 2 SELECTION columns
+    assert phasors_table.shape == (30, 7)
     assert "selection_1" in phasors_table.columns
 
     # Select first 3 points

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -36,7 +36,10 @@ def test_phasor_plotter(make_napari_viewer):
     phasors_table = intensity_image_layer.metadata[
         "phasor_features_labels_layer"
     ].features
-    assert phasors_table.shape == (30, 6)
+    assert phasors_table.shape == (
+        30,
+        7,
+    )  # table now has 6 DATA columns + 1 SELECTION column
     assert "MANUAL SELECTION #1" in phasors_table.columns
 
     # Check initial axes limits
@@ -87,8 +90,8 @@ def test_phasor_plotter(make_napari_viewer):
     phasors_table = intensity_image_layer.metadata[
         "phasor_features_labels_layer"
     ].features
-    # table now has 5 DATA columns + 2 SELECTION columns
-    assert phasors_table.shape == (30, 7)
+    # table now has 6 DATA columns + 2 SELECTION columns
+    assert phasors_table.shape == (30, 8)
     assert "selection_1" in phasors_table.columns
     # Select first 3 points
     manual_selection = np.array([1, 1, 1, 0, 0, 0, 0])

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -37,6 +37,15 @@ def test_phasor_plotter(make_napari_viewer):
     assert phasors_table.shape == (30, 6)
     assert "MANUAL SELECTION #1" in phasors_table.columns
 
+    # Check initial axes limits
+    assert plotter.plotter_inputs_widget.ax.get_xlim() == (-0.1, 1.1)
+    assert plotter.plotter_inputs_widget.ax.get_ylim() == (-0.05, 0.55)
+
+    # Check toggle semi-circle/polar plot display
+    plotter.toggle_semi_circle = False
+    assert plotter.plotter_inputs_widget.ax.get_xlim() == (-1.2, 1.2)
+    assert plotter.plotter_inputs_widget.ax.get_ylim() == (-1.2, 1.2)
+
     # Call the plot method
     plotter.plot()
     # Check that new layer is created

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -38,13 +38,13 @@ def test_phasor_plotter(make_napari_viewer):
     assert "MANUAL SELECTION #1" in phasors_table.columns
 
     # Check initial axes limits
-    assert plotter.plotter_inputs_widget.ax.get_xlim() == (-0.1, 1.1)
-    assert plotter.plotter_inputs_widget.ax.get_ylim() == (-0.05, 0.55)
+    assert plotter.canvas_widget.axes.get_xlim() == (-0.1, 1.1)
+    assert plotter.canvas_widget.axes.get_ylim() == (-0.05, 0.55)
 
     # Check toggle semi-circle/polar plot display
     plotter.toggle_semi_circle = False
-    assert plotter.plotter_inputs_widget.ax.get_xlim() == (-1.2, 1.2)
-    assert plotter.plotter_inputs_widget.ax.get_ylim() == (-1.2, 1.2)
+    assert plotter.canvas_widget.axes.get_xlim() == (-1.2, 1.2)
+    assert plotter.canvas_widget.axes.get_ylim() == (-1.2, 1.2)
 
     # Call the plot method
     plotter.plot()

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -30,6 +30,13 @@ def test_phasor_plotter(make_napari_viewer):
     # Create Plotter widget
     plotter = PlotterWidget(viewer)
 
+    # Check that plotter adds a new default manual selection column to the table
+    phasors_table = intensity_image_layer.metadata[
+        "phasor_features_labels_layer"
+    ].features
+    assert phasors_table.shape == (30, 6)
+    assert "MANUAL SELECTION #1" in phasors_table.columns
+
     # Call the plot method
     plotter.plot()
     # Check that new layer is created
@@ -62,7 +69,7 @@ def test_phasor_plotter(make_napari_viewer):
     phasors_table = intensity_image_layer.metadata[
         "phasor_features_labels_layer"
     ].features
-    assert phasors_table.shape == (30, 6)
+    assert phasors_table.shape == (30, 7) # table now has 5 DATA columns + 2 SELECTION columns
     assert "selection_1" in phasors_table.columns
 
     # Select first 3 points

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -356,7 +356,8 @@ class PlotterWidget(QWidget):
             self._update_semi_circle_plot(self.canvas_widget.axes)
         else:
             self._update_semi_circle_plot(
-                self.canvas_widget.axes, visible=False)
+                self.canvas_widget.axes, visible=False
+            )
             self._update_polar_plot(self.canvas_widget.axes)
         self._redefine_axes_limits()
 
@@ -372,7 +373,7 @@ class PlotterWidget(QWidget):
         """
         Generate the polar plot in the canvas widget.
 
-        Build the inner and outer circle and the 45 degrees lines in the plot.      
+        Build the inner and outer circle and the 45 degrees lines in the plot.
         """
         if len(self.polar_plot_artist_list) > 0:
             for artist in self.polar_plot_artist_list:
@@ -380,41 +381,167 @@ class PlotterWidget(QWidget):
                 artist.set_alpha(alpha)
         else:
             x1 = np.linspace(start=-1, stop=1, num=500)
-            def yp1(x1): return np.sqrt(1 - x1 ** 2)
-            def yn1(x1): return -np.sqrt(1 - x1 ** 2)
+
+            def yp1(x1):
+                return np.sqrt(1 - x1**2)
+
+            def yn1(x1):
+                return -np.sqrt(1 - x1**2)
+
             x2 = np.linspace(start=-0.5, stop=0.5, num=500)
-            def yp2(x2): return np.sqrt(0.5 ** 2 - x2 ** 2)
-            def yn2(x2): return -np.sqrt(0.5 ** 2 - x2 ** 2)
+
+            def yp2(x2):
+                return np.sqrt(0.5**2 - x2**2)
+
+            def yn2(x2):
+                return -np.sqrt(0.5**2 - x2**2)
+
             x3 = np.linspace(start=-1, stop=1, num=30)
             x4 = np.linspace(start=-0.7, stop=0.7, num=30)
-            self.polar_plot_artist_list.append(ax.plot(x1, list(map(
-                yp1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.plot(x1, list(map(
-                yn1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.plot(x2, list(map(
-                yp2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.plot(x2, list(map(
-                yn2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.scatter(
-                x3, [0] * len(x3), marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.scatter(
-                [0] * len(x3), x3, marker='|', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.scatter(
-                x4, x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.scatter(
-                x4, -x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate(
-                '0°', (1.05, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate(
-                '180°', (-0.95, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate(
-                '90°', (0.05, 1.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate(
-                '270°', (0.05, -0.95), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate(
-                '0.5', (0.42, 0.28), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate(
-                '1', (0.8, 0.65), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(
+                ax.plot(
+                    x1,
+                    list(map(yp1, x1)),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )[0]
+            )
+            self.polar_plot_artist_list.append(
+                ax.plot(
+                    x1,
+                    list(map(yn1, x1)),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )[0]
+            )
+            self.polar_plot_artist_list.append(
+                ax.plot(
+                    x2,
+                    list(map(yp2, x2)),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )[0]
+            )
+            self.polar_plot_artist_list.append(
+                ax.plot(
+                    x2,
+                    list(map(yn2, x2)),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )[0]
+            )
+            self.polar_plot_artist_list.append(
+                ax.scatter(
+                    x3,
+                    [0] * len(x3),
+                    marker='_',
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.scatter(
+                    [0] * len(x3),
+                    x3,
+                    marker='|',
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.scatter(
+                    x4,
+                    x4,
+                    marker='_',
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.scatter(
+                    x4,
+                    -x4,
+                    marker='_',
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.annotate(
+                    '0°',
+                    (1.05, 0.05),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.annotate(
+                    '180°',
+                    (-0.95, 0.05),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.annotate(
+                    '90°',
+                    (0.05, 1.05),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.annotate(
+                    '270°',
+                    (0.05, -0.95),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.annotate(
+                    '0.5',
+                    (0.42, 0.28),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+            self.polar_plot_artist_list.append(
+                ax.annotate(
+                    '1',
+                    (0.8, 0.65),
+                    color='darkgoldenrod',
+                    visible=visible,
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
         return ax
 
     def _update_semi_circle_plot(self, ax, visible=True, alpha=0.3, zorder=3):
@@ -430,9 +557,24 @@ class PlotterWidget(QWidget):
             x = (np.cos(angles) + 1) / 2
             y = np.sin(angles) / 2
             self.semi_circle_plot_artist_list.append(
-                ax.plot(x, y, 'darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder)[0])
-            self.semi_circle_plot_artist_list.append(ax.axhline(
-                0, color='darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder))
+                ax.plot(
+                    x,
+                    y,
+                    'darkgoldenrod',
+                    alpha=alpha,
+                    visible=visible,
+                    zorder=zorder,
+                )[0]
+            )
+            self.semi_circle_plot_artist_list.append(
+                ax.axhline(
+                    0,
+                    color='darkgoldenrod',
+                    alpha=alpha,
+                    visible=visible,
+                    zorder=zorder,
+                )
+            )
         return ax
 
     def _redefine_axes_limits(self, ensure_full_circle_displayed=True):
@@ -452,12 +594,22 @@ class PlotterWidget(QWidget):
             # Get polar plot limits
             circle_plot_limits = [-1, 1, -1, 1]  # xmin, xmax, ymin, ymax
         # Check if histogram is plotted
-        if self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram is not None:
+        if (
+            self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram
+            is not None
+        ):
             # Get histogram data limits
-            histogram_limits = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[-1].get_datalim(
-                self.canvas_widget.axes.transData)
+            histogram_limits = (
+                self.canvas_widget.artists[ArtistType.HISTOGRAM2D]
+                .histogram[-1]
+                .get_datalim(self.canvas_widget.axes.transData)
+            )
             plotted_data_limits = [
-                histogram_limits.x0, histogram_limits.x1, histogram_limits.y0, histogram_limits.y1]
+                histogram_limits.x0,
+                histogram_limits.x1,
+                histogram_limits.y0,
+                histogram_limits.y1,
+            ]
         else:
             plotted_data_limits = circle_plot_limits
         # Check if full circle should be displayed
@@ -465,19 +617,29 @@ class PlotterWidget(QWidget):
             # If not, only the data limits are used
             circle_plot_limits = plotted_data_limits
 
-        x_range = np.amax([plotted_data_limits[1], circle_plot_limits[1]]) - \
-            np.amin([plotted_data_limits[0], circle_plot_limits[0]])
-        y_range = np.amax([plotted_data_limits[3], circle_plot_limits[3]]) - \
-            np.amin([plotted_data_limits[2], circle_plot_limits[2]])
+        x_range = np.amax(
+            [plotted_data_limits[1], circle_plot_limits[1]]
+        ) - np.amin([plotted_data_limits[0], circle_plot_limits[0]])
+        y_range = np.amax(
+            [plotted_data_limits[3], circle_plot_limits[3]]
+        ) - np.amin([plotted_data_limits[2], circle_plot_limits[2]])
         # 10% of the range as a frame
-        xlim_0 = np.amin(
-            [plotted_data_limits[0], circle_plot_limits[0]]) - 0.1 * x_range
-        xlim_1 = np.amax(
-            [plotted_data_limits[1], circle_plot_limits[1]]) + 0.1 * x_range
-        ylim_0 = np.amin(
-            [plotted_data_limits[2], circle_plot_limits[2]]) - 0.1 * y_range
-        ylim_1 = np.amax(
-            [plotted_data_limits[3], circle_plot_limits[3]]) + 0.1 * y_range
+        xlim_0 = (
+            np.amin([plotted_data_limits[0], circle_plot_limits[0]])
+            - 0.1 * x_range
+        )
+        xlim_1 = (
+            np.amax([plotted_data_limits[1], circle_plot_limits[1]])
+            + 0.1 * x_range
+        )
+        ylim_0 = (
+            np.amin([plotted_data_limits[2], circle_plot_limits[2]])
+            - 0.1 * y_range
+        )
+        ylim_1 = (
+            np.amax([plotted_data_limits[3], circle_plot_limits[3]])
+            + 0.1 * y_range
+        )
 
         self.canvas_widget.axes.set_ylim([ylim_0, ylim_1])
         self.canvas_widget.axes.set_xlim([xlim_0, xlim_1])
@@ -493,7 +655,10 @@ class PlotterWidget(QWidget):
         """
         if color is None:
             self.canvas_widget.axes.set_facecolor(
-                self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_colormap(0))
+                self.canvas_widget.artists[
+                    ArtistType.HISTOGRAM2D
+                ].histogram_colormap(0)
+            )
         else:
             self.canvas_widget.axes.set_facecolor(color)
         self.canvas_widget.figure.canvas.draw_idle()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -156,6 +156,9 @@ class PlotterWidget(QWidget):
         )
         self.layout().addItem(spacer)
 
+        # Set minimum size
+        self.setMinimumSize(300, 300)
+
         # Connect napari signals when new layer is inseted or removed
         self.viewer.layers.events.inserted.connect(self.reset_layer_choices)
         self.viewer.layers.events.removed.connect(self.reset_layer_choices)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -338,7 +338,7 @@ class PlotterWidget(QWidget):
     def toggle_semi_circle(self, value: bool):
         """Sets the display semi circle value from the semi circle checkbox."""
         self.plotter_inputs_widget.semi_circle_checkbox.setChecked(value)
-        if self.toggle_semi_circle:
+        if value:
             self._update_polar_plot(self.canvas_widget.axes, visible=False)
             self._update_semi_circle_plot(self.canvas_widget.axes)
         else:

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -333,7 +333,7 @@ class PlotterWidget(QWidget):
             The display semi circle value.
         """
         return self.plotter_inputs_widget.semi_circle_checkbox.isChecked()
-    
+
     @toggle_semi_circle.setter
     def toggle_semi_circle(self, value: bool):
         """Sets the display semi circle value from the semi circle checkbox."""
@@ -342,7 +342,8 @@ class PlotterWidget(QWidget):
             self._update_polar_plot(self.canvas_widget.axes, visible=False)
             self._update_semi_circle_plot(self.canvas_widget.axes)
         else:
-            self._update_semi_circle_plot(self.canvas_widget.axes, visible=False)
+            self._update_semi_circle_plot(
+                self.canvas_widget.axes, visible=False)
             self._update_polar_plot(self.canvas_widget.axes)
         self._redefine_axes_limits()
 
@@ -353,7 +354,6 @@ class PlotterWidget(QWidget):
         And it displays either the universal semi-circle or the full polar plot in the canvas widget.
         """
         self.toggle_semi_circle = state
-        
 
     def _update_polar_plot(self, ax, visible=True, alpha=0.3, zorder=3):
         """
@@ -367,29 +367,43 @@ class PlotterWidget(QWidget):
                 artist.set_alpha(alpha)
         else:
             x1 = np.linspace(start=-1, stop=1, num=500)
-            yp1 = lambda x1: np.sqrt(1 - x1 ** 2)
-            yn1 = lambda x1: -np.sqrt(1 - x1 ** 2)
+            def yp1(x1): return np.sqrt(1 - x1 ** 2)
+            def yn1(x1): return -np.sqrt(1 - x1 ** 2)
             x2 = np.linspace(start=-0.5, stop=0.5, num=500)
-            yp2 = lambda x2: np.sqrt(0.5 ** 2 - x2 ** 2)
-            yn2 = lambda x2: -np.sqrt(0.5 ** 2 - x2 ** 2)
+            def yp2(x2): return np.sqrt(0.5 ** 2 - x2 ** 2)
+            def yn2(x2): return -np.sqrt(0.5 ** 2 - x2 ** 2)
             x3 = np.linspace(start=-1, stop=1, num=30)
             x4 = np.linspace(start=-0.7, stop=0.7, num=30)
-            self.polar_plot_artist_list.append(ax.plot(x1, list(map(yp1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.plot(x1, list(map(yn1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.plot(x2, list(map(yp2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.plot(x2, list(map(yn2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
-            self.polar_plot_artist_list.append(ax.scatter(x3, [0] * len(x3), marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.scatter([0] * len(x3), x3, marker='|', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.scatter(x4, x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.scatter(x4, -x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate('0°', (1.05, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate('180°', (-0.95, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate('90°', (0.05, 1.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate('270°', (0.05, -0.95), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate('0.5', (0.42, 0.28), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
-            self.polar_plot_artist_list.append(ax.annotate('1', (0.8, 0.65), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.plot(x1, list(map(
+                yp1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.plot(x1, list(map(
+                yn1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.plot(x2, list(map(
+                yp2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.plot(x2, list(map(
+                yn2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.scatter(
+                x3, [0] * len(x3), marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.scatter(
+                [0] * len(x3), x3, marker='|', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.scatter(
+                x4, x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.scatter(
+                x4, -x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate(
+                '0°', (1.05, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate(
+                '180°', (-0.95, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate(
+                '90°', (0.05, 1.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate(
+                '270°', (0.05, -0.95), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate(
+                '0.5', (0.42, 0.28), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate(
+                '1', (0.8, 0.65), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
         return ax
-    
+
     def _update_semi_circle_plot(self, ax, visible=True, alpha=0.3, zorder=3):
         '''
         Generate FLIM universal semi-circle plot
@@ -402,8 +416,10 @@ class PlotterWidget(QWidget):
             angles = np.linspace(0, np.pi, 180)
             x = (np.cos(angles) + 1) / 2
             y = np.sin(angles) / 2
-            self.semi_circle_plot_artist_list.append(ax.plot(x, y, 'darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder)[0])
-            self.semi_circle_plot_artist_list.append(ax.axhline(0, color='darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder))
+            self.semi_circle_plot_artist_list.append(
+                ax.plot(x, y, 'darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder)[0])
+            self.semi_circle_plot_artist_list.append(ax.axhline(
+                0, color='darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder))
         return ax
 
     def _redefine_axes_limits(self, ensure_full_circle_displayed=True):
@@ -418,29 +434,38 @@ class PlotterWidget(QWidget):
         # Redefine axes limits
         if self.toggle_semi_circle:
             # Get semi circle plot limits
-            circle_plot_limits = [0, 1, 0, 0.5] # xmin, xmax, ymin, ymax
+            circle_plot_limits = [0, 1, 0, 0.5]  # xmin, xmax, ymin, ymax
         else:
             # Get polar plot limits
-            circle_plot_limits = [-1, 1, -1, 1] # xmin, xmax, ymin, ymax
+            circle_plot_limits = [-1, 1, -1, 1]  # xmin, xmax, ymin, ymax
         # Check if histogram is plotted
         if self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram is not None:
             # Get histogram data limits
-            histogram_limits = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[-1].get_datalim(self.canvas_widget.axes.transData)
-            plotted_data_limits = [histogram_limits.x0, histogram_limits.x1, histogram_limits.y0, histogram_limits.y1]
-        else: 
+            histogram_limits = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[-1].get_datalim(
+                self.canvas_widget.axes.transData)
+            plotted_data_limits = [
+                histogram_limits.x0, histogram_limits.x1, histogram_limits.y0, histogram_limits.y1]
+        else:
             plotted_data_limits = circle_plot_limits
         # Check if full circle should be displayed
         if not ensure_full_circle_displayed:
             # If not, only the data limits are used
             circle_plot_limits = plotted_data_limits
-        
-        x_range = np.amax([plotted_data_limits[1], circle_plot_limits[1]]) - np.amin([plotted_data_limits[0], circle_plot_limits[0]])
-        y_range = np.amax([plotted_data_limits[3], circle_plot_limits[3]]) - np.amin([plotted_data_limits[2], circle_plot_limits[2]])
-        xlim_0 = np.amin([plotted_data_limits[0], circle_plot_limits[0]]) - 0.1 * x_range # 10% of the range as a frame
-        xlim_1 = np.amax([plotted_data_limits[1], circle_plot_limits[1]]) + 0.1 * x_range
-        ylim_0 = np.amin([plotted_data_limits[2], circle_plot_limits[2]]) - 0.1 * y_range
-        ylim_1 = np.amax([plotted_data_limits[3], circle_plot_limits[3]]) + 0.1 * y_range
-        
+
+        x_range = np.amax([plotted_data_limits[1], circle_plot_limits[1]]) - \
+            np.amin([plotted_data_limits[0], circle_plot_limits[0]])
+        y_range = np.amax([plotted_data_limits[3], circle_plot_limits[3]]) - \
+            np.amin([plotted_data_limits[2], circle_plot_limits[2]])
+        # 10% of the range as a frame
+        xlim_0 = np.amin(
+            [plotted_data_limits[0], circle_plot_limits[0]]) - 0.1 * x_range
+        xlim_1 = np.amax(
+            [plotted_data_limits[1], circle_plot_limits[1]]) + 0.1 * x_range
+        ylim_0 = np.amin(
+            [plotted_data_limits[2], circle_plot_limits[2]]) - 0.1 * y_range
+        ylim_1 = np.amax(
+            [plotted_data_limits[3], circle_plot_limits[3]]) + 0.1 * y_range
+
         self.canvas_widget.axes.set_ylim([ylim_0, ylim_1])
         self.canvas_widget.axes.set_xlim([xlim_0, xlim_1])
         self.canvas_widget.figure.canvas.draw_idle()
@@ -454,7 +479,8 @@ class PlotterWidget(QWidget):
             The color to set the background, by default None. If None, the first color of the histogram colormap is used.
         """
         if color is None:
-            self.canvas_widget.axes.set_facecolor(self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_colormap(0))
+            self.canvas_widget.axes.set_facecolor(
+                self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_colormap(0))
         else:
             self.canvas_widget.axes.set_facecolor(color)
         self.canvas_widget.figure.canvas.draw_idle()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -250,7 +250,7 @@ class PlotterWidget(QWidget):
                 new_selection_id
             )
             self.add_selection_id_to_features(new_selection_id)
-    
+
     def add_selection_id_to_features(self, new_selection_id: str):
         """Add a new selection id to the features table in the labels layer with phasor features.
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -187,7 +187,7 @@ class PlotterWidget(QWidget):
             list(colormaps.ALL_COLORMAPS.keys())
         )
         self.histogram_colormap = (
-            "magma"  # Set default colormap (same as in biaplotter)
+            "turbo"  # Set default colormap (same as in biaplotter)
         )
 
         # Connect canvas signals

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -211,6 +211,8 @@ class PlotterWidget(QWidget):
 
         # Set intial axes limits
         self._redefine_axes_limits()
+        # Set initial background color
+        self._update_plot_bg_color()
         # Populate labels layer combobox
         self.reset_layer_choices()
 
@@ -438,6 +440,20 @@ class PlotterWidget(QWidget):
         
         self.canvas_widget.axes.set_ylim([ylim_0, ylim_1])
         self.canvas_widget.axes.set_xlim([xlim_0, xlim_1])
+        self.canvas_widget.figure.canvas.draw_idle()
+
+    def _update_plot_bg_color(self, color=None):
+        """Change the background color of the canvas widget.
+
+        Parameters
+        ----------
+        color : str, optional
+            The color to set the background, by default None. If None, the first color of the histogram colormap is used.
+        """
+        if color is None:
+            self.canvas_widget.axes.set_facecolor(self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_colormap(0))
+        else:
+            self.canvas_widget.axes.set_facecolor(color)
         self.canvas_widget.figure.canvas.draw_idle()
 
     @property
@@ -713,6 +729,7 @@ class PlotterWidget(QWidget):
                 self.colorbar.remove()
         # Update axes limits
         self._redefine_axes_limits()
+        self._update_plot_bg_color()
         self.create_phasors_selected_layer()
 
     def create_phasors_selected_layer(self):

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -5,6 +5,7 @@ import numpy as np
 from biaplotter.plotter import ArtistType, CanvasWidget
 from matplotlib.colorbar import Colorbar
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, Normalize
+from matplotlib.lines import Line2D
 from napari.layers import Image, Labels
 from napari.utils import DirectLabelColormap, colormaps, notifications
 from qtpy import uic
@@ -195,6 +196,8 @@ class PlotterWidget(QWidget):
         self._labels_layer_with_phasor_features = None
         self.selection_id = "MANUAL SELECTION #1"
         self._phasors_selected_layer = None
+        self.polar_plot_artist_list = []
+        self.semi_circle_plot_artist_list = []
         self.toggle_semi_circle = True
         self.colorbar = None
         self._colormap = self.canvas_widget.artists[
@@ -206,6 +209,8 @@ class PlotterWidget(QWidget):
         # Start with the histogram2d plot type
         self.plot_type = ArtistType.HISTOGRAM2D.name
 
+        # Set intial axes limits
+        self._redefine_axes_limits()
         # Populate labels layer combobox
         self.reset_layer_choices()
 
@@ -329,14 +334,12 @@ class PlotterWidget(QWidget):
         """Sets the display semi circle value from the semi circle checkbox."""
         self.plotter_inputs_widget.semi_circle_checkbox.setChecked(value)
         if self.toggle_semi_circle:
-            circle_plotting_method = self.generate_semi_circle_plot
+            self._update_polar_plot(self.canvas_widget.axes, visible=False)
+            self._update_semi_circle_plot(self.canvas_widget.axes)
         else:
-            circle_plotting_method = self.generate_polar_plot
-        for artist in self.canvas_widget.artists.values():
-            if artist.ax is not None:
-                artist.ax.clear()
-                circle_plotting_method(artist.ax)
-                artist.draw()
+            self._update_semi_circle_plot(self.canvas_widget.axes, visible=False)
+            self._update_polar_plot(self.canvas_widget.axes)
+        self._redefine_axes_limits()
 
     def on_toggle_semi_circle(self, state):
         """Callback function when the semi circle checkbox is toggled.
@@ -347,47 +350,95 @@ class PlotterWidget(QWidget):
         self.toggle_semi_circle = state
         
 
-    def generate_polar_plot(self, ax):
-        """Generate the polar plot in the canvas widget.
-
-        Built the figure inner and outer circle and the 45 degrees lines in the plot
-
-        
+    def _update_polar_plot(self, ax, visible=True, alpha=0.3, zorder=3):
         """
-        x1 = np.linspace(start=-1, stop=1, num=500)
-        yp1 = lambda x1: np.sqrt(1 - x1 ** 2)
-        yn1 = lambda x1: -np.sqrt(1 - x1 ** 2)
-        x2 = np.linspace(start=-0.5, stop=0.5, num=500)
-        yp2 = lambda x2: np.sqrt(0.5 ** 2 - x2 ** 2)
-        yn2 = lambda x2: -np.sqrt(0.5 ** 2 - x2 ** 2)
-        x3 = np.linspace(start=-1, stop=1, num=30)
-        x4 = np.linspace(start=-0.7, stop=0.7, num=30)
-        ax.plot(x1, list(map(yp1, x1)), color='darkgoldenrod')
-        ax.plot(x1, list(map(yn1, x1)), color='darkgoldenrod')
-        ax.plot(x2, list(map(yp2, x2)), color='darkgoldenrod')
-        ax.plot(x2, list(map(yn2, x2)), color='darkgoldenrod')
-        ax.scatter(x3, [0] * len(x3), marker='_', color='darkgoldenrod')
-        ax.scatter([0] * len(x3), x3, marker='|', color='darkgoldenrod')
-        ax.scatter(x4, x4, marker='_', color='darkgoldenrod')
-        ax.scatter(x4, -x4, marker='_', color='darkgoldenrod')
-        ax.annotate('0º', (1, 0), color='darkgoldenrod')
-        ax.annotate('180º', (-1, 0), color='darkgoldenrod')
-        ax.annotate('90º', (0, 1), color='darkgoldenrod')
-        ax.annotate('270º', (0, -1), color='darkgoldenrod')
-        ax.annotate('0.5', (0.42, 0.28), color='darkgoldenrod')
-        ax.annotate('1', (0.8, 0.65), color='darkgoldenrod')
+        Generate the polar plot in the canvas widget.
+
+        Build the inner and outer circle and the 45 degrees lines in the plot.      
+        """
+        if len(self.polar_plot_artist_list) > 0:
+            for artist in self.polar_plot_artist_list:
+                artist.set_visible(visible)
+                artist.set_alpha(alpha)
+        else:
+            x1 = np.linspace(start=-1, stop=1, num=500)
+            yp1 = lambda x1: np.sqrt(1 - x1 ** 2)
+            yn1 = lambda x1: -np.sqrt(1 - x1 ** 2)
+            x2 = np.linspace(start=-0.5, stop=0.5, num=500)
+            yp2 = lambda x2: np.sqrt(0.5 ** 2 - x2 ** 2)
+            yn2 = lambda x2: -np.sqrt(0.5 ** 2 - x2 ** 2)
+            x3 = np.linspace(start=-1, stop=1, num=30)
+            x4 = np.linspace(start=-0.7, stop=0.7, num=30)
+            self.polar_plot_artist_list.append(ax.plot(x1, list(map(yp1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.plot(x1, list(map(yn1, x1)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.plot(x2, list(map(yp2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.plot(x2, list(map(yn2, x2)), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder)[0])
+            self.polar_plot_artist_list.append(ax.scatter(x3, [0] * len(x3), marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.scatter([0] * len(x3), x3, marker='|', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.scatter(x4, x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.scatter(x4, -x4, marker='_', color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate('0°', (1.05, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate('180°', (-0.95, 0.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate('90°', (0.05, 1.05), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate('270°', (0.05, -0.95), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate('0.5', (0.42, 0.28), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
+            self.polar_plot_artist_list.append(ax.annotate('1', (0.8, 0.65), color='darkgoldenrod', visible=visible, alpha=alpha, zorder=zorder))
         return ax
     
-    def generate_semi_circle_plot(self, ax):
+    def _update_semi_circle_plot(self, ax, visible=True, alpha=0.3, zorder=3):
         '''
         Generate FLIM universal semi-circle plot
         '''
-        angles = np.linspace(0, np.pi, 180)
-        x = (np.cos(angles) + 1) / 2
-        y = np.sin(angles) / 2
-        ax.plot(x, y, 'darkgoldenrod', alpha=0.3)
+        if len(self.semi_circle_plot_artist_list) > 0:
+            for artist in self.semi_circle_plot_artist_list:
+                artist.set_visible(visible)
+                artist.set_alpha(alpha)
+        else:
+            angles = np.linspace(0, np.pi, 180)
+            x = (np.cos(angles) + 1) / 2
+            y = np.sin(angles) / 2
+            self.semi_circle_plot_artist_list.append(ax.plot(x, y, 'darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder)[0])
+            self.semi_circle_plot_artist_list.append(ax.axhline(0, color='darkgoldenrod', alpha=alpha, visible=visible, zorder=zorder))
         return ax
 
+    def _redefine_axes_limits(self, ensure_full_circle_displayed=True):
+        """
+        Redefine axes limits based on the data plotted in the canvas widget.
+
+        Parameters
+        ----------
+        ensure_full_circle_displayed : bool, optional
+            Whether to ensure the full circle is displayed in the canvas widget, by default True.
+        """
+        # Redefine axes limits
+        if self.toggle_semi_circle:
+            # Get semi circle plot limits
+            circle_plot_limits = [0, 1, 0, 0.5] # xmin, xmax, ymin, ymax
+        else:
+            # Get polar plot limits
+            circle_plot_limits = [-1, 1, -1, 1] # xmin, xmax, ymin, ymax
+        # Check if histogram is plotted
+        if self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram is not None:
+            # Get histogram data limits
+            histogram_limits = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[-1].get_datalim(self.canvas_widget.axes.transData)
+            plotted_data_limits = [histogram_limits.x0, histogram_limits.x1, histogram_limits.y0, histogram_limits.y1]
+        else: 
+            plotted_data_limits = circle_plot_limits
+        # Check if full circle should be displayed
+        if not ensure_full_circle_displayed:
+            # If not, only the data limits are used
+            circle_plot_limits = plotted_data_limits
+        
+        x_range = np.amax([plotted_data_limits[1], circle_plot_limits[1]]) - np.amin([plotted_data_limits[0], circle_plot_limits[0]])
+        y_range = np.amax([plotted_data_limits[3], circle_plot_limits[3]]) - np.amin([plotted_data_limits[2], circle_plot_limits[2]])
+        xlim_0 = np.amin([plotted_data_limits[0], circle_plot_limits[0]]) - 0.1 * x_range # 10% of the range as a frame
+        xlim_1 = np.amax([plotted_data_limits[1], circle_plot_limits[1]]) + 0.1 * x_range
+        ylim_0 = np.amin([plotted_data_limits[2], circle_plot_limits[2]]) - 0.1 * y_range
+        ylim_1 = np.amax([plotted_data_limits[3], circle_plot_limits[3]]) + 0.1 * y_range
+        
+        self.canvas_widget.axes.set_ylim([ylim_0, ylim_1])
+        self.canvas_widget.axes.set_xlim([xlim_0, xlim_1])
+        self.canvas_widget.figure.canvas.draw_idle()
 
     @property
     def plot_type(self):
@@ -660,7 +711,8 @@ class PlotterWidget(QWidget):
             if self.colorbar is not None:
                 # remove colorbar
                 self.colorbar.remove()
-
+        # Update axes limits
+        self._redefine_axes_limits()
         self.create_phasors_selected_layer()
 
     def create_phasors_selected_layer(self):

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -812,6 +812,7 @@ class PlotterWidget(QWidget):
             if self.colorbar is not None:
                 # remove colorbar
                 self.colorbar.remove()
+                self.colorbar = None
         # Update axes limits
         self._redefine_axes_limits()
         self._update_plot_bg_color()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -122,6 +122,7 @@ class PlotterWidget(QWidget):
 
         # Load canvas widget
         self.canvas_widget = CanvasWidget(napari_viewer)
+        self.canvas_widget.class_spinbox.setValue(1)
         self.set_axes_labels()
         self.layout().addWidget(self.canvas_widget)
 


### PR DESCRIPTION
This PR should close #9 and partially addresses #42 .

By checking or unchecking the "Universal Semi-Circle / Full Polar Plot" checkbox, the corresponding plot is made visible and the axes limits are updated to ensure all data and chosen circle are included in the view.

I have also added a method to set the background of the figure to any color, but by default matches the first color of the selected colormap. If the user chooses a colormap and zooms out, the backgound will still match the colormap color instead of the napari theme color.

Once the `cmin` attribute that you suggested in implemented in [biaplotter](https://github.com/BiAPoL/biaplotter), we can set the background of the histogram to be white and the rest of the background of the plot will follow that color. 