### PR TITLE
Fix advanced options

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -77,7 +77,6 @@ def test_phasor_plotter(make_napari_viewer):
     plotter.histogram_colormap = "viridis"
     plotter.histogram_bins = 5
     plotter.histogram_log_scale = True
-    plotter.plot_type = ArtistType.SCATTER.name
     threshold = 1
     plotter.plotter_inputs_widget.threshold_slider.setValue(threshold)
     plotter.plotter_inputs_widget.median_filter_spinbox.setValue(3)

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -77,6 +77,7 @@ def test_phasor_plotter(make_napari_viewer):
     plotter.histogram_colormap = "viridis"
     plotter.histogram_bins = 5
     plotter.histogram_log_scale = True
+    plotter.plot_type = ArtistType.SCATTER.name
     threshold = 1
     plotter.plotter_inputs_widget.threshold_slider.setValue(threshold)
     plotter.plotter_inputs_widget.median_filter_spinbox.setValue(3)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -781,32 +781,41 @@ class PlotterWidget(QWidget):
         self.canvas_widget.artists[
             ArtistType.HISTOGRAM2D
         ].histogram_colormap = selected_histogram_colormap
+        # Set number of bins in the active artist
+        self.canvas_widget.artists[ArtistType.HISTOGRAM2D].bins = (
+            self.histogram_bins
+        )
         # Set log scale in the active artist
         if (
             self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram
             is not None
         ):
+            h = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[
+                    0
+                ]
             if self.histogram_log_scale:
-                self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[
-                    -1
-                ].set_norm(LogNorm())
+                # Set min_value to a small positive number
+                vmin = max(h[h > 0].min(), 1e-10) if np.any(h > 0) else 1
+                vmax = np.nanmax(h)  # Finds the maximum, ignoring NaNs
+                # Adjust vmax if it's NaN or insufficient for log scaling
+                if np.isnan(vmax) or vmax <= vmin:
+                    vmax = vmin * 2
+                if np.all(h <= 1):
+                    norm = Normalize(vmin=vmin, vmax=vmax)  # Use linear for binary data (0s and 1s)
+                else:
+                    norm = LogNorm(vmin=vmin, vmax=vmax)
             else:
-                self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[
+                vmin = np.nanmin(h)
+                vmax = np.nanmax(h)
+                norm = Normalize(vmin=vmin, vmax=vmax)
+            self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[
                     -1
-                ].set_norm(Normalize())
-        # Set number of bins in the active artist
-        self.canvas_widget.artists[ArtistType.HISTOGRAM2D].bins = (
-            self.histogram_bins
-        )
-        # # Temporarily set active artist "again" to have it displayed on top #TODO: Fix this
-        # self.canvas_widget.active_artist = self.canvas_widget.artists[
-        #     ArtistType[self.plot_type]
-        # ]
+                ].set_norm(norm)
 
         # Add a colorbar
         if self.colorbar is not None:
             self.colorbar.remove()
-        # creat cax for colorbar on the right side of the histogram
+        # Create cax for colorbar on the right side of the histogram
         self.cax = self.canvas_widget.artists[
             ArtistType.HISTOGRAM2D
         ].ax.inset_axes([1.05, 0, 0.05, 1])
@@ -816,30 +825,34 @@ class PlotterWidget(QWidget):
             cmap=self.canvas_widget.artists[
                 ArtistType.HISTOGRAM2D
             ].histogram_colormap,
-            norm=self.canvas_widget.artists[ArtistType.HISTOGRAM2D]
-            .histogram[-1]
-            .norm,
+            norm=norm,
         )
-        # set colorbar tick color
-        self.colorbar.ax.yaxis.set_tick_params(color="white")
-        # set colorbar edgecolor
-        self.colorbar.outline.set_edgecolor("white")
-
-        # Get the current ticks
-        ticks = self.colorbar.ax.get_yticks()
-
-        # Set the ticks using a FixedLocator
-        self.colorbar.ax.yaxis.set_major_locator(
-            ticker.FixedLocator(ticks)
-        )
-        # set colorbar ticklabels
-        self.colorbar.ax.set_yticklabels(
-            self.colorbar.ax.get_yticklabels(), color="white"
-        )
+       
+        self.set_colorbar_style(color="white")
         # Update axes limits
         self._redefine_axes_limits()
         self._update_plot_bg_color(color="white")
         self.create_phasors_selected_layer()
