### PR TITLE
Fix median filter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    phasorpy
+    phasorpy==0.2
     qtpy
     scikit-image
     biaplotter>=0.0.5a2

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -141,7 +141,7 @@ def test_phasor_plotter(make_napari_viewer):
         (len(harmonics),) + original_mean.data.shape,
     )
     original_g, original_s = phasor_filter(
-        original_g, original_s, repeat=3, size=3, axes=(1, 2)
+        original_g, original_s, repeat=3, size=3, skip_axis=0
     )
     _, original_g, original_s = phasor_threshold(
         original_mean,

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -50,7 +50,7 @@ def test_apply_filter_and_threshold(make_napari_viewer):
         original_s, (len(harmonics),) + original_mean.data.shape
     )
     original_g, original_s = phasor_filter(
-        original_g, original_s, repeat=1, size=3, axes=(1, 2)
+        original_g, original_s, repeat=1, size=3, skip_axis=0
     )
     _, original_g, original_s = phasor_threshold(
         original_mean, original_g, original_s, threshold

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -471,8 +471,9 @@ def test_calibration_widget(make_napari_viewer):
         original_imag,
         calibration_real,
         calibration_imag,
-        frequency=80 * np.array(harmonic),
+        frequency=80,
         lifetime=2,
+        harmonic=harmonic,
         skip_axis=0,
     )
     assert np.allclose(calibrated_real, expected_real)

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -52,7 +52,6 @@ def apply_filter_and_threshold(
             repeat=repeat,
             size=size,
             skip_axis=0,
-            # axes=tuple(range(1, real.ndim)),
         )
     mean, real, imag = phasor_threshold(mean, real, imag, threshold)
     (

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -51,7 +51,8 @@ def apply_filter_and_threshold(
             method=method,
             repeat=repeat,
             size=size,
-            axes=tuple(range(1, real.ndim)),
+            skip_axis=0,
+            # axes=tuple(range(1, real.ndim)),
         )
     mean, real, imag = phasor_threshold(mean, real, imag, threshold)
     (

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -444,39 +444,28 @@ class CalibrationWidget(QWidget):
             "calibrated" not in sample_metadata["settings"].keys()
             or sample_metadata["settings"]["calibrated"] is False
         ):
-            skip_axis = None
-            if len(np.unique(sample_phasor_data["harmonic"])) > 1:
-                skip_axis = (0,)
-                real, imag = phasor_calibrate(
-                    np.reshape(
-                        sample_phasor_data["G_original"],
-                        (len(harmonics),) + original_mean_shape,
-                    ),
-                    np.reshape(
-                        sample_phasor_data["S_original"],
-                        (len(harmonics),) + original_mean_shape,
-                    ),
-                    np.reshape(
-                        calibration_phasor_data["G_original"],
-                        (len(harmonics),) + original_mean_shape,
-                    ),
-                    np.reshape(
-                        calibration_phasor_data["S_original"],
-                        (len(harmonics),) + original_mean_shape,
-                    ),
-                    frequency=frequency * np.array(harmonics),
-                    lifetime=lifetime,
-                    skip_axis=skip_axis,
-                )
-            else:
-                real, imag = phasor_calibrate(
+            real, imag = phasor_calibrate(
+                np.reshape(
                     sample_phasor_data["G_original"],
+                    (len(harmonics),) + original_mean_shape,
+                ),
+                np.reshape(
                     sample_phasor_data["S_original"],
+                    (len(harmonics),) + original_mean_shape,
+                ),
+                np.reshape(
                     calibration_phasor_data["G_original"],
+                    (len(harmonics),) + original_mean_shape,
+                ),
+                np.reshape(
                     calibration_phasor_data["S_original"],
-                    frequency=frequency,
-                    lifetime=lifetime,
-                )
+                    (len(harmonics),) + original_mean_shape,
+                ),
+                frequency=frequency,
+                lifetime=lifetime,
+                harmonic=harmonics.tolist(),
+                skip_axis=0,
+            )
             sample_phasor_data["G_original"] = real.flatten()
             sample_phasor_data["S_original"] = imag.flatten()
             sample_metadata["settings"]["calibrated"] = True

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -409,18 +409,24 @@ class CalibrationWidget(QWidget):
             self.calibration_widget.sample_layer_combobox.addItem(layer.name)
 
     def _on_click(self):
-        frequency = int(
-            self.calibration_widget.frequency_line_edit_widget.text()
-        )
-        lifetime = float(
-            self.calibration_widget.lifetime_line_edit_widget.text()
-        )
+        frequency = self.calibration_widget.frequency_line_edit_widget.text()
+        lifetime = self.calibration_widget.lifetime_line_edit_widget.text()
+        if frequency == "":
+            show_error("Enter frequency")
+            return
+        if lifetime == "":
+            show_error("Enter reference lifetime")
+            return
+        frequency = int(frequency)
+        lifetime = float(lifetime)
         sample_name = (
             self.calibration_widget.sample_layer_combobox.currentText()
         )
         calibration_name = (
             self.calibration_widget.calibration_layer_combobox.currentText()
         )
+        if sample_name == "" or calibration_name == "":
+            return
         sample_metadata = self.viewer.layers[sample_name].metadata
         sample_phasor_data = sample_metadata[
             "phasor_features_labels_layer"


### PR DESCRIPTION
The [release of PhasorPy v0.2](https://github.com/phasorpy/phasorpy/releases/tag/v0.2) modified the `phasor_filter` function and created a bug when filtering in the Plotter Widget.

This PR fixes the `skip_axis` parameter to match the changes in `phasor_filter` and also fixes the version for PhasorPy to 0.2 to avoid future release that have breaking points to create this types of bug. Also in this PR I modified the Calibration Widget to match the changes of `phasor_calibrate` in PhasorPy v0.2 to handle multiple harmonics.