### PR TITLE
Support PhasorPy v0.7 and fix OME-TIF reading test

### DIFF
--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -244,7 +244,7 @@ def test_reader_ometif():
     assert isinstance(phasor_features, Labels)
     assert phasor_features.data.shape == (512, 512)
     assert isinstance(phasor_features.features, pd.DataFrame)
-    assert phasor_features.features.shape == (262144, 6)
+    assert phasor_features.features.shape == (524288, 6)
     expected_columns = [
         "label",
         "G_original",
@@ -255,7 +255,7 @@ def test_reader_ometif():
     ]
     actual_columns = phasor_features.features.columns.tolist()
     assert actual_columns == expected_columns
-    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1]
+    assert np.unique(phasor_features.features["harmonic"]).tolist() == [1, 2]
 
 
 # TODO: Add tests for .tif files

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -12,7 +12,6 @@ This module contains widgets to:
 """
 
 from math import ceil, log10
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
@@ -23,14 +22,9 @@ from matplotlib.backends.backend_qt5agg import (
 from matplotlib.colors import LinearSegmentedColormap
 from napari.layers import Image
 from napari.utils.notifications import show_error, show_info
-from phasorpy.phasor import (
-    phasor_calibrate,
-    phasor_center,
-    phasor_from_lifetime,
+from phasorpy.lifetime import (
     phasor_to_apparent_lifetime,
-    polar_from_reference_phasor,
 )
-from qtpy import uic
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import (

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -6,10 +6,9 @@ from napari.layers import Image
 from napari.utils.notifications import show_error, show_info
 from phasorpy.phasor import (
     phasor_center,
-    phasor_from_lifetime,
     phasor_transform,
-    polar_from_reference_phasor,
 )
+from phasorpy.lifetime import phasor_from_lifetime, polar_from_reference_phasor
 from qtpy import uic
 from qtpy.QtWidgets import QVBoxLayout, QWidget
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -10,7 +10,7 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Circle
 from napari.layers import Image
 from napari.utils import colormaps, notifications
-from phasorpy.phasor import phasor_from_lifetime
+from phasorpy.lifetime import phasor_from_lifetime
 from qtpy import uic
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (


### PR DESCRIPTION
This PR proposes changes to support the newest release (v0.7) of PhasorPy.

It also fixes the `test_reader_ometif` test based on the recent change of file for testing OME-TIF which contains two harmonics instead of one. 