### PR TITLE
Fix calibration bug of original data not being modified

### DIFF
--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -381,13 +381,13 @@ def test_calibration_widget(make_napari_viewer):
     calibrated_real = np.reshape(
         viewer.layers[0]
         .metadata["phasor_features_labels_layer"]
-        .features["G"],
+        .features["G_original"],
         (len(harmonic),) + original_mean.data.shape,
     )
     calibrated_imag = np.reshape(
         viewer.layers[0]
         .metadata["phasor_features_labels_layer"]
-        .features["S"],
+        .features["S_original"],
         (len(harmonic),) + original_mean.data.shape,
     )
     expected_real, expected_imag = phasor_calibrate(

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -391,19 +391,19 @@ class CalibrationWidget(QWidget):
                 skip_axis = (0,)
                 real, imag = phasor_calibrate(
                     np.reshape(
-                        sample_phasor_data["G"],
+                        sample_phasor_data["G_original"],
                         (len(harmonics),) + original_mean_shape,
                     ),
                     np.reshape(
-                        sample_phasor_data["S"],
+                        sample_phasor_data["S_original"],
                         (len(harmonics),) + original_mean_shape,
                     ),
                     np.reshape(
-                        calibration_phasor_data["G"],
+                        calibration_phasor_data["G_original"],
                         (len(harmonics),) + original_mean_shape,
                     ),
                     np.reshape(
-                        calibration_phasor_data["S"],
+                        calibration_phasor_data["S_original"],
                         (len(harmonics),) + original_mean_shape,
                     ),
                     frequency=frequency * np.array(harmonics),
@@ -412,15 +412,15 @@ class CalibrationWidget(QWidget):
                 )
             else:
                 real, imag = phasor_calibrate(
-                    sample_phasor_data["G"],
-                    sample_phasor_data["S"],
-                    calibration_phasor_data["G"],
-                    calibration_phasor_data["S"],
+                    sample_phasor_data["G_original"],
+                    sample_phasor_data["S_original"],
+                    calibration_phasor_data["G_original"],
+                    calibration_phasor_data["S_original"],
                     frequency=frequency,
                     lifetime=lifetime,
                 )
-            sample_phasor_data["G"] = real.flatten()
-            sample_phasor_data["S"] = imag.flatten()
+            sample_phasor_data["G_original"] = real.flatten()
+            sample_phasor_data["S_original"] = imag.flatten()
             sample_metadata["calibrated"] = True
             show_info(f"Calibrated {sample_name}")
         elif sample_metadata["calibrated"] is True:


### PR DESCRIPTION
This PR fixes a bug  with Calibration Widget. Since the addition of "G_original" and "S_original" columns to phasor features, it modified the "G" and "S" column instead, which each time it was plotted got the original G and S, instead of the calibrated.