### PR TITLE
Update minimal biaplotter version to have shift for circles option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     phasorpy
     qtpy
     scikit-image
-    biaplotter>=0.0.5a0
+    biaplotter>=0.0.5a2
     lfdfiles
     sdtfile
     ptufile


### PR DESCRIPTION
Hi @bruno-pannunzio ,

I have updated `biaplotter` to have the functionality of holding the 'SHIFT' key while dragging the ellipse to remain as a circle. Similar thing for the rectangle.

Thus, here we just need to pin the minimum dependency version.