### PR TITLE
Add autocomplete frequency and modifications to lifetime widget

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -157,6 +157,13 @@ def raw_file_reader(
     """
     filename, file_extension = _get_filename_extension(path)
     raw_data = extension_mapping["raw"][file_extension](path, reader_options)
+    settings = {}
+    if (
+        file_extension != '.fbd'
+        and hasattr(raw_data, "attrs")
+        and 'frequency' in raw_data.attrs.keys()
+    ):
+        settings['frequency'] = raw_data.attrs['frequency']
     layers = []
     iter_axis = iter_index_mapping[file_extension]
     if iter_axis is None:
@@ -185,6 +192,7 @@ def raw_file_reader(
             "metadata": {
                 "phasor_features_labels_layer": labels_layer,
                 "original_mean": mean_intensity_image,
+                "settings": settings,
             },
         }
         layers.append((mean_intensity_image, add_kwargs))
@@ -209,6 +217,7 @@ def raw_file_reader(
                 "metadata": {
                     "phasor_features_labels_layer": labels_layer,
                     "original_mean": mean_intensity_image,
+                    "settings": settings,
                 },
             }
             layers.append((mean_intensity_image, add_kwargs))
@@ -268,6 +277,8 @@ def processed_file_reader(
                 settings["calibrated"] = bool(settings["calibrated"])
     else:
         settings = {}
+    if "frequency" in attrs.keys():
+        settings["frequency"] = attrs["frequency"]
     add_kwargs = {
         "name": filename + " Intensity Image",
         "metadata": {

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -25,9 +25,10 @@ def test_reader_ptu():
         layer_data_tuple[1]["name"] == "test_file Intensity Image: Channel 0"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -68,9 +69,10 @@ def test_reader_fbd():
         == "test_file$EI0S Intensity Image: Channel 0"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -102,9 +104,10 @@ def test_reader_fbd():
         == "test_file$EI0S Intensity Image: Channel 1"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -145,9 +148,10 @@ def test_reader_sdt():
         == "seminal_receptacle_FLIM_single_image Intensity Image"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -184,9 +188,10 @@ def test_reader_lsm():
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert layer_data_tuple[1]["name"] == "test_file Intensity Image"
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"

--- a/src/napari_phasors/_tests/test_sample_data.py
+++ b/src/napari_phasors/_tests/test_sample_data.py
@@ -26,9 +26,10 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
         == "Convallaria_$EI0S Intensity Image: Channel 0"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -60,9 +61,10 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
         == "Calibration_Rhodamine110_$EI0S Intensity Image: Channel 0"
     )
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -97,9 +99,10 @@ def test_embryo_FLIM_sample_data(make_napari_viewer):
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert layer_data_tuple[1]["name"] == "Embryo Intensity Image"
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -128,9 +131,10 @@ def test_embryo_FLIM_sample_data(make_napari_viewer):
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert layer_data_tuple[1]["name"] == "Fluorescein_Embryo Intensity Image"
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"
@@ -164,9 +168,10 @@ def test_paramecium_HSI_sample_data(make_napari_viewer):
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert layer_data_tuple[1]["name"] == "paramecium Intensity Image"
     assert (
-        len(layer_data_tuple[1]["metadata"]) == 2
+        len(layer_data_tuple[1]["metadata"]) == 3
         and "phasor_features_labels_layer" in layer_data_tuple[1]["metadata"]
         and "original_mean" in layer_data_tuple[1]["metadata"]
+        and "settings" in layer_data_tuple[1]["metadata"]
     )
     phasor_features = layer_data_tuple[1]["metadata"][
         "phasor_features_labels_layer"

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -636,9 +636,13 @@ def test_lifetime_widget(make_napari_viewer):
     assert main_widget._labels_layer_with_phasor_features is None
     assert main_widget.layer_combobox.count() == 0
     assert main_widget.frequency_input.text() == ""
-    assert (
-        main_widget.lifetime_colormap_combobox.currentText() == 'turbo'
-    )  # default colormap
+    assert main_widget.lifetime_colormap == None
+    assert main_widget.colormap_contrast_limits == None
+    assert main_widget.hist_fig is not None
+    assert main_widget.hist_ax is not None
+    assert main_widget.counts is None
+    assert main_widget.bin_edges is None
+    assert main_widget.bin_centers is None
     assert (
         main_widget.lifetime_type_combobox.currentText() == 'Phase'
     )  # default lifetime type
@@ -680,14 +684,8 @@ def test_lifetime_widget(make_napari_viewer):
     assert main_widget.selected_harmonic == harmonic[0]
     assert (
         main_widget.lifetime_layer.name
-        == "Lifetime: FLIM data Intensity Image"
+        == "Phase Lifetime: FLIM data Intensity Image"
     )
-    # Check harmonic selector
-    main_widget.harmonic_selector.setValue(2)
-    assert main_widget.selected_harmonic == harmonic[1]
-    # Check colormap selector
-    main_widget.lifetime_colormap_combobox.setCurrentText('viridis')
-    assert main_widget.lifetime_colormap_combobox.currentText() == 'viridis'
     # Check lifetime type selector
     main_widget.lifetime_type_combobox.setCurrentText('Modulation')
     assert main_widget.lifetime_type_combobox.currentText() == 'Modulation'
@@ -702,10 +700,9 @@ def test_lifetime_widget(make_napari_viewer):
     np.testing.assert_array_equal(
         main_widget.lifetime_data, expected_modulation_lifetimes
     )
-    assert main_widget.selected_harmonic == harmonic[1]
     assert (
         main_widget.lifetime_layer.name
-        == "Lifetime: FLIM data Intensity Image"
+        == "Modulation Lifetime: FLIM data Intensity Image"
     )
-    # assert no other layer is created
-    assert len(viewer.layers) == 2
+    # assert one layer for modulation and one for phase were created
+    assert len(viewer.layers) == 3

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -14,13 +14,13 @@ This module contains widgets to:
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colormaps
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
 )
+from matplotlib.colors import LinearSegmentedColormap
 from napari.layers import Image
 from napari.utils.notifications import show_error, show_info
 from phasorpy.phasor import phasor_calibrate, phasor_to_apparent_lifetime
@@ -374,11 +374,14 @@ class CalibrationWidget(QWidget):
             self.calibration_widget,
         )
 
-        # self.calibration_widget.frequency_line_edit_widget.setText("0")
-
         # Connect callbacks
         self.calibration_widget.calibrate_push_button.clicked.connect(
             self._on_click
+        )
+
+        # Connect comboboxes
+        self.calibration_widget.sample_layer_combobox.currentIndexChanged.connect(
+            self._on_combobox_change
         )
 
         # Connect layer events to populate combobox
@@ -408,6 +411,21 @@ class CalibrationWidget(QWidget):
         for layer in image_layers:
             self.calibration_widget.sample_layer_combobox.addItem(layer.name)
 
+    def _on_combobox_change(self):
+        layer_name = (
+            self.calibration_widget.sample_layer_combobox.currentText()
+        )
+        if layer_name == "":
+            return
+        layer_metadata = self.viewer.layers[layer_name].metadata
+        if (
+            'settings' in layer_metadata.keys()
+            and 'frequency' in layer_metadata['settings'].keys()
+        ):
+            self.calibration_widget.frequency_line_edit_widget.setText(
+                str(layer_metadata['settings']['frequency'])
+            )
+
     def _on_click(self):
         sample_name = (
             self.calibration_widget.sample_layer_combobox.currentText()
@@ -426,7 +444,10 @@ class CalibrationWidget(QWidget):
         if lifetime == "":
             show_error("Enter reference lifetime")
             return
-        frequency = int(frequency)
+        frequency = float(frequency)
+        self.viewer.layers[sample_name].metadata["settings"][
+            "frequency"
+        ] = frequency
         lifetime = float(lifetime)
         sample_metadata = self.viewer.layers[sample_name].metadata
         sample_phasor_data = sample_metadata[
@@ -594,6 +615,12 @@ class LifetimeWidget(QWidget):
         self.lifetime_layer = None
         self.harmonics = None
         self.selected_harmonic = None
+        self.lifetime_colormap = None
+        self.colormap_contrast_limits = None
+        self.hist_fig, self.hist_ax = plt.subplots()
+        self.counts = None
+        self.bin_edges = None
+        self.bin_centers = None
 
         # Create main layout
         self.main_layout = QVBoxLayout(self)
@@ -611,15 +638,9 @@ class LifetimeWidget(QWidget):
         self.frequency_input = QLineEdit()
         self.frequency_input.setValidator(QDoubleValidator())
         self.main_layout.addWidget(self.frequency_input)
-        # Add colormap combobox
-        self.main_layout.addWidget(QLabel("Lifetime colormap: "))
-        self.lifetime_colormap_combobox = QComboBox()
-        self.lifetime_colormap_combobox.addItems(plt.colormaps())
-        self.lifetime_colormap_combobox.setCurrentText("turbo")
-        self.main_layout.addWidget(self.lifetime_colormap_combobox)
         # Add combobox to select between phase or modulation apparent lifetime
         self.main_layout.addWidget(
-            QLabel("Show phase of modulation apparent lifetime: ")
+            QLabel("Display phase or modulation apparent lifetimes: ")
         )
         self.lifetime_type_combobox = QComboBox()
         self.lifetime_type_combobox.addItems(["Phase", "Modulation"])
@@ -637,35 +658,26 @@ class LifetimeWidget(QWidget):
             self._populate_layers_combobox
         )
 
-        # Populate combobox
-        self._populate_layers_combobox()
-
-        # Add layout for histogram
+        # Add histogram widget
         self.histogram_widget = QWidget(self)
         self.histogram_layout = QVBoxLayout(self.histogram_widget)
+        # Embed the Matplotlib figure into the widget
+        canvas = FigureCanvas(self.hist_fig)
+        self.histogram_layout.addWidget(canvas)
+
+        # Add harmonic selector label and QSpinBox if they don't exist
+        self.harmonic_selector_label = QLabel(
+            "Select a harmonic to display its lifetime histogram:"
+        )
+        self.histogram_layout.addWidget(self.harmonic_selector_label)
+        self.harmonic_selector = QSpinBox()
+        self.harmonic_selector.valueChanged.connect(self._on_harmonic_changed)
+        self.histogram_layout.addWidget(self.harmonic_selector)
         self.main_layout.addWidget(self.histogram_widget)
+        self.histogram_widget.hide()
 
-    @property
-    def lifetime_colormap(self):
-        """Gets or sets the lifetime colormap from the colormap combobox.
-
-        Returns
-        -------
-        str
-            The colormap name.
-        """
-        return self.lifetime_colormap_combobox.currentText()
-
-    @lifetime_colormap.setter
-    def lifetime_colormap(self, colormap: str):
-        """Sets the lifetime colormap from the colormap combobox."""
-        if colormap not in plt.colormaps():
-            show_error(
-                f"{colormap} is not a valid colormap. "
-                "Setting to default colormap."
-            )
-            colormap = self.lifetime_colormap.name
-        self.lifetime_colormap_combobox.setCurrentText(colormap)
+        # Populate combobox
+        self._populate_layers_combobox()
 
     def _populate_layers_combobox(self):
         """Populate combobox with image layers."""
@@ -681,18 +693,24 @@ class LifetimeWidget(QWidget):
 
     def _on_layers_combobox_change(self):
         """Callback whenever the layer combobox changes."""
-        # TODO: get the frequency automatically from the metadata
         layer_name = self.layer_combobox.currentText()
         if layer_name == "":
             self._labels_layer_with_phasor_features = None
-            self.histogram_widget.hide()
             return
-        self._labels_layer_with_phasor_features = self.viewer.layers[
-            layer_name
-        ].metadata['phasor_features_labels_layer']
+        layer_metadata = self.viewer.layers[layer_name].metadata
+        self._labels_layer_with_phasor_features = layer_metadata[
+            'phasor_features_labels_layer'
+        ]
         self.harmonics = np.unique(
             self._labels_layer_with_phasor_features.features['harmonic']
         )
+        if (
+            'settings' in layer_metadata.keys()
+            and 'frequency' in layer_metadata['settings'].keys()
+        ):
+            self.frequency_input.setText(
+                str(layer_metadata['settings']['frequency'])
+            )
 
     def calculate_lifetimes(self):
         """Calculate the lifetimes for all harmonics."""
@@ -738,46 +756,13 @@ class LifetimeWidget(QWidget):
         if self.lifetime_data is None:
             return
 
-        # Initialize a list to hold the colored arrays for each harmonic
-        combined_colored_array = []
-
-        # Iterate over each harmonic
-        for harmonic_index in range(len(self.harmonics)):
-            lifetime_data = self.lifetime_data[harmonic_index]
-
-            # Flatten the lifetime data for percentile calculation
-            flattened_data = lifetime_data.flatten()
-            flattened_data = flattened_data[flattened_data > 0]
-
-            # Calculate the 5th and 95th percentiles
-            lower_bound = np.percentile(flattened_data, 5)
-            upper_bound = np.percentile(flattened_data, 95)
-
-            # Normalize the array to the range [lower_bound, upper_bound]
-            norm = mcolors.Normalize(vmin=lower_bound, vmax=upper_bound)
-
-            # Choose a colormap
-            cmap = colormaps[self.lifetime_colormap]
-
-            # Apply the colormap to the normalized array
-            colored_array = cmap(norm(lifetime_data))
-
-            # Set the first value of the colormap to transparent
-            colored_array[..., -1][lifetime_data == lifetime_data.min()] = 0
-
-            # Append the colored array to the list
-            combined_colored_array.append(colored_array)
-
-        # Stack the colored arrays along a new axis to combine them
-        combined_colored_array = np.stack(combined_colored_array, axis=0)
-
         # Build lifetime layer
-        lifetime_layer_name = f"Lifetime: {self.layer_combobox.currentText()}"
+        lifetime_layer_name = f"{self.lifetime_type_combobox.currentText()} Lifetime: {self.layer_combobox.currentText()}"
         selected_lifetime_layer = Image(
-            combined_colored_array,
+            self.lifetime_data,
             name=lifetime_layer_name,
             scale=self._labels_layer_with_phasor_features.scale,
-            colormap=self.lifetime_colormap,
+            colormap='turbo',
         )
 
         # Check if the layer is in the viewer before attempting to remove it
@@ -785,6 +770,12 @@ class LifetimeWidget(QWidget):
             self.viewer.layers.remove(self.viewer.layers[lifetime_layer_name])
 
         self.lifetime_layer = self.viewer.add_layer(selected_lifetime_layer)
+        self.lifetime_colormap = self.lifetime_layer.colormap.colors
+        self.lifetime_layer.events.colormap.connect(self._on_colormap_changed)
+        self.colormap_contrast_limits = self.lifetime_layer.contrast_limits
+        self.lifetime_layer.events.contrast_limits.connect(
+            self._on_colormap_changed
+        )
 
     def plot_lifetime_histogram(self):
         """Plot the histogram of the lifetime data as a line plot."""
@@ -794,98 +785,63 @@ class LifetimeWidget(QWidget):
             return
         if self.selected_harmonic is None:
             self.selected_harmonic = self.harmonics.min()
+
+        self.harmonic_selector.setMinimum(self.harmonics.min())
+        self.harmonic_selector.setMaximum(self.harmonics.min())
+        self.harmonic_selector.setValue(self.selected_harmonic)
+
         harmonic_index = list(self.harmonics).index(self.selected_harmonic)
         lifetime_data = self.lifetime_data[harmonic_index]
-        # Flatten the lifetime data for histogram plotting
         flattened_data = lifetime_data.flatten()
         flattened_data = flattened_data[flattened_data > 0]
 
-        # Calculate the histogram values
-        counts, bin_edges = np.histogram(flattened_data, bins=100)
+        self.counts, self.bin_edges = np.histogram(flattened_data, bins=300)
+        self.bin_centers = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2
 
-        # Calculate the bin centers
-        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+        self._update_lifetime_histogram()
+        self.histogram_widget.show()
 
-        # Calculate the 5th and 95th percentiles
-        lower_bound = np.percentile(flattened_data, 5)
-        upper_bound = np.percentile(flattened_data, 95)
+    def _update_lifetime_histogram(self):
+        """Update the histogram plot with the current histogram values."""
+        self.hist_ax.clear()
+        self.hist_ax.plot(self.bin_centers, self.counts, color='none', alpha=0)
 
-        # Create a Matplotlib figure and axis
-        fig, ax = plt.subplots()
+        # Create the colormap by linear combination of the napari cmap
+        cmap = LinearSegmentedColormap.from_list(
+            'custom_cmap', self.lifetime_colormap
+        )
+        norm = plt.Normalize(
+            vmin=self.colormap_contrast_limits[0],
+            vmax=self.colormap_contrast_limits[1],
+        )
 
-        # Plot the histogram values as a line plot with transparent line color
-        ax.plot(bin_centers, counts, color='none', alpha=0)
-
-        # Normalize the bin values to the range [lower_bound, upper_bound]
-        norm = plt.Normalize(vmin=lower_bound, vmax=upper_bound)
-
-        # Get the colormap
-        cmap = colormaps[self.lifetime_colormap]
-
-        # Fill the area under the curve using the colormap
         for count, bin_start, bin_end in zip(
-            counts, bin_edges[:-1], bin_edges[1:]
+            self.counts, self.bin_edges[:-1], self.bin_edges[1:]
         ):
             bin_center = (bin_start + bin_end) / 2
             color = cmap(norm(bin_center))
-            ax.fill_between(
+            self.hist_ax.fill_between(
                 [bin_start, bin_end], 0, count, color=color, alpha=0.7
             )
 
-        ax.set_title('Lifetime Data Histogram')
-        ax.set_xlabel('Lifetime')
-        ax.set_ylabel('Frequency')
+        self.hist_ax.set_title('Lifetime Distribution')
+        self.hist_ax.set_xlabel('Lifetime (ns)')
+        self.hist_ax.set_ylabel('Pixel count')
 
-        # Clear the previous histogram plot but keep the QSpinBox and QLabel
-        for i in reversed(range(self.histogram_layout.count())):
-            widget_to_remove = self.histogram_layout.itemAt(i).widget()
-            if isinstance(widget_to_remove, FigureCanvas):
-                self.histogram_layout.removeWidget(widget_to_remove)
-                widget_to_remove.setParent(None)
-
-        # Embed the Matplotlib figure into the widget
-        canvas = FigureCanvas(fig)
-        self.histogram_layout.addWidget(canvas)
-        self.histogram_widget.show()
-
-        # Add harmonic selector label and QSpinBox if they don't exist
-        if not hasattr(self, 'harmonic_selector_label'):
-            self.harmonic_selector_label = QLabel(
-                "Select a harmonic to display its lifetime histogram:"
-            )
-            self.histogram_layout.addWidget(self.harmonic_selector_label)
-        if not hasattr(self, 'harmonic_selector'):
-            self.harmonic_selector = QSpinBox()
-            self.harmonic_selector.setMinimum(self.harmonics.min())
-            self.harmonic_selector.setMaximum(self.harmonics.max())
-            self.harmonic_selector.setValue(self.selected_harmonic)
-            self.harmonic_selector.valueChanged.connect(
-                self._on_harmonic_changed
-            )
-
-        # Ensure the harmonic label and QSpinBox are always at the bottom
-        if self.harmonic_selector_label not in [
-            self.histogram_layout.itemAt(i).widget()
-            for i in range(self.histogram_layout.count())
-        ]:
-            self.histogram_layout.addWidget(self.harmonic_selector_label)
-        else:
-            self.histogram_layout.removeWidget(self.harmonic_selector_label)
-            self.histogram_layout.addWidget(self.harmonic_selector_label)
-        if self.harmonic_selector not in [
-            self.histogram_layout.itemAt(i).widget()
-            for i in range(self.histogram_layout.count())
-        ]:
-            self.histogram_layout.addWidget(self.harmonic_selector)
-        else:
-            self.histogram_layout.removeWidget(self.harmonic_selector)
-            self.histogram_layout.addWidget(self.harmonic_selector)
-        self.harmonic_selector.setValue(self.selected_harmonic)
+        # Refresh the canvas to show the updated histogram
+        self.hist_fig.canvas.draw_idle()
 
     def _on_harmonic_changed(self):
         """Callback whenever the harmonic selector changes."""
         self.selected_harmonic = self.harmonic_selector.value()
         self.plot_lifetime_histogram()
+
+    def _on_colormap_changed(self, event):
+        """Callback whenever the colormap changes."""
+        layer = event.source
+        self.lifetime_colormap = layer.colormap.colors
+        self.colormap_contrast_limits = layer.contrast_limits
+        self._update_lifetime_histogram()
 
     def _on_click(self):
         """Callback whenever the plot lifetime button is clicked."""

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -789,7 +789,7 @@ class LifetimeWidget(QWidget):
             self.selected_harmonic = self.harmonics.min()
 
         self.harmonic_selector.setMinimum(self.harmonics.min())
-        self.harmonic_selector.setMaximum(self.harmonics.min())
+        self.harmonic_selector.setMaximum(self.harmonics.max())
 
         harmonic_index = list(self.harmonics).index(self.selected_harmonic)
         lifetime_data = self.lifetime_data[harmonic_index]

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -445,6 +445,8 @@ class CalibrationWidget(QWidget):
             show_error("Enter reference lifetime")
             return
         frequency = float(frequency)
+        if "settings" not in self.viewer.layers[sample_name].metadata.keys():
+            self.viewer.layers[sample_name].metadata["settings"] = {}
         self.viewer.layers[sample_name].metadata["settings"][
             "frequency"
         ] = frequency
@@ -788,7 +790,6 @@ class LifetimeWidget(QWidget):
 
         self.harmonic_selector.setMinimum(self.harmonics.min())
         self.harmonic_selector.setMaximum(self.harmonics.min())
-        self.harmonic_selector.setValue(self.selected_harmonic)
 
         harmonic_index = list(self.harmonics).index(self.selected_harmonic)
         lifetime_data = self.lifetime_data[harmonic_index]


### PR DESCRIPTION
This PR proposes two main changes:

1. Reading the frequency parameter from the metadata (when available) and autocompleting this field with this frequency value across different widgets that ask the user the frequency as input. As en exception, files with FBD format are excluded from this because the format is not trusted to have the correct frequency value. If there is no frequency available in the metadata, after the first time a user inputs the frequency, this is stored in the 'settings' dictionary and is used for autocompleting in other widgets.

2. Modifications in the lifetime widget include:
- Changing the lifetime image layer from RGB to the actual lifetime values (this was suggested in #69)
- The previous change allows now for selection of colormap from the napari colormaps and to select the range of values mapped to the colormap
- The histogram showing the lifetime distribution was updated to follow this changes in the colormap accordingly.