### PR TITLE
Set custom turbo colormap

### DIFF
--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -8,7 +8,8 @@ import warnings
 import numpy as np
 from napari.layers import Image
 from phasorpy.phasor import phasor_filter, phasor_threshold
-from napari.utils.colormaps import Colormap, ALL_COLORMAPS
+from napari.utils.colormaps import Colormap
+from napari.utils.colormaps import ALL_COLORMAPS
 
 
 def apply_filter_and_threshold(

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -69,3 +69,24 @@ def apply_filter_and_threshold(
     layer.data = mean
     layer.refresh()
     return
+
+def turbo_first_color_changed_colormap(first='white'):
+    """Create a colormap with the first color being white.
+
+    Returns
+    -------
+    colormap : np.ndarray
+        Colormap with the first color being white.
+
+    """
+    from napari.utils.colormaps import Colormap, ALL_COLORMAPS
+    if first == 'white':
+        color = (1, 1, 1, 1)
+    elif first == 'black':
+        color = (0, 0, 0, 1)
+    else:
+        raise ValueError(f"Invalid value for first: {first}")
+    turbo_colors = ALL_COLORMAPS['turbo'].colors.copy()
+    turbo_colors[0] = color
+    turbo_colormap = Colormap(turbo_colors, name='turbo_' + first + '_first')
+    return turbo_colormap

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -70,6 +70,7 @@ def apply_filter_and_threshold(
     layer.refresh()
     return
 
+
 def turbo_first_color_changed_colormap(first='white'):
     """Create a colormap with the first color being white.
 
@@ -80,6 +81,7 @@ def turbo_first_color_changed_colormap(first='white'):
 
     """
     from napari.utils.colormaps import Colormap, ALL_COLORMAPS
+
     if first == 'white':
         color = (1, 1, 1, 1)
     elif first == 'black':

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 from napari.layers import Image
 from phasorpy.phasor import phasor_filter, phasor_threshold
+from napari.utils.colormaps import Colormap, ALL_COLORMAPS
 
 
 def apply_filter_and_threshold(
@@ -80,8 +81,6 @@ def turbo_first_color_changed_colormap(first='white'):
         Colormap with the first color being white.
 
     """
-    from napari.utils.colormaps import Colormap, ALL_COLORMAPS
-
     if first == 'white':
         color = (1, 1, 1, 1)
     elif first == 'black':

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -25,7 +25,10 @@ from napari_phasors._synthetic_generator import (
     make_intensity_layer_with_phasors,
     make_raw_flim_data,
 )
-from napari_phasors._utils import apply_filter_and_threshold, turbo_first_color_changed_colormap
+from napari_phasors._utils import (
+    apply_filter_and_threshold,
+    turbo_first_color_changed_colormap,
+)
 
 if TYPE_CHECKING:
     import napari
@@ -695,7 +698,10 @@ class PlotterWidget(QWidget):
     @histogram_colormap.setter
     def histogram_colormap(self, colormap: str):
         """Sets the histogram colormap from the colormap combobox."""
-        if colormap not in colormaps.ALL_COLORMAPS.keys() and colormap != "turbo_white_first":
+        if (
+            colormap not in colormaps.ALL_COLORMAPS.keys()
+            and colormap != "turbo_white_first"
+        ):
             notifications.WarningNotification(
                 f"{colormap} is not a valid colormap. Setting to default colormap."
             )

--- a/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
@@ -78,7 +78,7 @@
           <number>10000</number>
          </property>
          <property name="value">
-          <number>10</number>
+          <number>100</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
OK same text from #49 here again, but now this PR should be clean.

Here is an attempt to fix https://github.com/napari-phasors/napari-phasors/issues/42 .
I could not make the cmin parameter from the colormap work, so I made a modified colormap.

@bruno-pannunzio please consider this as an alternative implementation. If you have another implementation using the cmin that is cleaner, let me know and we can close this.