### PR TITLE
Comply with biaplotter 0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     phasorpy==0.3
     qtpy
     scikit-image
-    biaplotter>=0.0.5a2
+    biaplotter>=0.1.0
     lfdfiles
     sdtfile
     ptufile
@@ -66,7 +66,7 @@ testing =
     napari
     qtpy
     scikit-image
-    biaplotter>=0.0.5a0
+    biaplotter>=0.1.0
     PyQt5
     pandas
     black

--- a/src/napari_phasors/__init__.py
+++ b/src/napari_phasors/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.3.dev"
+__version__ = "0.0.4.dev"
 
 from ._reader import napari_get_reader
 from ._sample_data import (

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -468,9 +468,11 @@ class PlotterWidget(QWidget):
         ):
             # Get histogram data limits
             x_edges = self.canvas_widget.artists[
-                ArtistType.HISTOGRAM2D].histogram[1]
+                ArtistType.HISTOGRAM2D
+            ].histogram[1]
             y_edges = self.canvas_widget.artists[
-                ArtistType.HISTOGRAM2D].histogram[2]
+                ArtistType.HISTOGRAM2D
+            ].histogram[2]
             plotted_data_limits = [
                 x_edges[0],
                 x_edges[-1],
@@ -822,9 +824,13 @@ class PlotterWidget(QWidget):
             is not None
         ):
             if self.histogram_log_scale:
-                self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_color_normalization_method = "log"
+                self.canvas_widget.artists[
+                    ArtistType.HISTOGRAM2D
+                ].histogram_color_normalization_method = "log"
             else:
-                self.canvas_widget.artists[ArtistType.HISTOGRAM2D].histogram_color_normalization_method = "linear"
+                self.canvas_widget.artists[
+                    ArtistType.HISTOGRAM2D
+                ].histogram_color_normalization_method = "linear"
 
         # if active artist is histogram, add a colorbar
         if self.plot_type == ArtistType.HISTOGRAM2D.name:


### PR DESCRIPTION
biaplotter `0.1.0` will be released soon, and there are breaking changes, which should be fixed here. We should merge this quickly after the new version is out.

These are the main changes in this PR:

Dependency updates:

* Updated `biaplotter` dependency in `setup.cfg` to version `0.1.0` for both `install_requires` and `testing` sections. [[1]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L37-R37) [[2]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L69-R69)

Versioning:

* Incremented the package version in `src/napari_phasors/__init__.py` from `0.0.3.dev` to `0.0.4.dev`.

Colormap and histogram normalization:

* Changed the colormap reference from `categorical_colormap` to `overlay_colormap` in the `__init__` method of `plotter.py`.
* Updated the `_redefine_axes_limits` method in `plotter.py` to use `x_edges` and `y_edges` for histogram data limits instead of `histogram_limits`.
* Modified the `plot` method in `plotter.py` to set the histogram color normalization method to "log" or "linear" based on `histogram_log_scale` and updated the colorbar creation to use the selected colormap and normalization instance. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L825-R833) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L858-R849)