### PR TITLE
Change setting saved as JSON format

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -4,9 +4,10 @@ and computes phasor coordinates with `phasorpy.phasor.phasor_from_signal`
 
 """
 
-import ast
 import inspect
+import json
 import os
+import sys
 from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy as np
@@ -258,9 +259,11 @@ def processed_file_reader(
     )
     layers = []
     if "description" in attrs.keys():
-        description = ast.literal_eval(attrs["description"])
+        description = json.loads(attrs["description"])
+        if sys.getsizeof(description) > 512 * 512:  # Threshold: 256 KB
+            raise ValueError("Description dictionary is too large.")
         if "napari_phasors_settings" in description:
-            settings = description["napari_phasors_settings"]
+            settings = json.loads(description["napari_phasors_settings"])
             if "calibrated" in settings.keys():
                 settings["calibrated"] = bool(settings["calibrated"])
     else:

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -1,4 +1,5 @@
 # %%
+import importlib.metadata
 import os
 
 import numpy as np
@@ -48,6 +49,9 @@ def test_write_ometif(tmp_path):
     assert len(layer_data_tuple) == 2
     np.testing.assert_array_almost_equal(
         layer_data_tuple[0], intensity_image_layer.data
+    )
+    assert layer_data_tuple[1]["metadata"]["settings"]["version"] == str(
+        importlib.metadata.version("napari-phasors")
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -68,14 +68,14 @@ def apply_filter_and_threshold(
             mean = merged_mean
     layer.data = mean
     # Update the settings dictionary of the layer
-    if 'settings' not in layer.metadata:
-        layer.metadata['settings'] = {}
-    layer.metadata['settings']['filter'] = {
-        'method': method,
-        'size': size,
-        'repeat': repeat,
+    if "settings" not in layer.metadata:
+        layer.metadata["settings"] = {}
+    layer.metadata["settings"]["filter"] = {
+        "method": method,
+        "size": size,
+        "repeat": repeat,
     }
-    layer.metadata['settings']['threshold'] = threshold
+    layer.metadata["settings"]["threshold"] = threshold
     layer.refresh()
     return
 

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -433,7 +433,7 @@ class CalibrationWidget(QWidget):
         harmonics = np.unique(sample_phasor_data["harmonic"])
         original_mean_shape = sample_metadata["original_mean"].shape
         if "settings" not in sample_metadata.keys():
-            sample_metadata['settings'] = {}
+            sample_metadata["settings"] = {}
         if (
             "calibrated" not in sample_metadata["settings"].keys()
             or sample_metadata["settings"]["calibrated"] is False

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -6,6 +6,8 @@ to `OME-TIFF` format.
 
 from __future__ import annotations
 
+import importlib.metadata
+import json
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple, Union
 
 import numpy as np
@@ -60,12 +62,14 @@ def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
     )
     if not path.endswith(".ome.tif"):
         path += ".ome.tif"
+    settings["version"] = str(importlib.metadata.version('napari-phasors'))
+    description = json.dumps({"napari_phasors_settings": json.dumps(settings)})
     phasor_to_ometiff(
         path,
         mean,
         G,
         S,
         harmonic=harmonics,
-        description={'napari_phasors_settings': settings},
+        description=description,
     )
     return path


### PR DESCRIPTION
This PR proposes the modification of how the setting from the 'napari-phasors' plugin are saved and read. As pointed out in #73, reading with `ast.literal_eval` was unsafe. As proposed, this implementation is based on the JSON format, that can be checked for excessive size when being read. 

Also, the version of the 'napari-phasors' was added to the settings saved for future traceability.