+
+    def set_colorbar_style(self, color="white"):
+        """Set the colorbar style in the canvas widget."""
+        # Set colorbar tick color
+        self.colorbar.ax.yaxis.set_tick_params(color=color)
+        # Set colorbar edgecolor
+        self.colorbar.outline.set_edgecolor(color)
+        # Add label to colorbar
+        if isinstance(self.colorbar.norm, LogNorm):
+            self.colorbar.ax.set_ylabel("Log10(Count)", color=color)
+        else:
+            self.colorbar.ax.set_ylabel("Count", color=color)
+        # Get the current ticks
+        ticks = self.colorbar.ax.get_yticks()
+        # Set the ticks using a FixedLocator
+        self.colorbar.ax.yaxis.set_major_locator(ticker.FixedLocator(ticks))
+        # Set colorbar ticklabels colors individually (this may fail for some math expressions)
+        tick_labels = self.colorbar.ax.get_yticklabels()
+        for tick_label in tick_labels:
+            tick_label.set_color(color)
 
     def create_phasors_selected_layer(self):
         """Create or update the phasors selected layer."""

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -818,6 +818,10 @@ class PlotterWidget(QWidget):
         self.canvas_widget.artists[ArtistType.HISTOGRAM2D].bins = (
             self.histogram_bins
         )
+        # Temporarily set active artist "again" to have it displayed on top #TODO: Fix this
+        self.canvas_widget.active_artist = self.canvas_widget.artists[
+            ArtistType[self.plot_type]
+        ]
         # Set log scale in the active artist
         if (
             self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -790,9 +790,7 @@ class PlotterWidget(QWidget):
             self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram
             is not None
         ):
-            h = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[
-                    0
-                ]
+            h = self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[0]
             if self.histogram_log_scale:
                 # Set min_value to a small positive number
                 vmin = max(h[h > 0].min(), 1e-10) if np.any(h > 0) else 1
@@ -801,7 +799,9 @@ class PlotterWidget(QWidget):
                 if np.isnan(vmax) or vmax <= vmin:
                     vmax = vmin * 2
                 if np.all(h <= 1):
-                    norm = Normalize(vmin=vmin, vmax=vmax)  # Use linear for binary data (0s and 1s)
+                    norm = Normalize(
+                        vmin=vmin, vmax=vmax
+                    )  # Use linear for binary data (0s and 1s)
                 else:
                     norm = LogNorm(vmin=vmin, vmax=vmax)
             else:
@@ -809,8 +809,8 @@ class PlotterWidget(QWidget):
                 vmax = np.nanmax(h)
                 norm = Normalize(vmin=vmin, vmax=vmax)
             self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram[
-                    -1
-                ].set_norm(norm)
+                -1
+            ].set_norm(norm)
 
         # Add a colorbar
         if self.colorbar is not None:
@@ -827,7 +827,7 @@ class PlotterWidget(QWidget):
             ].histogram_colormap,
             norm=norm,
         )
-       
+
         self.set_colorbar_style(color="white")
         # Update axes limits
         self._redefine_axes_limits()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -99,6 +99,8 @@ class PlotterWidget(QWidget):
             The checkbox for displaying the universal semi-circle (if True) or the full polar plot (if False).
     extra_inputs_widget : QWidget
         The extra plotter inputs widget. It is collapsible. The widget contains:
+        - plot_type_combobox : QComboBox
+            The combobox for selecting the plot type.
         - colormap_combobox : QComboBox
             The combobox for selecting the histogram colormap.
         - number_of_bins_spinbox : QSpinBox
@@ -178,6 +180,10 @@ class PlotterWidget(QWidget):
         )
         self.plot_button.clicked.connect(self.plot)
 
+        # Populate plot type combobox
+        self.extra_inputs_widget.plot_type_combobox.addItems(
+            [ArtistType.SCATTER.name, ArtistType.HISTOGRAM2D.name]
+        )
         # Populate colormap combobox
         self.extra_inputs_widget.colormap_combobox.addItems(
             list(colormaps.ALL_COLORMAPS.keys())
@@ -187,6 +193,9 @@ class PlotterWidget(QWidget):
         )
 
         # Connect canvas signals
+        self.canvas_widget.artists[
+            ArtistType.SCATTER
+        ].color_indices_changed_signal.connect(self.manual_selection_changed)
         self.canvas_widget.artists[
             ArtistType.HISTOGRAM2D
         ].color_indices_changed_signal.connect(self.manual_selection_changed)
@@ -205,6 +214,8 @@ class PlotterWidget(QWidget):
         self._histogram_colormap = self.canvas_widget.artists[
             ArtistType.HISTOGRAM2D
         ].histogram_colormap
+        # Start with the histogram2d plot type
+        self.plot_type = ArtistType.HISTOGRAM2D.name
 
         # Set intial axes limits
         self._redefine_axes_limits()
@@ -548,6 +559,22 @@ class PlotterWidget(QWidget):
         self.canvas_widget.figure.canvas.draw_idle()
 
     @property
