### PR TITLE
Applying threshold and filtering when reading OME-TIF and saving calibration parameters in metadata

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -141,7 +141,7 @@ def test_phasor_plotter(make_napari_viewer):
         (len(harmonics),) + original_mean.data.shape,
     )
     original_mean, original_g, original_s = phasor_filter_median(
-        original_mean, original_g, original_s, repeat=3, size=3, skip_axis=0
+        original_mean, original_g, original_s, repeat=3, size=3
     )
     _, original_g, original_s = phasor_threshold(
         original_mean,

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -253,3 +253,4 @@ def test_reader_ometif():
 
 
 # TODO: Add tests for .tif files
+# TODO: test filter and threshold when reading OME-TIF

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -50,7 +50,7 @@ def test_apply_filter_and_threshold(make_napari_viewer):
         original_s, (len(harmonics),) + original_mean.data.shape
     )
     original_mean, original_g, original_s = phasor_filter_median(
-        original_mean, original_g, original_s, repeat=1, size=3, skip_axis=0
+        original_mean, original_g, original_s, repeat=1, size=3
     )
     _, original_g, original_s = phasor_threshold(
         original_mean, original_g, original_s, threshold

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -468,6 +468,7 @@ def test_calibration_widget(make_napari_viewer):
         mock_show_info.assert_called_once_with(f"Calibrated {sample_name}")
     # Check if the calibration was successful
     assert viewer.layers[0].metadata["settings"]["calibrated"] is True
+    # TODO: check 'calibration_phase' and 'calibration_modulation' values
     calibrated_real = np.reshape(
         viewer.layers[0]
         .metadata["phasor_features_labels_layer"]

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -50,7 +50,6 @@ def apply_filter_and_threshold(
             imag,
             repeat=repeat,
             size=size,
-            skip_axis=0,
         )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)


### PR DESCRIPTION
This PR proposes two additions:

1. When opening an exported OME-TIF from the napari-phasors plugin, apply threshold and filtering if these parameters are present in the metadata of the file. This solves issue #84

2. Saving calibration phase and modulation parameters in the `settings` dictionary stored in the metadata of the OME-TIF file exported by the plugin. This parameters are called `calibration_phase` and `calibration_modulation` in the `settings` dictionary. This solves issue #85. This parameters can be used to apply transformation (rotation and scaling) to other images that use the same calibration. (Not implemented)