### PR TITLE
Bump version for release v0.0.3

### DIFF
--- a/src/napari_phasors/__init__.py
+++ b/src/napari_phasors/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.2alpha"
+__version__ = "0.0.3"
 
 from ._reader import napari_get_reader
 from ._sample_data import (


### PR DESCRIPTION
This PR bumps the version of the napari-phasors plugin to version 0.0.3 ahead of release.