### PR TITLE
Add widgets to sub-menus under new napari Layers menu and IO Utilities

### DIFF
--- a/src/napari_phasors/napari.yaml
+++ b/src/napari_phasors/napari.yaml
@@ -26,7 +26,7 @@ contributions:
       title: Write OME-TIFF
     - id: napari-phasors.PhasorTransform
       python_name: napari_phasors:PhasorTransform
-      title: Phasor Transform
+      title: Phasor Custom Import
     - id: napari-phasors.CalibrationWidget
       python_name: napari_phasors:CalibrationWidget
       title: Calibration Widget
@@ -57,7 +57,7 @@ contributions:
       key: unique_id.3
   widgets:
     - command: napari-phasors.PhasorTransform
-      display_name: Phasor Transform
+      display_name: Phasor Custom Import
     - command: napari-phasors.CalibrationWidget
       display_name: Calibration Widget
     - command: napari-phasors.plot_phasor
@@ -67,4 +67,25 @@ contributions:
     - command: napari-phasors.WriterWidget
       display_name: Export Phasor
 
+  menus:
+    napari/file/io_utilities:
+      - submenu: io_phasors_submenu
+    napari/layers/visualize:
+      - submenu: phasors_submenu
+      - submenu: lifetimes_submenu
+    phasors_submenu:
+      - command: napari-phasors.plot_phasor
+      - command: napari-phasors.CalibrationWidget
+    lifetimes_submenu:
+      - command: napari-phasors.LifetimeWidget
+    io_phasors_submenu:
+      - command: napari-phasors.PhasorTransform
+      - command: napari-phasors.WriterWidget
 
+  submenus:
+    - id: phasors_submenu
+      label: Phasors
+    - id: lifetimes_submenu
+      label: Lifetimes
+    - id: io_phasors_submenu
+      label: Phasors


### PR DESCRIPTION
hi @bruno-pannunzio ,

This PR provides new ways to find and split by category the napari-phasors widgets. It works with napari > 0.0.5.

I placed the Calibration and Phasor Plot widgets under the `Layer -> Visualization -> Phasors` entry (calibration is not really a visualization widget, but still I thought it should be placed close to the phasor plot widget).

![image](https://github.com/user-attachments/assets/0a875164-ff95-4f6f-8ec2-5d730fb885fd)

I placed the lifetime widget under `Layer -> Visualization -> Lifetime`.

Finally, I placed Phasor Transform and Phasor Export under `File -> IO Utilities -> Phasors`. 

![image](https://github.com/user-attachments/assets/5e8dbecf-78d1-4a4d-a553-d7d9f8981f42)


I renamed Phasor Transform (which is a bit confusing) to Phasor Custom Import. We can discuss a better naming, but it is sort of an "import" data widget, because the data is loaded.