+    def plot_type(self):
+        """Gets or sets the plot type from the plot type combobox.
+
+        Returns
+        -------
+        str
+            The plot type.
+        """
+        return self.extra_inputs_widget.plot_type_combobox.currentText()
+
+    @plot_type.setter
+    def plot_type(self, type):
+        """Sets the plot type from the plot type combobox."""
+        self.extra_inputs_widget.plot_type_combobox.setCurrentText(type)
+
+    @property
     def histogram_colormap(self):
         """Gets or sets the histogram colormap from the colormap combobox.
 
@@ -732,6 +759,12 @@ class PlotterWidget(QWidget):
 
     def set_axes_labels(self):
         """Set the axes labels in the canvas widget."""
+        self.canvas_widget.artists[ArtistType.SCATTER].ax.set_xlabel(
+            "G", color="white"
+        )
+        self.canvas_widget.artists[ArtistType.SCATTER].ax.set_ylabel(
+            "S", color="white"
+        )
         self.canvas_widget.artists[ArtistType.HISTOGRAM2D].ax.set_xlabel(
             "G", color="white"
         )
@@ -759,7 +792,7 @@ class PlotterWidget(QWidget):
         x_data, y_data, selection_id_data = self.get_features()
         # Set active artist
         self.canvas_widget.active_artist = self.canvas_widget.artists[
-            ArtistType.HISTOGRAM2D
+            ArtistType[self.plot_type]
         ]
         self.canvas_widget.active_artist.ax.set_facecolor('white')
         self.canvas_widget.artists[ArtistType.HISTOGRAM2D].cmin = 1
@@ -812,23 +845,29 @@ class PlotterWidget(QWidget):
                 -1
             ].set_norm(norm)
 
-        # Add a colorbar
-        if self.colorbar is not None:
-            self.colorbar.remove()
-        # Create cax for colorbar on the right side of the histogram
-        self.cax = self.canvas_widget.artists[
-            ArtistType.HISTOGRAM2D
-        ].ax.inset_axes([1.05, 0, 0.05, 1])
-        # Create colorbar
-        self.colorbar = Colorbar(
-            ax=self.cax,
-            cmap=self.canvas_widget.artists[
+        # if active artist is histogram, add a colorbar
+        if self.plot_type == ArtistType.HISTOGRAM2D.name:
+            if self.colorbar is not None:
+                self.colorbar.remove()
+            # Create cax for colorbar on the right side of the histogram
+            self.cax = self.canvas_widget.artists[
                 ArtistType.HISTOGRAM2D
-            ].histogram_colormap,
-            norm=norm,
-        )
+            ].ax.inset_axes([1.05, 0, 0.05, 1])
+            # Create colorbar
+            self.colorbar = Colorbar(
+                ax=self.cax,
+                cmap=self.canvas_widget.artists[
+                    ArtistType.HISTOGRAM2D
+                ].histogram_colormap,
+                norm=norm,
+            )
 
-        self.set_colorbar_style(color="white")
+            self.set_colorbar_style(color="white")
+        else:
+            if self.colorbar is not None:
+                # remove colorbar
+                self.colorbar.remove()
+                self.colorbar = None
         # Update axes limits
         self._redefine_axes_limits()
         self._update_plot_bg_color(color="white")

--- a/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
@@ -35,41 +35,28 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="4" column="1">
-        <widget class="QCheckBox" name="log_scale_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Colors in Log Scale:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="plot_type_combobox"/>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Plot Type:</string>
+          <string>Number of Histogram 2D Bins:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="colormap_combobox"/>
-       </item>
-       <item row="1" column="0">
+       <item row="0" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Colormap:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QSpinBox" name="number_of_bins_spinbox">
          <property name="minimum">
           <number>2</number>
@@ -82,12 +69,15 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_3">
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="log_scale_checkbox">
          <property name="text">
-          <string>Number of Histogram 2D Bins:</string>
+          <string/>
          </property>
         </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="colormap_combobox"/>
        </item>
       </layout>
      </widget>

--- a/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
@@ -35,28 +35,41 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="3" column="0">
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="log_scale_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Colors in Log Scale:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_3">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="plot_type_combobox"/>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Number of Histogram 2D Bins:</string>
+          <string>Plot Type:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
+       <item row="1" column="1">
+        <widget class="QComboBox" name="colormap_combobox"/>
+       </item>
+       <item row="1" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Colormap:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QSpinBox" name="number_of_bins_spinbox">
          <property name="minimum">
           <number>2</number>
@@ -69,15 +82,12 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QCheckBox" name="log_scale_checkbox">
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="text">
-          <string/>
+          <string>Number of Histogram 2D Bins:</string>
          </property>
         </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="colormap_combobox"/>
        </item>
       </layout>
      </widget>

--- a/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget_extra.ui
@@ -65,7 +65,7 @@
           <number>10000</number>
          </property>
          <property name="value">
-          <number>10</number>
+          <number>100</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This PR removes the Plot Type combobox since the scatter plot would never be used for phasors.
It also fixes the color log scale functionality and sets the initial number of histogram bins from 10 to 100.

This fixes #60 