### PR TITLE
Enable higher dimensional stacks reading

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    phasorpy==0.3
+    phasorpy==0.4
     qtpy
     scikit-image
     biaplotter>=0.0.5a2
@@ -71,7 +71,7 @@ testing =
     pandas
     black
     isort
-    phasorpy==0.3
+    phasorpy==0.4
     tifffile
     lfdfiles
     sdtfile

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     tifffile
     pandas
     pyqt5
+    natsort
 
 python_requires = >=3.10
 include_package_data = True
@@ -76,6 +77,7 @@ testing =
     lfdfiles
     sdtfile
     ptufile
+    natsort
     
 
 

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -5,21 +5,21 @@ and computes phasor coordinates with `phasorpy.phasor.phasor_from_signal`
 """
 
 import inspect
+import itertools
 import json
 import os
 import sys
 import warnings
-import itertools
 from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy as np
-import xarray as xr
 import pandas as pd
 import phasorpy.io as io
 import tifffile
+import xarray as xr
 from napari.layers import Labels
+from napari.utils.colormaps.colormap_utils import CYMRGB, MAGENTA_GREEN
 from napari.utils.notifications import show_error
-from napari.utils.colormaps.colormap_utils import MAGENTA_GREEN, CYMRGB
 from phasorpy.phasor import (
     phasor_filter_median,
     phasor_from_signal,

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -399,7 +399,8 @@ def make_phasors_labels_layer(
     """
     pixel_id = np.arange(1, mean_intensity_image.size + 1)
     table = pd.DataFrame()
