### PR TITLE
Edit multichannel image reading

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -30,25 +30,25 @@ extension_mapping = {
     "raw": {
         ".ptu": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_ptu,
+            io.signal_from_ptu,
             {"frame": (-1, False), "keepdims": (True, False)},
             reader_options,
         ),
         ".fbd": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_fbd,
+            io.signal_from_fbd,
             {"frame": (-1, False), "keepdims": (True, False)},
             reader_options,
         ),
         ".sdt": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_sdt,
+            io.signal_from_sdt,
             {},
             reader_options,
         ),
         ".lsm": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_lsm,
+            io.signal_from_lsm,
             {},
             reader_options,
         ),

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -166,8 +166,8 @@ def raw_file_reader(
     filename, file_extension = _get_filename_extension(path)
     if file_extension == ".sdt":
         # Try reading .sdt with increasing 'index' numbers to collect all files as channels
-        i=0
-        raw_data=[]
+        i = 0
+        raw_data = []
         while True:
             try:
                 _data = extension_mapping["raw"][".sdt"](path, {"index": i})
@@ -177,10 +177,14 @@ def raw_file_reader(
                 break
         # Stack list of xarrays in a new axis "C" (shapes must match)
         for _data in raw_data:
-            assert _data.shape == raw_data[0].shape, "Shapes from files in .sdt do not match!"
+            assert (
+                _data.shape == raw_data[0].shape
+            ), "Shapes from files in .sdt do not match!"
         raw_data = xr.concat(raw_data, dim="C")
     else:
-        raw_data = extension_mapping["raw"][file_extension](path, reader_options)
+        raw_data = extension_mapping["raw"][file_extension](
+            path, reader_options
+        )
     settings = {}
     if (
         file_extension != '.fbd'


### PR DESCRIPTION
This PR adds extra metadata to layers if images are multichannel (`len(layers) > 1`) to have them with different colormaps and `additive` blending following napari conventions (as in [here](https://github.com/napari/napari/blob/8a958c94ffb5b8a3cb6d72f41b490823fdac6636/napari/layers/utils/stack_utils.py#L106)).

Also, it seems that if `.sdt` has more channels, they are stored in a list fashion. The current code only loads the first image/channel of these files. Assuming all the arrays in the list have the same shape (**this needs double checking**), the current changes repeat the reading function with an increasing `index` (argument from [signal_from_sdt](https://www.phasorpy.org/docs/stable/api/io/#phasorpy.io.signal_from_sdt) function) until it fails, and then stacks the collected arrays along a new 'C' axis.

Finally, this code updates the reading function names in agreement with `phasorpy 0.4`.