### PR TITLE
Read the first two harmonics by default for raw files and all harmonics in processed files

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -190,9 +190,17 @@ def raw_file_reader(
             ), "Shapes from files in .sdt do not match!"
         raw_data = xr.concat(raw_data, dim="C")
     else:
-        raw_data = extension_mapping["raw"][file_extension](
-            path, reader_options
-        )
+        # Try reading with default harmonics [1, 2], fall back to None if not available
+        try:
+            raw_data = extension_mapping["raw"][file_extension](
+                path, reader_options
+            )
+        except Exception:
+            # If harmonics [1, 2] are not available, set to None and retry
+            harmonics = None
+            raw_data = extension_mapping["raw"][file_extension](
+                path, reader_options
+            )
     settings = {}
     if (
         file_extension != '.fbd'

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -153,7 +153,8 @@ def raw_file_reader(
         Dictionary containing the arguments to pass to the function.
     harmonics : Union[int, Sequence[int], None], optional
         Harmonic(s) to be processed. Can be a single integer, a sequence of
-        integers, or None. Default is None.
+        integers, or None. Default is None, which sets the first two harmonics
+        to be processed.
 
     Returns
     -------
@@ -167,6 +168,9 @@ def raw_file_reader(
         in 'metadata' contain phasor coordinates as columns 'G' and 'S'.
 
     """
+    # Set default harmonics if None is passed
+    if harmonics is None:
+        harmonics = [1, 2]
     filename, file_extension = _get_filename_extension(path)
     if file_extension == ".sdt":
         # Try reading .sdt with increasing 'index' numbers to collect all files as channels
@@ -280,7 +284,8 @@ def processed_file_reader(
         Dictionary containing the arguments to pass to the function.
     harmonics : Union[int, Sequence[int], None], optional
         Harmonic(s) to be processed. Can be a single integer, a sequence of
-        integers, or None. Default is None.
+        integers, or None. Default is None, which sets all harmonics present
+        in the file to be processed.
 
     Returns
     -------
@@ -294,6 +299,9 @@ def processed_file_reader(
         in 'metadata' contain phasor coordinates as columns 'G' and 'S'.
 
     """
+    # Set default harmonics if None is passed
+    if harmonics is None:
+        harmonics = 'all'
     filename, file_extension = _get_filename_extension(path)
     reader_options = reader_options or {"harmonic": harmonics}
     mean_intensity_image, G_image, S_image, attrs = extension_mapping[
@@ -311,12 +319,14 @@ def processed_file_reader(
         settings = {}
     if "frequency" in attrs.keys():
         settings["frequency"] = attrs["frequency"]
+    harmonics_read = attrs.get("harmonic", None)
+
     labels_layer = make_phasors_labels_layer(
         mean_intensity_image,
         G_image,
         S_image,
         name=filename,
-        harmonics=harmonics,
+        harmonics=harmonics_read,
     )
 
     filter_size = None

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -36,7 +36,7 @@ def test_reader_ptu():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 6)
+    assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -47,6 +47,7 @@ def test_reader_ptu():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 def test_reader_fbd():
@@ -80,7 +81,7 @@ def test_reader_fbd():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 6)
+    assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -91,6 +92,7 @@ def test_reader_fbd():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
     # Second Channel
     layer_data_tuple = layer_data_list[1]
     assert isinstance(layer_data_tuple, tuple) and len(layer_data_tuple) == 2
@@ -115,7 +117,7 @@ def test_reader_fbd():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 6)
+    assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -126,6 +128,7 @@ def test_reader_fbd():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 def test_reader_sdt():
@@ -159,7 +162,7 @@ def test_reader_sdt():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 6)
+    assert phasor_features.features.shape == (524288, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -170,6 +173,7 @@ def test_reader_sdt():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 def test_reader_lsm():
@@ -199,7 +203,7 @@ def test_reader_lsm():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 6)
+    assert phasor_features.features.shape == (524288, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -210,6 +214,7 @@ def test_reader_lsm():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 def test_reader_ometif():
@@ -250,6 +255,7 @@ def test_reader_ometif():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1]
 
 
 # TODO: Add tests for .tif files

--- a/src/napari_phasors/_tests/test_sample_data.py
+++ b/src/napari_phasors/_tests/test_sample_data.py
@@ -37,7 +37,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 6)
+    assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -48,6 +48,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
     # Calibration
     layer_data_tuple = layer_data_list[1]
     assert isinstance(layer_data_tuple, tuple) and len(layer_data_tuple) == 2
@@ -72,7 +73,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (1, 256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (65536, 6)
+    assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -83,6 +84,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 def test_embryo_FLIM_sample_data(make_napari_viewer):
@@ -110,7 +112,7 @@ def test_embryo_FLIM_sample_data(make_napari_viewer):
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 6)
+    assert phasor_features.features.shape == (524288, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -121,6 +123,7 @@ def test_embryo_FLIM_sample_data(make_napari_viewer):
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
     # Calibration
     layer_data_tuple = layer_data_list[1]
     assert isinstance(layer_data_tuple, tuple) and len(layer_data_tuple) == 2
@@ -142,7 +145,7 @@ def test_embryo_FLIM_sample_data(make_napari_viewer):
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 6)
+    assert phasor_features.features.shape == (524288, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -153,6 +156,7 @@ def test_embryo_FLIM_sample_data(make_napari_viewer):
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 def test_paramecium_HSI_sample_data(make_napari_viewer):
@@ -179,7 +183,7 @@ def test_paramecium_HSI_sample_data(make_napari_viewer):
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 6)
+    assert phasor_features.features.shape == (524288, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -190,3 +194,4 @@ def test_paramecium_HSI_sample_data(make_napari_viewer):
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]


### PR DESCRIPTION
This PR proposes reading the first two harmonics by default for raw file formats, as was suggested in #110. 

Also, for processed file formats (currently only OME-TIF), all present harmonics in the file are to be read. At the moment, only the first one is being read by default, unless imported via de "Custom Import" widget. This is the reason of the issue raised in #102. Although it was suggested that only the first harmonic is being saved, all harmonics are saved, but only the first one was read by default. This PR should fix this and read all available harmonics by default.