-    if len(G_image.shape) > 2:
+    if len(G_image.shape) > len(mean_intensity_image.shape):
+        # If G_image has more dimensions than mean_intensity_image, it means it has multiple harmonics in the first axis
         for i in range(G_image.shape[0]):
             harmonic_value = harmonics[i] if harmonics is not None else i + 1
             sub_table = pd.DataFrame(

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -457,13 +457,7 @@ def stack_reader(
     most_frequent_file_extension = max(set(suffixes), key=suffixes.count)
     # Filter out files that do not have the most frequent extension
     file_paths = [p for p, s in zip(file_paths, suffixes) if s == most_frequent_file_extension]
-    if most_frequent_file_extension in tuple(extension_mapping["processed"].keys()):
-        print("To be implemented")
-        return
-            # return lambda path: processed_stack_reader(
-            #     file_paths, most_frequent_file_extension, reader_options=reader_options, harmonics=harmonics
-            # )
-    elif most_frequent_file_extension in tuple(extension_mapping["raw"].keys()):
+    if most_frequent_file_extension in tuple(extension_mapping["raw"].keys()):
         return raw_stack_reader(
             file_paths=file_paths, file_extension=most_frequent_file_extension, reader_options=reader_options, harmonics=harmonics
         )

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -30,25 +30,25 @@ extension_mapping = {
     "raw": {
         ".ptu": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_ptu,
+            io.signal_from_ptu,
             {"frame": (-1, False), "keepdims": (True, False)},
             reader_options,
         ),
         ".fbd": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_fbd,
+            io.signal_from_fbd,
             {"frame": (-1, False), "keepdims": (True, False)},
             reader_options,
         ),
         ".sdt": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_sdt,
+            io.signal_from_sdt,
             {},
             reader_options,
         ),
         ".lsm": lambda path, reader_options: _parse_and_call_io_function(
             path,
-            io.read_lsm,
+            io.signal_from_lsm,
             {},
             reader_options,
         ),

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -166,8 +166,8 @@ def raw_file_reader(
     filename, file_extension = _get_filename_extension(path)
     if file_extension == ".sdt":
         # Try reading .sdt with increasing 'index' numbers to collect all files as channels
-        i=0
-        raw_data=[]
+        i = 0
+        raw_data = []
         while True:
             try:
                 _data = extension_mapping["raw"][".sdt"](path, {"index": i})
@@ -177,10 +177,14 @@ def raw_file_reader(
                 break
         # Stack list of xarrays in a new axis "C" (shapes must match)
         for _data in raw_data:
-            assert _data.shape == raw_data[0].shape, "Shapes from files in .sdt do not match!"
+            assert (
+                _data.shape == raw_data[0].shape
+            ), "Shapes from files in .sdt do not match!"
         raw_data = xr.concat(raw_data, dim="C")
     else:
-        raw_data = extension_mapping["raw"][file_extension](path, reader_options)
+        raw_data = extension_mapping["raw"][file_extension](
+            path, reader_options
+        )
     settings = {}
     if (
         file_extension != '.fbd'

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 import phasorpy.io as io
 import tifffile
-import xarray as xr
+from pathlib import Path
 from napari.layers import Labels
 from napari.utils.colormaps.colormap_utils import CYMRGB, MAGENTA_GREEN
 from napari.utils.notifications import show_error
@@ -121,17 +121,54 @@ def napari_get_reader(
         in 'metadata' contain phasor coordinates as columns 'G' and 'S'.
 
     """
-    if path.endswith(tuple(extension_mapping["processed"].keys())):
-        return lambda path: processed_file_reader(
-            path, reader_options=reader_options, harmonics=harmonics
-        )
-    elif path.endswith(tuple(extension_mapping["raw"].keys())):
-        return lambda path: raw_file_reader(
+    path = Path(path) # Convert to Path object for easier manipulation
+    if path.is_dir():
+        return lambda path: stack_reader(
             path, reader_options=reader_options, harmonics=harmonics
         )
     else:
-        show_error("File extension not supported.")
+        suffix = ''.join(path.suffixes) # Get the full suffix (e.g. .ome.tif)
+        if suffix in tuple(extension_mapping["processed"].keys()):
+            return lambda path: processed_file_reader(
+                path, reader_options=reader_options, harmonics=harmonics
+            )
+        elif suffix in tuple(extension_mapping["raw"].keys()):
+            return lambda path: raw_file_reader(
+                path, reader_options=reader_options, harmonics=harmonics
+            )
+        else:
+            show_error("File extension not supported.")
 
+def _stack_sdt_channels(path):
+    """Read .sdt files with increasing 'index' numbers and stack them as channels.
+
+    Parameters
+    ----------
+    path : Path
+        Path to file.
+    
+    Returns
+    -------
+    raw_data : xarray.DataArray
+        Stacked xarray DataArray with all channels.
+    """
+    from xarray import concat
+    # Try reading .sdt with increasing 'index' numbers to collect all files as channels
+    i = 0
+    raw_data = []
+    while True:
+        try:
+            _data = extension_mapping["raw"][".sdt"](path, {"index": i})
+            raw_data.append(_data)
+            i += 1
+        except IndexError:
+            break
+    # Stack list of xarrays in a new axis "C" (shapes must match)
+    for _data in raw_data:
+        assert (
+            _data.shape == raw_data[0].shape
+        ), "Shapes from files in .sdt do not match!"
+    return concat(raw_data, dim="C")
 
 def raw_file_reader(
     path: str,
@@ -165,22 +202,7 @@ def raw_file_reader(
     """
     filename, file_extension = _get_filename_extension(path)
     if file_extension == ".sdt":
-        # Try reading .sdt with increasing 'index' numbers to collect all files as channels
-        i = 0
-        raw_data = []
-        while True:
-            try:
-                _data = extension_mapping["raw"][".sdt"](path, {"index": i})
-                raw_data.append(_data)
-                i += 1
-            except IndexError:
-                break
-        # Stack list of xarrays in a new axis "C" (shapes must match)
-        for _data in raw_data:
-            assert (
-                _data.shape == raw_data[0].shape
-            ), "Shapes from files in .sdt do not match!"
-        raw_data = xr.concat(raw_data, dim="C")
+        raw_data = _stack_sdt_channels(path)
     else:
         raw_data = extension_mapping["raw"][file_extension](
             path, reader_options
@@ -367,6 +389,197 @@ def processed_file_reader(
     layers.append((mean_intensity_image, add_kwargs))
     return layers
 
+def extract_value_after_prefix(path, prefix='t'):
+    """
+    Extracts an the integer value from the file path based on the given prefix.
+    For example, if prefix is 't', it will search for the pattern '_t<number>'.
+    Strips the 0s from the beginning of the number.
+    Returns the matching string with leading 0s stripped if found, otherwise an empty string.
+
+    Parameters
+    ----------
+    path : Path
+        Path object of the file.
+    prefix : str
+        Prefix to search for in the file name. Default is 't'.
+
+    Returns
+    -------
+    str
+        Extracted value after the prefix, with leading 0s stripped.
+        If no match is found, returns an empty string.
+    """
+    import re
+    regex = r'_' + prefix + r'(\d+)'
+    match = re.search(regex, path.stem)
+    return match.group(1).lstrip('0') if match else ''
+
+def extract_paths_with_same_value_after_prefix(file_paths, extract_prefix='t', sort_prefix='z'):
+    """
+    Extracts all file paths with the same value after the given prefix.
+    Returns a dictionary where the key is the extract prefix + value and the value is a list of paths sorted by the sort prefix.
+    For example, if prefix is 't' and sort prefix is 'z', it will search for the pattern '_t<number>' and sort by '_z<number>'.
+
+    Parameters
+    ----------
+    file_paths : list of Path
+        List of Path objects of the files.
+    extract_prefix : str
+        Prefix to search for in the file name. Default is 't'.
+    sort_prefix : str
+        Prefix to sort the file paths by. Default is 'z'.
+
+    Returns
+    -------
+    dict
+        Dictionary where the key is the extract prefix + value and the value is a list of paths sorted by the sort prefix.
+    """
+    from natsort import natsorted
+    file_paths = natsorted(file_paths, key=lambda x: extract_value_after_prefix(x, prefix=extract_prefix))
+    paths_dict = {}
+    for path in file_paths:
+        value = extract_value_after_prefix(path, extract_prefix)
+        if (extract_prefix+value) not in paths_dict:
+            paths_dict[extract_prefix+value] = []
+        paths_dict[extract_prefix+value].append(path)
+
+    # Sort the paths in each list
+    for k in paths_dict:
+        paths_dict[k] = natsorted(paths_dict[k], key=lambda x: extract_value_after_prefix(x, sort_prefix))
+    return paths_dict
+
+def stack_reader(
+        path: Path,
+        reader_options: Optional[dict] = None,
+        harmonics: Union[int, Sequence[int], None] = None,
+) -> list[tuple]:
+    file_paths, suffixes = [(p, p.stem,''.join(p.suffixes)) for p in path.iterdir()]
+    most_frequent_file_extension = max(set(suffixes), key=suffixes.count)
+    if most_frequent_file_extension in tuple(extension_mapping["processed"].keys()):
+            return lambda path: processed_file_reader(
+                file_paths, most_frequent_file_extension, reader_options=reader_options, harmonics=harmonics
+            )
+    elif most_frequent_file_extension in tuple(extension_mapping["raw"].keys()):
+        return lambda path: raw_file_reader(
+            file_paths, most_frequent_file_extension, reader_options=reader_options, harmonics=harmonics
+        )
+    else:
+        show_error("File extension not supported.")
+
+def raw_stack_reader(
+          file_paths: list[Path],
+          file_extension: str,
+            reader_options: Optional[dict] = None,
+            harmonics: Union[int, Sequence[int], None] = None,
+) -> tuple[np.ndarray, dict]:
+    from tqdm import tqdm
+    folder_name = file_paths[0].parent.name
+    structured_file_path_dict = extract_paths_with_same_value_after_prefix(file_paths, extract_prefix='t', sort_prefix='z')
+
+    progress_bar = tqdm(
+        total=sum((len(v) for v in structured_file_path_dict.values())),
+        desc="Reading stack",
+        unit="files",
+    )
+
+    z_list_mean_intensity, z_list_G, z_list_S, t_list_mean_intensity, t_list_G, t_list_S = [], [], [], [], [], []
+    for t, list_of_z_slice_paths in structured_file_path_dict.items():
+        for z_slice_path in list_of_z_slice_paths:
+            if file_extension == ".sdt":
+                _raw_data = _stack_sdt_channels(z_slice_path)
+            else:
+                _raw_data = extension_mapping["raw"][file_extension](
+                    z_slice_path, reader_options
+                )
+            iter_axis = iter_index_mapping[file_extension]
+            if iter_axis is None:
+                # Single channel analysis
+                if file_extension == ".tif":
+                    mean_intensity_image, G_image, S_image = phasor_from_signal(
+                        _raw_data, axis=0, harmonic=harmonics
+                    )
+                else:
+                    # Calculate phasor over channels if file is of hyperspectral type
+                    mean_intensity_image, G_image, S_image = phasor_from_signal(
+                        _raw_data, axis=_raw_data.dims.index("C"), harmonic=harmonics
+                    )
+                # Add unitary axis representing channels
+                mean_intensity_image = np.expand_dims(mean_intensity_image, axis=-1)
+                G_image = np.expand_dims(G_image, axis=-1)
+                S_image = np.expand_dims(S_image, axis=-1)
+            else:
+                iter_axis_index = _raw_data.dims.index(iter_axis)
+                c_list_mean_intensity, c_list_G, c_list_S = [], [], []
+                for channel in range(_raw_data.shape[iter_axis_index]):
+                    # Calculate phasor over photon counts dimension if file is FLIM
+                    mean_intensity_image, G_image, S_image = phasor_from_signal(
+                        _raw_data.sel(C=channel),
+                        axis=_raw_data.sel(C=channel).dims.index("H"),
+                        harmonic=harmonics,
+                    )
+                    c_list_mean_intensity.append(mean_intensity_image)
+                    c_list_G.append(G_image)
+                    c_list_S.append(S_image)
+                # Stack list having channel being last axis
+                mean_intensity_image = np.stack(c_list_mean_intensity, axis=-1)
+                G_image = np.stack(c_list_G, axis=-1)
+                S_image = np.stack(c_list_S, axis=-1)
+            z_list_mean_intensity.append(mean_intensity_image)
+            z_list_G.append(G_image)
+            z_list_S.append(S_image)
+            progress_bar.update(1)
+        z_stack_mean_intensity = np.stack(z_list_mean_intensity)
+        z_stack_G = np.stack(z_list_G)
+        z_stack_S = np.stack(z_list_S)
+        t_list_mean_intensity.append(z_stack_mean_intensity)
+        t_list_G.append(z_stack_G)
+        t_list_S.append(z_stack_S)
+        z_list_mean_intensity.clear()
+        z_list_G.clear()
+        z_list_S.clear()
+    stack_mean_intensity = np.stack(t_list_mean_intensity) # TZYXC
+    stack_G = np.stack(t_list_G) # QTZYXC (Q for number of harmonics)
+    stack_S = np.stack(t_list_S)
+    progress_bar.close()
+    settings = {}
+    if (
+        file_extension != '.fbd'
+        and hasattr(_raw_data, "attrs")
+        and 'frequency' in _raw_data.attrs.keys()
+    ):
+        settings['frequency'] = _raw_data.attrs['frequency']
+    layers = []
+    for ch in range(stack_mean_intensity.shape[-1]):
+        labels_layer = make_phasors_labels_layer(
+                stack_mean_intensity,
+                stack_G,
+                stack_S,
+                name=folder_name,
+                harmonics=harmonics,
+            )
+        layer_name = [f"{folder_name} Intensity Image: " if stack_mean_intensity.shape[-1] == 1 else f"{folder_name} Intensity Image: Channel {ch}"][0]
+        add_kwargs = {
+            "name": layer_name,
+            "metadata": {
+                "phasor_features_labels_layer": labels_layer,
+                "original_mean": mean_intensity_image,
+                "settings": settings,
+            },
+        }
+        layers.append((mean_intensity_image, add_kwargs))
+        # Set colormaps if multichannel image
+    if len(layers) == 2:
+        # add colormaps MAGENTA_GREEN
+        for layer, cmap in zip(layers, MAGENTA_GREEN):
+            layer[1]["colormap"] = cmap
+            layer[1]['blending'] = 'additive'
+    elif len(layers) > 2:
+        # add colormaps CYMRGB in a cycle
+        for layer, cmap in zip(layers, itertools.cycle(CYMRGB)):
+            layer[1]["colormap"] = cmap
+            layer[1]['blending'] = 'additive'
+
+    return layers
 
 def make_phasors_labels_layer(
     mean_intensity_image: Any,
@@ -434,7 +647,7 @@ def make_phasors_labels_layer(
     labels_layer = Labels(
         labels_data,
         name=f"{name} Phasor Features Layer",
-        scale=(1, 1),
+        scale=tuple(np.ones(mean_intensity_image.ndim)), #TODO: apply proper scale based on metadata
         features=table,
     )
     return labels_layer

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -145,7 +145,7 @@ def test_reader_sdt():
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"]
-        == "seminal_receptacle_FLIM_single_image Intensity Image"
+        == "seminal_receptacle_FLIM_single_image Intensity Image: Channel 0"
     )
     assert (
         len(layer_data_tuple[1]["metadata"]) == 3

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -279,7 +279,7 @@ def test_phasor_transform_sdt_widget(make_napari_viewer):
     assert len(viewer.layers) == 1
     assert (
         viewer.layers[0].name
-        == "seminal_receptacle_FLIM_single_image Intensity Image"
+        == "seminal_receptacle_FLIM_single_image Intensity Image: Channel 0"
     )
     assert viewer.layers[0].data.shape == (512, 512)
     phasor_data = (
@@ -293,7 +293,7 @@ def test_phasor_transform_sdt_widget(make_napari_viewer):
     assert len(viewer.layers) == 2
     assert (
         viewer.layers[1].name
-        == "seminal_receptacle_FLIM_single_image Intensity Image [1]"
+        == "seminal_receptacle_FLIM_single_image Intensity Image: Channel 0 [1]"
     )
     assert viewer.layers[1].data.shape == (512, 512)
     phasor_data = (

--- a/src/napari_phasors/napari.yaml
+++ b/src/napari_phasors/napari.yaml
@@ -38,7 +38,7 @@ contributions:
       title: Plot lifetime image
   readers:
     - command: napari-phasors.get_reader
-      accepts_directories: false
+      accepts_directories: true
       filename_patterns: ['*.fbd','*.ptu', '*.lsm', '*ome.tif', '*.tif', '*.sdt']
   writers:
     - command: napari-phasors.write_ome_tiff


### PR DESCRIPTION
This PR is a draft for now.

It allows building and displaying in napari a higher dimensional array (3D timelapse multichannel) from individual raw files in a  folder.

It was only tested on multiple `.ptu` files in a folder.

It relies on a file naming convention to work, since the individual files do not contain an information of which z-slice or timepoint they belong to. This implementation and convention is similar to the one in [napari-flim-phasor-plotter](https://github.com/zoccoler/napari-flim-phasor-plotter).

To do:
- [ ] write automated tests
- [ ] check if it works/makes sense for other raw file formats

_Note:
I also tested it on an artificially generated 4D single `.ome.tif` file. The data for this file was calculated with [phasor_from_signal](https://www.phasorpy.org/docs/stable/api/phasor/#phasorpy.phasor.phasor_from_signal) and saved with [phasor_to_ometiff](https://www.phasorpy.org/docs/stable/api/io/#phasorpy.io.phasor_to_ometiff) with `dims='TZYX'`. No stack building necessary here, functionality is already existing before this PR if axes order are `('T', 'Z', 'Y', 'X')` (napari convention is to end with 'ZYX', except for RGB images). It works with multiple harmonics as well. However, it does not work if an extra dimension, like 'C' is included, because, if multiple harmonics are present, G and S images become 6D (`Q`, `T`, `Z`, `C`, `Y`, `X`) and a `OmeXmlError: more than 3 modulo dimensions` is thrown from `tifffile` after trying to save the images with  [phasor_to_ometiff](https://www.phasorpy.org/docs/stable/api/io/#phasorpy.io.phasor_to_ometiff)._