### PR TITLE
Add automatic threshold and wavelet filter

### DIFF
--- a/src/napari_phasors/_tests/test_filter_tab.py
+++ b/src/napari_phasors/_tests/test_filter_tab.py
@@ -59,14 +59,17 @@ def test_filter_widget_initialization_values(make_napari_viewer):
     assert filter_widget.threshold_method_combobox.itemText(0) == "None"
     assert filter_widget.threshold_method_combobox.itemText(1) == "Manual"
     assert filter_widget.threshold_method_combobox.itemText(2) == "Otsu"
-    assert filter_widget.threshold_method_combobox.itemText(3) == "Li" 
+    assert filter_widget.threshold_method_combobox.itemText(3) == "Li"
     assert filter_widget.threshold_method_combobox.itemText(4) == "Yen"
     assert filter_widget.threshold_method_combobox.currentText() == "Otsu"
 
     # Test median filter UI components
     assert hasattr(filter_widget, 'median_filter_label')
     assert isinstance(filter_widget.median_filter_label, QLabel)
-    assert filter_widget.median_filter_label.text() == "Median Filter Kernel Size: 3 x 3"
+    assert (
+        filter_widget.median_filter_label.text()
+        == "Median Filter Kernel Size: 3 x 3"
+    )
 
     assert hasattr(filter_widget, 'median_filter_spinbox')
     assert isinstance(filter_widget.median_filter_spinbox, QSpinBox)
@@ -139,7 +142,7 @@ def test_filter_method_switching(make_napari_viewer):
     # Switch to wavelet
     filter_widget.filter_method_combobox.setCurrentText("Wavelet")
     filter_widget.on_filter_method_changed()
-    
+
     assert filter_widget.median_filter_widget.isHidden()
     assert not filter_widget.wavelet_filter_widget.isHidden()
 
@@ -251,15 +254,15 @@ def create_image_layer_with_incompatible_harmonics():
     """Create an image layer with incompatible harmonics for wavelet filtering."""
     # Create base layer
     layer = create_image_layer_with_phasors()
-    
+
     # Modify harmonics to be incompatible (e.g., [1, 3, 5] - no doubles/halves)
     phasor_features = layer.metadata['phasor_features_labels_layer']
-    
+
     # Create new harmonics that don't have double/half relationships
     num_pixels = len(phasor_features.features['harmonic'])
     incompatible_harmonics = np.random.choice([1, 3, 5], size=num_pixels)
     phasor_features.features['harmonic'] = incompatible_harmonics
-    
+
     return layer
 
 
@@ -267,13 +270,15 @@ def test_wavelet_harmonics_validation_compatible(make_napari_viewer):
     """Test wavelet harmonics validation with compatible harmonics."""
     viewer = make_napari_viewer()
     intensity_image_layer = create_image_layer_with_phasors()
-    
+
     # Ensure compatible harmonics (e.g., [1, 2] where 2 = 1*2)
-    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer']
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ]
     num_pixels = len(phasor_features.features['harmonic'])
     compatible_harmonics = np.random.choice([1, 2], size=num_pixels)
     phasor_features.features['harmonic'] = compatible_harmonics
-    
+
     viewer.add_layer(intensity_image_layer)
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
@@ -313,13 +318,15 @@ def test_apply_button_with_wavelet_filter(make_napari_viewer):
     """Test apply button with wavelet filter method."""
     viewer = make_napari_viewer()
     intensity_image_layer = create_image_layer_with_phasors()
-    
+
     # Set up compatible harmonics
-    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer']
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ]
     num_pixels = len(phasor_features.features['harmonic'])
     compatible_harmonics = np.random.choice([1, 2], size=num_pixels)
     phasor_features.features['harmonic'] = compatible_harmonics
-    
+
     viewer.add_layer(intensity_image_layer)
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
@@ -331,7 +338,9 @@ def test_apply_button_with_wavelet_filter(make_napari_viewer):
     filter_widget.threshold_slider.setValue(10)
 
     with (
-        patch('napari_phasors.filter_tab.apply_filter_and_threshold') as mock_apply,
+        patch(
+            'napari_phasors.filter_tab.apply_filter_and_threshold'
+        ) as mock_apply,
         patch.object(parent, 'plot') as mock_plot,
     ):
         filter_widget.apply_button_clicked()
@@ -339,13 +348,13 @@ def test_apply_button_with_wavelet_filter(make_napari_viewer):
         # Check that apply_filter_and_threshold was called with wavelet parameters
         mock_apply.assert_called_once()
         call_args = mock_apply.call_args
-        
+
         assert call_args[0][0] == intensity_image_layer  # layer
         assert call_args[1]['filter_method'] == 'wavelet'
         assert call_args[1]['sigma'] == 1.5
         assert call_args[1]['levels'] == 2
         assert 'harmonics' in call_args[1]
-        
+
         mock_plot.assert_called_once()
 
 
@@ -364,7 +373,9 @@ def test_apply_button_with_median_filter(make_napari_viewer):
     filter_widget.threshold_slider.setValue(10)
 
     with (
-        patch('napari_phasors.filter_tab.apply_filter_and_threshold') as mock_apply,
+        patch(
+            'napari_phasors.filter_tab.apply_filter_and_threshold'
+        ) as mock_apply,
         patch.object(parent, 'plot') as mock_plot,
     ):
         filter_widget.apply_button_clicked()
@@ -372,7 +383,7 @@ def test_apply_button_with_median_filter(make_napari_viewer):
         # Check that apply_filter_and_threshold was called with median parameters
         mock_apply.assert_called_once()
         call_args = mock_apply.call_args
-        
+
         assert call_args[0][0] == intensity_image_layer  # layer
         assert call_args[1]['filter_method'] == 'median'
         assert call_args[1]['size'] == 5
@@ -395,7 +406,9 @@ def test_threshold_method_storage_in_metadata(make_napari_viewer):
 
     # Check that threshold method was stored
     assert "settings" in intensity_image_layer.metadata
-    assert intensity_image_layer.metadata["settings"]["threshold_method"] == "Li"
+    assert (
+        intensity_image_layer.metadata["settings"]["threshold_method"] == "Li"
+    )
 
 
 def test_calculate_automatic_threshold(make_napari_viewer):
@@ -408,9 +421,13 @@ def test_calculate_automatic_threshold(make_napari_viewer):
     test_data = np.random.rand(100, 100) * 100
 
     # Test each method
-    otsu_threshold = filter_widget.calculate_automatic_threshold("Otsu", test_data)
+    otsu_threshold = filter_widget.calculate_automatic_threshold(
+        "Otsu", test_data
+    )
     li_threshold = filter_widget.calculate_automatic_threshold("Li", test_data)
-    yen_threshold = filter_widget.calculate_automatic_threshold("Yen", test_data)
+    yen_threshold = filter_widget.calculate_automatic_threshold(
+        "Yen", test_data
+    )
 
     # All should return valid numbers
     assert isinstance(otsu_threshold, (int, float))
@@ -435,16 +452,18 @@ def test_settings_restoration_with_wavelet(make_napari_viewer):
     """Test that wavelet settings are properly restored from metadata."""
     viewer = make_napari_viewer()
     intensity_image_layer = create_image_layer_with_phasors()
-    
+
     # Set up compatible harmonics
-    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer']
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ]
     num_pixels = len(phasor_features.features['harmonic'])
     compatible_harmonics = np.random.choice([1, 2], size=num_pixels)
     phasor_features.features['harmonic'] = compatible_harmonics
 
     # Add wavelet settings to metadata
     intensity_image_layer.metadata["settings"] = {
-        "threshold": 0.3,
+        "threshold": 0.1,
         "threshold_method": "Li",
         "filter": {
             "method": "wavelet",
@@ -452,7 +471,7 @@ def test_settings_restoration_with_wavelet(make_napari_viewer):
             "levels": 4,
         },
     }
-    
+
     viewer.add_layer(intensity_image_layer)
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
@@ -477,7 +496,7 @@ def test_settings_restoration_with_incompatible_wavelet(make_napari_viewer):
             "levels": 4,
         },
     }
-    
+
     viewer.add_layer(intensity_image_layer)
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
@@ -543,12 +562,14 @@ def test_filter_widget_with_layer_data(make_napari_viewer):
 
     # Check that default threshold is now set using Otsu method (not 10% of max)
     mean_data = intensity_image_layer.metadata["original_mean"]
-    expected_otsu_threshold = filter_widget.calculate_automatic_threshold("Otsu", mean_data)
+    expected_otsu_threshold = filter_widget.calculate_automatic_threshold(
+        "Otsu", mean_data
+    )
     expected_default_threshold = int(
         expected_otsu_threshold * filter_widget.threshold_factor
     )
     assert filter_widget.threshold_slider.value() == expected_default_threshold
-    
+
     # Also check that the default threshold method is "Otsu"
     assert filter_widget.threshold_method_combobox.currentText() == "Otsu"
 
@@ -759,7 +780,7 @@ def test_filter_widget_layer_with_settings(make_napari_viewer):
 
     # Add metadata with settings
     intensity_image_layer.metadata["settings"] = {
-        "threshold": 0.3,
+        "threshold": 0.1,
         "threshold_method": "Li",
         "filter": {"method": "median", "size": 7, "repeat": 3},
     }
@@ -771,7 +792,7 @@ def test_filter_widget_layer_with_settings(make_napari_viewer):
     # Check that settings are loaded correctly
     assert (
         filter_widget.threshold_slider.value()
-        == 0.3 * filter_widget.threshold_factor
+        == 0.1 * filter_widget.threshold_factor
     )
     assert filter_widget.median_filter_spinbox.value() == 7
     assert filter_widget.median_filter_repetition_spinbox.value() == 3
@@ -831,7 +852,8 @@ def test_filter_widget_ui_layout(make_napari_viewer):
     # Check horizontal layouts exist (now more due to additional filter options)
     h_layouts = filter_widget.findChildren(QHBoxLayout)
     assert (
-        len(h_layouts) >= 5  # More layouts now due to filter method selection, threshold method, etc.
+        len(h_layouts)
+        >= 5  # More layouts now due to filter method selection, threshold method, etc.
     )
 
 

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from matplotlib.colors import ListedColormap
-from phasorpy.phasor import phasor_filter_median, phasor_threshold
+from phasorpy.phasor import phasor_filter_median, phasor_threshold, phasor_filter_pawflim
 
 from napari_phasors._synthetic_generator import (
     make_intensity_layer_with_phasors,
@@ -10,11 +10,57 @@ from napari_phasors._utils import (
     apply_filter_and_threshold,
     colormap_to_dict,
     update_frequency_in_metadata,
+    validate_harmonics_for_wavelet,
 )
 
 
-def test_apply_filter_and_threshold(make_napari_viewer):
-    """Test apply_filter_and_threshold function."""
+def test_validate_harmonics_for_wavelet():
+    """Test validate_harmonics_for_wavelet function."""
+    # Test compatible harmonics (each has double or half)
+    compatible_harmonics_1 = [1, 2]  # 2 = 1*2
+    assert validate_harmonics_for_wavelet(compatible_harmonics_1) == True
+    
+    compatible_harmonics_2 = [2, 4]  # 4 = 2*2
+    assert validate_harmonics_for_wavelet(compatible_harmonics_2) == True
+    
+    compatible_harmonics_3 = [1, 2, 4]  # 2 = 1*2, 4 = 2*2
+    assert validate_harmonics_for_wavelet(compatible_harmonics_3) == True
+    
+    compatible_harmonics_4 = [2, 1, 4]  # Same as above, different order
+    assert validate_harmonics_for_wavelet(compatible_harmonics_4) == True
+    
+    compatible_harmonics_5 = [0.5, 1, 2]  # 1 = 0.5*2, 2 = 1*2
+    assert validate_harmonics_for_wavelet(compatible_harmonics_5) == True
+    
+    # Test incompatible harmonics (some don't have double or half)
+    incompatible_harmonics_1 = [1, 3]  # 3 has no double/half relationship with 1
+    assert validate_harmonics_for_wavelet(incompatible_harmonics_1) == False
+    
+    incompatible_harmonics_2 = [1, 3, 5]  # None have double/half relationships
+    assert validate_harmonics_for_wavelet(incompatible_harmonics_2) == False
+    
+    incompatible_harmonics_3 = [1, 2, 5]  # 1,2 are compatible but 5 is not
+    assert validate_harmonics_for_wavelet(incompatible_harmonics_3) == False
+    
+    # Test single harmonic (incompatible by definition)
+    single_harmonic = [1]
+    assert validate_harmonics_for_wavelet(single_harmonic) == False
+    
+    # Test empty array
+    empty_harmonics = []
+    assert validate_harmonics_for_wavelet(empty_harmonics) == True  # Vacuously true
+    
+    # Test numpy array input
+    numpy_harmonics = np.array([1, 2, 4])
+    assert validate_harmonics_for_wavelet(numpy_harmonics) == True
+    
+    # Test with duplicates
+    harmonics_with_duplicates = [1, 1, 2, 2]
+    assert validate_harmonics_for_wavelet(harmonics_with_duplicates) == True
+
+
+def test_apply_filter_and_threshold_median(make_napari_viewer):
+    """Test apply_filter_and_threshold function with median filter."""
     raw_flim_data = make_raw_flim_data(shape=(5, 5))
     harmonic = [1, 2]
     intensity_image_layer = make_intensity_layer_with_phasors(
@@ -35,7 +81,16 @@ def test_apply_filter_and_threshold(make_napari_viewer):
     viewer = make_napari_viewer()
     viewer.add_layer(intensity_image_layer)
     threshold = 0.02
-    apply_filter_and_threshold(intensity_image_layer, threshold=threshold)
+    
+    # Test median filter
+    apply_filter_and_threshold(
+        intensity_image_layer, 
+        threshold=threshold,
+        filter_method="median",
+        size=3,
+        repeat=1
+    )
+    
     assert np.all(
         intensity_image_layer.metadata['original_mean'] == original_mean
     )
@@ -49,10 +104,10 @@ def test_apply_filter_and_threshold(make_napari_viewer):
     assert np.all(phasor_features['S_original'] == original_s)
     harmonics = np.unique(phasor_features['harmonic'])
     original_g = np.reshape(
-        original_g, (len(harmonics),) + original_mean.data.shape
+        original_g, (len(harmonics),) + original_mean.shape
     )
     original_s = np.reshape(
-        original_s, (len(harmonics),) + original_mean.data.shape
+        original_s, (len(harmonics),) + original_mean.shape
     )
     original_mean, original_g, original_s = phasor_filter_median(
         original_mean, original_g, original_s, repeat=1, size=3
@@ -61,13 +116,338 @@ def test_apply_filter_and_threshold(make_napari_viewer):
         original_mean, original_g, original_s, threshold
     )
     filtered_thresholded_g = np.reshape(
-        phasor_features['G'], (len(harmonics),) + original_mean.data.shape
+        phasor_features['G'], (len(harmonics),) + original_mean.shape
     )
     filtered_thresholded_s = np.reshape(
-        phasor_features['S'], (len(harmonics),) + original_mean.data.shape
+        phasor_features['S'], (len(harmonics),) + original_mean.shape
     )
     assert np.allclose(original_g, filtered_thresholded_g, equal_nan=True)
     assert np.allclose(original_s, filtered_thresholded_s, equal_nan=True)
+
+    # Check that settings are saved in metadata
+    assert "settings" in intensity_image_layer.metadata
+    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "median"
+    assert intensity_image_layer.metadata["settings"]["filter"]["size"] == 3
+    assert intensity_image_layer.metadata["settings"]["filter"]["repeat"] == 1
+    assert intensity_image_layer.metadata["settings"]["threshold"] == threshold
+
+
+def test_apply_filter_and_threshold_wavelet_compatible(make_napari_viewer):
+    """Test apply_filter_and_threshold function with compatible wavelet harmonics."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    harmonic = [1, 2]  # Compatible harmonics
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+    original_mean = intensity_image_layer.metadata['original_mean'].copy()
+    original_g = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['G_original'].copy()
+    original_s = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['S_original'].copy()
+
+    viewer = make_napari_viewer()
+    viewer.add_layer(intensity_image_layer)
+    
+    threshold = 0.02
+    sigma = 2.0
+    levels = 1
+    
+    # Test wavelet filter with compatible harmonics
+    apply_filter_and_threshold(
+        intensity_image_layer,
+        threshold=threshold,
+        filter_method="wavelet",
+        sigma=sigma,
+        levels=levels
+    )
+    
+    # Check that original data is preserved
+    assert np.all(
+        intensity_image_layer.metadata['original_mean'] == original_mean
+    )
+    
+    # Check that phasor features are updated (they should be different from original)
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features
+    assert np.all(phasor_features['G_original'] == original_g)
+    assert np.all(phasor_features['S_original'] == original_s)
+    
+    # The filtered G and S should be different from original (unless no filtering occurred)
+    # We can't easily predict the exact values, but we can check they exist and are valid
+    assert 'G' in phasor_features
+    assert 'S' in phasor_features
+    assert len(phasor_features['G']) == len(original_g)
+    assert len(phasor_features['S']) == len(original_s)
+    
+    # Check that settings are saved
+    assert "settings" in intensity_image_layer.metadata
+    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert intensity_image_layer.metadata["settings"]["filter"]["sigma"] == sigma
+    assert intensity_image_layer.metadata["settings"]["filter"]["levels"] == levels
+    assert intensity_image_layer.metadata["settings"]["threshold"] == threshold
+
+
+def test_apply_filter_and_threshold_wavelet_incompatible(make_napari_viewer):
+    """Test apply_filter_and_threshold function with incompatible wavelet harmonics."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    # Create layer with incompatible harmonics
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=[1, 3]  # Incompatible harmonics
+    )
+    original_mean = intensity_image_layer.metadata['original_mean'].copy()
+    original_g = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['G_original'].copy()
+    original_s = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['S_original'].copy()
+
+    viewer = make_napari_viewer()
+    viewer.add_layer(intensity_image_layer)
+    
+    threshold = 0.02
+    
+    # Test wavelet filter with incompatible harmonics - should only apply threshold
+    apply_filter_and_threshold(
+        intensity_image_layer,
+        threshold=threshold,
+        filter_method="wavelet",
+        sigma=2.0,
+        levels=1
+    )
+    
+    # Check that original data is preserved
+    assert np.all(
+        intensity_image_layer.metadata['original_mean'] == original_mean
+    )
+    
+    # Since harmonics are incompatible, no wavelet filtering should occur
+    # Only thresholding should be applied
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features
+    
+    # The G and S values should be thresholded versions of the original
+    # (without wavelet filtering)
+    harmonics = np.unique(phasor_features['harmonic'])
+    reshaped_g = np.reshape(original_g, (len(harmonics),) + original_mean.shape)
+    reshaped_s = np.reshape(original_s, (len(harmonics),) + original_mean.shape)
+    
+    # Apply only threshold (no filtering) for comparison
+    _, expected_g, expected_s = phasor_threshold(
+        original_mean, reshaped_g, reshaped_s, threshold
+    )
+    
+    actual_g = np.reshape(
+        phasor_features['G'], (len(harmonics),) + original_mean.shape
+    )
+    actual_s = np.reshape(
+        phasor_features['S'], (len(harmonics),) + original_mean.shape
+    )
+    
+    assert np.allclose(expected_g, actual_g, equal_nan=True)
+    assert np.allclose(expected_s, actual_s, equal_nan=True)
+
+def test_apply_filter_and_threshold_custom_harmonics_values():
+    """Test apply_filter_and_threshold with custom harmonics and validate results."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    harmonic = [1, 2]  # Layer harmonics
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+    
+    original_mean = intensity_image_layer.metadata['original_mean'].copy()
+    original_g = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['G_original'].copy()
+    original_s = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['S_original'].copy()
+    
+    # Test with custom harmonics that match the layer's harmonics
+    custom_harmonics = np.array([1, 2])
+    threshold = 0.01
+    sigma = 1.5
+    levels = 2
+    
+    apply_filter_and_threshold(
+        intensity_image_layer,
+        threshold=threshold,
+        filter_method="wavelet",
+        sigma=sigma,
+        levels=levels,
+        harmonics=custom_harmonics
+    )
+    
+    # Calculate expected results
+    expected_g = np.reshape(original_g, (len(custom_harmonics),) + original_mean.shape)
+    expected_s = np.reshape(original_s, (len(custom_harmonics),) + original_mean.shape)
+    
+    expected_mean, expected_g, expected_s = phasor_filter_pawflim(
+        original_mean,
+        expected_g,
+        expected_s,
+        sigma=sigma,
+        levels=levels,
+        harmonic=custom_harmonics,
+    )
+    # Apply threshold to get the final expected values (including mean modifications)
+    expected_mean, expected_g, expected_s = phasor_threshold(
+        expected_mean, expected_g, expected_s, threshold
+    )
+    
+    # Compare results
+    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer'].features
+    actual_g = np.reshape(
+        phasor_features['G'], (len(custom_harmonics),) + original_mean.shape
+    )
+    actual_s = np.reshape(
+        phasor_features['S'], (len(custom_harmonics),) + original_mean.shape
+    )
+    
+    assert np.allclose(expected_g, actual_g, equal_nan=True)
+    assert np.allclose(expected_s, actual_s, equal_nan=True)
+    assert np.allclose(expected_mean, intensity_image_layer.data, equal_nan=True)
+    
+    # Check metadata
+    assert "settings" in intensity_image_layer.metadata
+    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+
+
+def test_apply_filter_and_threshold_no_filter():
+    """Test apply_filter_and_threshold with no filtering (repeat=0 for median)."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    harmonic = [1, 2]
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+    original_mean = intensity_image_layer.metadata['original_mean'].copy()
+    original_g = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['G_original'].copy()
+    original_s = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['S_original'].copy()
+    
+    threshold = 0.02
+    
+    # Test median filter with repeat=0 (no filtering)
+    apply_filter_and_threshold(
+        intensity_image_layer,
+        threshold=threshold,
+        filter_method="median",
+        size=3,
+        repeat=0  # No filtering
+    )
+    
+    # Only thresholding should be applied
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features
+    
+    harmonics = np.unique(phasor_features['harmonic'])
+    reshaped_g = np.reshape(original_g, (len(harmonics),) + original_mean.shape)
+    reshaped_s = np.reshape(original_s, (len(harmonics),) + original_mean.shape)
+    
+    # Apply only threshold for comparison
+    _, expected_g, expected_s = phasor_threshold(
+        original_mean, reshaped_g, reshaped_s, threshold
+    )
+    
+    actual_g = np.reshape(
+        phasor_features['G'], (len(harmonics),) + original_mean.shape
+    )
+    actual_s = np.reshape(
+        phasor_features['S'], (len(harmonics),) + original_mean.shape
+    )
+    
+    assert np.allclose(expected_g, actual_g, equal_nan=True)
+    assert np.allclose(expected_s, actual_s, equal_nan=True)
+
+
+def test_apply_filter_and_threshold_custom_harmonics():
+    """Test apply_filter_and_threshold with custom harmonics parameter."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    harmonic = [1, 2]  # Use only the harmonics we'll pass as custom
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+    
+    # Test with custom harmonics that match the layer's harmonics
+    custom_harmonics = np.array([1, 2])
+    
+    apply_filter_and_threshold(
+        intensity_image_layer,
+        threshold=0.01,
+        filter_method="wavelet",
+        sigma=1.0,
+        levels=1,
+        harmonics=custom_harmonics
+    )
+    
+    # Should work without error
+    assert "settings" in intensity_image_layer.metadata
+    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    
+    
+def test_apply_filter_and_threshold_custom_harmonics_subset():
+    """Test apply_filter_and_threshold with custom harmonics that are a subset."""
+    raw_flim_data = make_raw_flim_data(shape=(5, 5))
+    harmonic = [1, 2]  # Layer has these harmonics
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+    
+    # Get original features
+    original_g = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['G_original'].copy()
+    original_s = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['S_original'].copy()
+    
+    # Manually create a subset of G and S for custom harmonics
+    # This simulates what should happen when using a subset of harmonics
+    layer_harmonics = np.unique(intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features['harmonic'])
+    
+    # Create new features with only harmonic [1] 
+    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer']
+    mask = phasor_features.features['harmonic'] == 1
+    
+    # Create new G_original and S_original with only harmonic 1
+    new_g_original = original_g[mask]
+    new_s_original = original_s[mask]
+    new_harmonics = phasor_features.features['harmonic'][mask]
+    
+    # Update the layer's features to have only harmonic 1
+    phasor_features.features = {
+        'G_original': new_g_original,
+        'S_original': new_s_original,
+        'G': new_g_original.copy(),
+        'S': new_s_original.copy(),
+        'harmonic': new_harmonics
+    }
+    
+    # Now test with custom harmonics
+    custom_harmonics = np.array([1])
+    
+    apply_filter_and_threshold(
+        intensity_image_layer,
+        threshold=0.01,
+        filter_method="wavelet",
+        sigma=1.0,
+        levels=1,
+        harmonics=custom_harmonics
+    )
+    
+    # Should work without error since harmonics match the modified features
+    assert "settings" in intensity_image_layer.metadata
+    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
 
 
 def test_colormap_to_dict():

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -1,6 +1,10 @@
 import numpy as np
 from matplotlib.colors import ListedColormap
-from phasorpy.phasor import phasor_filter_median, phasor_threshold, phasor_filter_pawflim
+from phasorpy.phasor import (
+    phasor_filter_median,
+    phasor_filter_pawflim,
+    phasor_threshold,
+)
 
 from napari_phasors._synthetic_generator import (
     make_intensity_layer_with_phasors,
@@ -19,41 +23,46 @@ def test_validate_harmonics_for_wavelet():
     # Test compatible harmonics (each has double or half)
     compatible_harmonics_1 = [1, 2]  # 2 = 1*2
     assert validate_harmonics_for_wavelet(compatible_harmonics_1) == True
-    
+
     compatible_harmonics_2 = [2, 4]  # 4 = 2*2
     assert validate_harmonics_for_wavelet(compatible_harmonics_2) == True
-    
+
     compatible_harmonics_3 = [1, 2, 4]  # 2 = 1*2, 4 = 2*2
     assert validate_harmonics_for_wavelet(compatible_harmonics_3) == True
-    
+
     compatible_harmonics_4 = [2, 1, 4]  # Same as above, different order
     assert validate_harmonics_for_wavelet(compatible_harmonics_4) == True
-    
+
     compatible_harmonics_5 = [0.5, 1, 2]  # 1 = 0.5*2, 2 = 1*2
     assert validate_harmonics_for_wavelet(compatible_harmonics_5) == True
-    
+
     # Test incompatible harmonics (some don't have double or half)
-    incompatible_harmonics_1 = [1, 3]  # 3 has no double/half relationship with 1
+    incompatible_harmonics_1 = [
+        1,
+        3,
+    ]  # 3 has no double/half relationship with 1
     assert validate_harmonics_for_wavelet(incompatible_harmonics_1) == False
-    
+
     incompatible_harmonics_2 = [1, 3, 5]  # None have double/half relationships
     assert validate_harmonics_for_wavelet(incompatible_harmonics_2) == False
-    
+
     incompatible_harmonics_3 = [1, 2, 5]  # 1,2 are compatible but 5 is not
     assert validate_harmonics_for_wavelet(incompatible_harmonics_3) == False
-    
+
     # Test single harmonic (incompatible by definition)
     single_harmonic = [1]
     assert validate_harmonics_for_wavelet(single_harmonic) == False
-    
+
     # Test empty array
     empty_harmonics = []
-    assert validate_harmonics_for_wavelet(empty_harmonics) == True  # Vacuously true
-    
+    assert (
+        validate_harmonics_for_wavelet(empty_harmonics) == True
+    )  # Vacuously true
+
     # Test numpy array input
     numpy_harmonics = np.array([1, 2, 4])
     assert validate_harmonics_for_wavelet(numpy_harmonics) == True
-    
+
     # Test with duplicates
     harmonics_with_duplicates = [1, 1, 2, 2]
     assert validate_harmonics_for_wavelet(harmonics_with_duplicates) == True
@@ -81,16 +90,16 @@ def test_apply_filter_and_threshold_median(make_napari_viewer):
     viewer = make_napari_viewer()
     viewer.add_layer(intensity_image_layer)
     threshold = 0.02
-    
+
     # Test median filter
     apply_filter_and_threshold(
-        intensity_image_layer, 
+        intensity_image_layer,
         threshold=threshold,
         filter_method="median",
         size=3,
-        repeat=1
+        repeat=1,
     )
-    
+
     assert np.all(
         intensity_image_layer.metadata['original_mean'] == original_mean
     )
@@ -126,7 +135,10 @@ def test_apply_filter_and_threshold_median(make_napari_viewer):
 
     # Check that settings are saved in metadata
     assert "settings" in intensity_image_layer.metadata
-    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "median"
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["method"]
+        == "median"
+    )
     assert intensity_image_layer.metadata["settings"]["filter"]["size"] == 3
     assert intensity_image_layer.metadata["settings"]["filter"]["repeat"] == 1
     assert intensity_image_layer.metadata["settings"]["threshold"] == threshold
@@ -140,53 +152,65 @@ def test_apply_filter_and_threshold_wavelet_compatible(make_napari_viewer):
         raw_flim_data, harmonic=harmonic
     )
     original_mean = intensity_image_layer.metadata['original_mean'].copy()
-    original_g = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['G_original'].copy()
-    original_s = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['S_original'].copy()
+    original_g = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['G_original']
+        .copy()
+    )
+    original_s = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['S_original']
+        .copy()
+    )
 
     viewer = make_napari_viewer()
     viewer.add_layer(intensity_image_layer)
-    
+
     threshold = 0.02
     sigma = 2.0
     levels = 1
-    
+
     # Test wavelet filter with compatible harmonics
     apply_filter_and_threshold(
         intensity_image_layer,
         threshold=threshold,
         filter_method="wavelet",
         sigma=sigma,
-        levels=levels
+        levels=levels,
     )
-    
+
     # Check that original data is preserved
     assert np.all(
         intensity_image_layer.metadata['original_mean'] == original_mean
     )
-    
+
     # Check that phasor features are updated (they should be different from original)
     phasor_features = intensity_image_layer.metadata[
         'phasor_features_labels_layer'
     ].features
     assert np.all(phasor_features['G_original'] == original_g)
     assert np.all(phasor_features['S_original'] == original_s)
-    
+
     # The filtered G and S should be different from original (unless no filtering occurred)
     # We can't easily predict the exact values, but we can check they exist and are valid
     assert 'G' in phasor_features
     assert 'S' in phasor_features
     assert len(phasor_features['G']) == len(original_g)
     assert len(phasor_features['S']) == len(original_s)
-    
+
     # Check that settings are saved
     assert "settings" in intensity_image_layer.metadata
-    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
-    assert intensity_image_layer.metadata["settings"]["filter"]["sigma"] == sigma
-    assert intensity_image_layer.metadata["settings"]["filter"]["levels"] == levels
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["method"]
+        == "wavelet"
+    )
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["sigma"] == sigma
+    )
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["levels"]
+        == levels
+    )
     assert intensity_image_layer.metadata["settings"]["threshold"] == threshold
 
 
@@ -198,58 +222,67 @@ def test_apply_filter_and_threshold_wavelet_incompatible(make_napari_viewer):
         raw_flim_data, harmonic=[1, 3]  # Incompatible harmonics
     )
     original_mean = intensity_image_layer.metadata['original_mean'].copy()
-    original_g = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['G_original'].copy()
-    original_s = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['S_original'].copy()
+    original_g = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['G_original']
+        .copy()
+    )
+    original_s = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['S_original']
+        .copy()
+    )
 
     viewer = make_napari_viewer()
     viewer.add_layer(intensity_image_layer)
-    
+
     threshold = 0.02
-    
+
     # Test wavelet filter with incompatible harmonics - should only apply threshold
     apply_filter_and_threshold(
         intensity_image_layer,
         threshold=threshold,
         filter_method="wavelet",
         sigma=2.0,
-        levels=1
+        levels=1,
     )
-    
+
     # Check that original data is preserved
     assert np.all(
         intensity_image_layer.metadata['original_mean'] == original_mean
     )
-    
+
     # Since harmonics are incompatible, no wavelet filtering should occur
     # Only thresholding should be applied
     phasor_features = intensity_image_layer.metadata[
         'phasor_features_labels_layer'
     ].features
-    
+
     # The G and S values should be thresholded versions of the original
     # (without wavelet filtering)
     harmonics = np.unique(phasor_features['harmonic'])
-    reshaped_g = np.reshape(original_g, (len(harmonics),) + original_mean.shape)
-    reshaped_s = np.reshape(original_s, (len(harmonics),) + original_mean.shape)
-    
+    reshaped_g = np.reshape(
+        original_g, (len(harmonics),) + original_mean.shape
+    )
+    reshaped_s = np.reshape(
+        original_s, (len(harmonics),) + original_mean.shape
+    )
+
     # Apply only threshold (no filtering) for comparison
     _, expected_g, expected_s = phasor_threshold(
         original_mean, reshaped_g, reshaped_s, threshold
     )
-    
+
     actual_g = np.reshape(
         phasor_features['G'], (len(harmonics),) + original_mean.shape
     )
     actual_s = np.reshape(
         phasor_features['S'], (len(harmonics),) + original_mean.shape
     )
-    
+
     assert np.allclose(expected_g, actual_g, equal_nan=True)
     assert np.allclose(expected_s, actual_s, equal_nan=True)
+
 
 def test_apply_filter_and_threshold_custom_harmonics_values():
     """Test apply_filter_and_threshold with custom harmonics and validate results."""
@@ -258,34 +291,42 @@ def test_apply_filter_and_threshold_custom_harmonics_values():
     intensity_image_layer = make_intensity_layer_with_phasors(
         raw_flim_data, harmonic=harmonic
     )
-    
+
     original_mean = intensity_image_layer.metadata['original_mean'].copy()
-    original_g = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['G_original'].copy()
-    original_s = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['S_original'].copy()
-    
+    original_g = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['G_original']
+        .copy()
+    )
+    original_s = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['S_original']
+        .copy()
+    )
+
     # Test with custom harmonics that match the layer's harmonics
     custom_harmonics = np.array([1, 2])
     threshold = 0.01
     sigma = 1.5
     levels = 2
-    
+
     apply_filter_and_threshold(
         intensity_image_layer,
         threshold=threshold,
         filter_method="wavelet",
         sigma=sigma,
         levels=levels,
-        harmonics=custom_harmonics
+        harmonics=custom_harmonics,
     )
-    
+
     # Calculate expected results
-    expected_g = np.reshape(original_g, (len(custom_harmonics),) + original_mean.shape)
-    expected_s = np.reshape(original_s, (len(custom_harmonics),) + original_mean.shape)
-    
+    expected_g = np.reshape(
+        original_g, (len(custom_harmonics),) + original_mean.shape
+    )
+    expected_s = np.reshape(
+        original_s, (len(custom_harmonics),) + original_mean.shape
+    )
+
     expected_mean, expected_g, expected_s = phasor_filter_pawflim(
         original_mean,
         expected_g,
@@ -298,23 +339,30 @@ def test_apply_filter_and_threshold_custom_harmonics_values():
     expected_mean, expected_g, expected_s = phasor_threshold(
         expected_mean, expected_g, expected_s, threshold
     )
-    
+
     # Compare results
-    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer'].features
+    phasor_features = intensity_image_layer.metadata[
+        'phasor_features_labels_layer'
+    ].features
     actual_g = np.reshape(
         phasor_features['G'], (len(custom_harmonics),) + original_mean.shape
     )
     actual_s = np.reshape(
         phasor_features['S'], (len(custom_harmonics),) + original_mean.shape
     )
-    
+
     assert np.allclose(expected_g, actual_g, equal_nan=True)
     assert np.allclose(expected_s, actual_s, equal_nan=True)
-    assert np.allclose(expected_mean, intensity_image_layer.data, equal_nan=True)
-    
+    assert np.allclose(
+        expected_mean, intensity_image_layer.data, equal_nan=True
+    )
+
     # Check metadata
     assert "settings" in intensity_image_layer.metadata
-    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["method"]
+        == "wavelet"
+    )
 
 
 def test_apply_filter_and_threshold_no_filter():
@@ -325,45 +373,53 @@ def test_apply_filter_and_threshold_no_filter():
         raw_flim_data, harmonic=harmonic
     )
     original_mean = intensity_image_layer.metadata['original_mean'].copy()
-    original_g = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['G_original'].copy()
-    original_s = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['S_original'].copy()
-    
+    original_g = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['G_original']
+        .copy()
+    )
+    original_s = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['S_original']
+        .copy()
+    )
+
     threshold = 0.02
-    
+
     # Test median filter with repeat=0 (no filtering)
     apply_filter_and_threshold(
         intensity_image_layer,
         threshold=threshold,
         filter_method="median",
         size=3,
-        repeat=0  # No filtering
+        repeat=0,  # No filtering
     )
-    
+
     # Only thresholding should be applied
     phasor_features = intensity_image_layer.metadata[
         'phasor_features_labels_layer'
     ].features
-    
+
     harmonics = np.unique(phasor_features['harmonic'])
-    reshaped_g = np.reshape(original_g, (len(harmonics),) + original_mean.shape)
-    reshaped_s = np.reshape(original_s, (len(harmonics),) + original_mean.shape)
-    
+    reshaped_g = np.reshape(
+        original_g, (len(harmonics),) + original_mean.shape
+    )
+    reshaped_s = np.reshape(
+        original_s, (len(harmonics),) + original_mean.shape
+    )
+
     # Apply only threshold for comparison
     _, expected_g, expected_s = phasor_threshold(
         original_mean, reshaped_g, reshaped_s, threshold
     )
-    
+
     actual_g = np.reshape(
         phasor_features['G'], (len(harmonics),) + original_mean.shape
     )
     actual_s = np.reshape(
         phasor_features['S'], (len(harmonics),) + original_mean.shape
     )
-    
+
     assert np.allclose(expected_g, actual_g, equal_nan=True)
     assert np.allclose(expected_s, actual_s, equal_nan=True)
 
@@ -375,24 +431,27 @@ def test_apply_filter_and_threshold_custom_harmonics():
     intensity_image_layer = make_intensity_layer_with_phasors(
         raw_flim_data, harmonic=harmonic
     )
-    
+
     # Test with custom harmonics that match the layer's harmonics
     custom_harmonics = np.array([1, 2])
-    
+
     apply_filter_and_threshold(
         intensity_image_layer,
         threshold=0.01,
         filter_method="wavelet",
         sigma=1.0,
         levels=1,
-        harmonics=custom_harmonics
+        harmonics=custom_harmonics,
     )
-    
+
     # Should work without error
     assert "settings" in intensity_image_layer.metadata
-    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
-    
-    
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["method"]
+        == "wavelet"
+    )
+
+
 def test_apply_filter_and_threshold_custom_harmonics_subset():
     """Test apply_filter_and_threshold with custom harmonics that are a subset."""
     raw_flim_data = make_raw_flim_data(shape=(5, 5))
@@ -400,54 +459,65 @@ def test_apply_filter_and_threshold_custom_harmonics_subset():
     intensity_image_layer = make_intensity_layer_with_phasors(
         raw_flim_data, harmonic=harmonic
     )
-    
+
     # Get original features
-    original_g = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['G_original'].copy()
-    original_s = intensity_image_layer.metadata[
-        'phasor_features_labels_layer'
-    ].features['S_original'].copy()
-    
+    original_g = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['G_original']
+        .copy()
+    )
+    original_s = (
+        intensity_image_layer.metadata['phasor_features_labels_layer']
+        .features['S_original']
+        .copy()
+    )
+
     # Manually create a subset of G and S for custom harmonics
     # This simulates what should happen when using a subset of harmonics
-    layer_harmonics = np.unique(intensity_image_layer.metadata[
+    layer_harmonics = np.unique(
+        intensity_image_layer.metadata[
+            'phasor_features_labels_layer'
+        ].features['harmonic']
+    )
+
+    # Create new features with only harmonic [1]
+    phasor_features = intensity_image_layer.metadata[
         'phasor_features_labels_layer'
-    ].features['harmonic'])
-    
-    # Create new features with only harmonic [1] 
-    phasor_features = intensity_image_layer.metadata['phasor_features_labels_layer']
+    ]
     mask = phasor_features.features['harmonic'] == 1
-    
+
     # Create new G_original and S_original with only harmonic 1
     new_g_original = original_g[mask]
     new_s_original = original_s[mask]
     new_harmonics = phasor_features.features['harmonic'][mask]
-    
+
     # Update the layer's features to have only harmonic 1
     phasor_features.features = {
         'G_original': new_g_original,
         'S_original': new_s_original,
         'G': new_g_original.copy(),
         'S': new_s_original.copy(),
-        'harmonic': new_harmonics
+        'harmonic': new_harmonics,
     }
-    
+
     # Now test with custom harmonics
     custom_harmonics = np.array([1])
-    
+
     apply_filter_and_threshold(
         intensity_image_layer,
         threshold=0.01,
         filter_method="wavelet",
         sigma=1.0,
         levels=1,
-        harmonics=custom_harmonics
+        harmonics=custom_harmonics,
     )
-    
+
     # Should work without error since harmonics match the modified features
     assert "settings" in intensity_image_layer.metadata
-    assert intensity_image_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert (
+        intensity_image_layer.metadata["settings"]["filter"]["method"]
+        == "wavelet"
+    )
 
 
 def test_colormap_to_dict():

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from napari.layers import Image
-from phasorpy.phasor import phasor_filter_median, phasor_threshold, phasor_filter_pawflim
+from phasorpy.phasor import (
+    phasor_filter_median,
+    phasor_filter_pawflim,
+    phasor_threshold,
+)
 
 if TYPE_CHECKING:
     import napari
@@ -16,27 +20,27 @@ if TYPE_CHECKING:
 
 def validate_harmonics_for_wavelet(harmonics):
     """Validate that harmonics have their double or half correspondent.
-    
+
     Parameters
     ----------
     harmonics : array-like
         Array of harmonic values
-        
+
     Returns
     -------
     bool
         True if harmonics are valid for wavelet filtering, False otherwise
     """
     harmonics = np.array(harmonics)
-    
+
     for harmonic in harmonics:
         # Check if double or half exists
         has_double = (harmonic * 2) in harmonics
         has_half = (harmonic / 2) in harmonics
-        
+
         if not (has_double or has_half):
             return False
-    
+
     return True
 
 
@@ -76,17 +80,17 @@ def apply_filter_and_threshold(
     """
     mean = layer.metadata['original_mean'].copy()
     phasor_features = layer.metadata['phasor_features_labels_layer'].features
-    
+
     if harmonics is None:
         harmonics = np.unique(phasor_features['harmonic'])
-    
+
     real, imag = (
         phasor_features['G_original'].copy(),
         phasor_features['S_original'].copy(),
     )
     real = np.reshape(real, (len(harmonics),) + mean.shape)
     imag = np.reshape(imag, (len(harmonics),) + mean.shape)
-    
+
     if filter_method == "median" and repeat > 0:
         mean, real, imag = phasor_filter_median(
             mean,
@@ -95,7 +99,9 @@ def apply_filter_and_threshold(
             repeat=repeat,
             size=size,
         )
-    elif filter_method == "wavelet" and validate_harmonics_for_wavelet(harmonics):
+    elif filter_method == "wavelet" and validate_harmonics_for_wavelet(
+        harmonics
+    ):
         mean, real, imag = phasor_filter_pawflim(
             mean,
             real,
@@ -104,7 +110,7 @@ def apply_filter_and_threshold(
             levels=levels,
             harmonic=harmonics,
         )
-    
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
         mean, real, imag = phasor_threshold(mean, real, imag, threshold)

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -8,11 +8,36 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from napari.layers import Image
-from phasorpy.phasor import phasor_filter_median, phasor_threshold
-from qtpy.QtWidgets import QWidget
+from phasorpy.phasor import phasor_filter_median, phasor_threshold, phasor_filter_pawflim
 
 if TYPE_CHECKING:
     import napari
+
+
+def validate_harmonics_for_wavelet(harmonics):
+    """Validate that harmonics have their double or half correspondent.
+    
+    Parameters
+    ----------
+    harmonics : array-like
+        Array of harmonic values
+        
+    Returns
+    -------
+    bool
+        True if harmonics are valid for wavelet filtering, False otherwise
+    """
+    harmonics = np.array(harmonics)
+    
+    for harmonic in harmonics:
+        # Check if double or half exists
+        has_double = (harmonic * 2) in harmonics
+        has_half = (harmonic / 2) in harmonics
+        
+        if not (has_double or has_half):
+            return False
+    
+    return True
 
 
 def apply_filter_and_threshold(
@@ -20,8 +45,12 @@ def apply_filter_and_threshold(
     /,
     *,
     threshold: float = 0,
+    filter_method: str = "median",
     size: int = 3,
     repeat: int = 1,
+    sigma: float = 1.0,
+    levels: int = 3,
+    harmonics: np.ndarray = None,
 ):
     """Apply filter to an image layer.
 
@@ -31,24 +60,34 @@ def apply_filter_and_threshold(
         Napari image layer with phasor features.
     threshold : float
         Threshold value for the mean value to be applied to G and S.
-    method : str
-        Filter method. Options are 'median'.
+    filter_method : str
+        Filter method. Options are 'median' or 'wavelet'.
     size : int
-        Size of the filter.
+        Size of the median filter.
     repeat : int
-        Number of times to apply the filter.
+        Number of times to apply the median filter.
+    sigma : float
+        Sigma parameter for wavelet filter.
+    levels : int
+        Number of levels for wavelet filter.
+    harmonics : np.ndarray, optional
+        Harmonic values for wavelet filter. If None, will be extracted from layer.
 
     """
     mean = layer.metadata['original_mean'].copy()
     phasor_features = layer.metadata['phasor_features_labels_layer'].features
-    harmonics = np.unique(phasor_features['harmonic'])
+    
+    if harmonics is None:
+        harmonics = np.unique(phasor_features['harmonic'])
+    
     real, imag = (
         phasor_features['G_original'].copy(),
         phasor_features['S_original'].copy(),
     )
     real = np.reshape(real, (len(harmonics),) + mean.shape)
     imag = np.reshape(imag, (len(harmonics),) + mean.shape)
-    if repeat > 0:
+    
+    if filter_method == "median" and repeat > 0:
         mean, real, imag = phasor_filter_median(
             mean,
             real,
@@ -56,6 +95,16 @@ def apply_filter_and_threshold(
             repeat=repeat,
             size=size,
         )
+    elif filter_method == "wavelet" and validate_harmonics_for_wavelet(harmonics):
+        mean, real, imag = phasor_filter_pawflim(
+            mean,
+            real,
+            imag,
+            sigma=sigma,
+            levels=levels,
+            harmonic=harmonics,
+        )
+    
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
         mean, real, imag = phasor_threshold(mean, real, imag, threshold)
@@ -68,8 +117,11 @@ def apply_filter_and_threshold(
     if "settings" not in layer.metadata:
         layer.metadata["settings"] = {}
     layer.metadata["settings"]["filter"] = {
+        "method": filter_method,
         "size": size,
         "repeat": repeat,
+        "sigma": sigma,
+        "levels": levels,
     }
     layer.metadata["settings"]["threshold"] = threshold
     layer.refresh()

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -8,6 +8,7 @@ from matplotlib.backends.backend_qt5agg import (
 from napari.utils.notifications import show_error
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QDoubleSpinBox,
     QHBoxLayout,
@@ -126,6 +127,13 @@ class FilterWidget(QWidget):
         self.threshold_method_combobox.setCurrentText("Otsu")
         threshold_method_layout.addWidget(self.threshold_method_combobox)
         scroll_layout.addLayout(threshold_method_layout)
+
+        # Add log scale checkbox to the same line
+        self.log_scale_checkbox = QCheckBox("Log scale")
+        self.log_scale_checkbox.setChecked(False)
+        self.log_scale_checkbox.stateChanged.connect(self.on_log_scale_changed)
+        threshold_method_layout.addWidget(self.log_scale_checkbox)
+        threshold_method_layout.addStretch()
 
         # Threshold slider and label
         theshold_slider_layout = QHBoxLayout()
@@ -552,6 +560,18 @@ class FilterWidget(QWidget):
             linewidth=2,
             label='Threshold',
         )
+
+        self.hist_fig.canvas.draw_idle()
+
+    def on_log_scale_changed(self, state):
+        """Callback when log scale checkbox is toggled."""
+        if self.parent_widget._labels_layer_with_phasor_features is None:
+            return
+
+        if state == 2:
+            self.hist_ax.set_yscale('log')
+        else:
+            self.hist_ax.set_yscale('linear')
 
         self.hist_fig.canvas.draw_idle()
 

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -8,6 +8,8 @@ from matplotlib.backends.backend_qt5agg import (
 from napari.utils.notifications import show_error
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
     QHBoxLayout,
     QLabel,
     QPushButton,
@@ -17,8 +19,9 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from skimage.filters import threshold_otsu, threshold_li, threshold_yen
 
-from ._utils import apply_filter_and_threshold
+from ._utils import apply_filter_and_threshold, validate_harmonics_for_wavelet
 
 
 class FilterWidget(QWidget):
@@ -26,7 +29,8 @@ class FilterWidget(QWidget):
 
     Provides controls for:
       - Median filtering (kernel size and repetitions)
-      - Intensity thresholding via a slider
+      - Wavelet filtering (sigma and levels)
+      - Automatic and manual intensity thresholding
       - Visualization of the mean intensity histogram with a dynamic line
       - Applying filter and threshold operations to the selected image layer
 
@@ -59,6 +63,7 @@ class FilterWidget(QWidget):
             figsize=(8, 4), constrained_layout=True
         )
         self.threshold_line = None
+        self._updating_threshold = False  # Flag to prevent recursive updates
 
         # Style the histogram axes and figure initially
         self.style_histogram_axes()
@@ -73,8 +78,14 @@ class FilterWidget(QWidget):
         self.threshold_slider.valueChanged.connect(
             self.on_threshold_slider_change
         )
+        self.threshold_method_combobox.currentTextChanged.connect(
+            self.on_threshold_method_changed
+        )
+        self.filter_method_combobox.currentTextChanged.connect(
+            self.on_filter_method_changed
+        )
         self.median_filter_spinbox.valueChanged.connect(
-            self.on_kernel_size_change
+            self.on_median_kernel_size_change
         )
         self.apply_button.clicked.connect(self.apply_button_clicked)
 
@@ -86,25 +97,35 @@ class FilterWidget(QWidget):
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
 
-        # Median filter kernel size
-        median_filter_layout = QHBoxLayout()
-        self.label_4 = QLabel("Median Filter Kernel Size: 3 x 3")
-        self.median_filter_spinbox = QSpinBox()
-        self.median_filter_spinbox.setMinimum(2)
-        self.median_filter_spinbox.setMaximum(99)
-        self.median_filter_spinbox.setValue(3)
-        median_filter_layout.addWidget(self.label_4)
-        median_filter_layout.addWidget(self.median_filter_spinbox)
-        scroll_layout.addLayout(median_filter_layout)
+        # Filter method selection
+        filter_method_layout = QHBoxLayout()
+        filter_method_layout.addWidget(QLabel("Filter Method:"))
+        self.filter_method_combobox = QComboBox()
+        self.filter_method_combobox.addItems(["Median", "Wavelet"])
+        filter_method_layout.addWidget(self.filter_method_combobox)
+        scroll_layout.addLayout(filter_method_layout)
 
-        # Median filter repetitions
-        repetitions_layout = QHBoxLayout()
-        repetitions_layout.addWidget(QLabel("Filter Repetitions:"))
-        self.median_filter_repetition_spinbox = QSpinBox()
-        self.median_filter_repetition_spinbox.setMinimum(0)
-        self.median_filter_repetition_spinbox.setValue(0)
-        repetitions_layout.addWidget(self.median_filter_repetition_spinbox)
-        scroll_layout.addLayout(repetitions_layout)
+        # Create containers for filter-specific parameters
+        self.median_filter_widget = QWidget()
+        self.setup_median_filter_ui()
+        scroll_layout.addWidget(self.median_filter_widget)
+
+        self.wavelet_filter_widget = QWidget()
+        self.setup_wavelet_filter_ui()
+        scroll_layout.addWidget(self.wavelet_filter_widget)
+
+        # Threshold method selection
+        threshold_method_layout = QHBoxLayout()
+        threshold_method_layout.addWidget(QLabel("Threshold Method:"))
+        self.threshold_method_combobox = QComboBox()
+        self.threshold_method_combobox = QComboBox()
+        self.threshold_method_combobox.addItems([
+            "None", "Manual", "Otsu", "Li", "Yen"
+        ])
+        # Set Otsu as default
+        self.threshold_method_combobox.setCurrentText("Otsu")
+        threshold_method_layout.addWidget(self.threshold_method_combobox)
+        scroll_layout.addLayout(threshold_method_layout)
 
         # Threshold slider and label
         theshold_slider_layout = QHBoxLayout()
@@ -137,6 +158,187 @@ class FilterWidget(QWidget):
 
         self.setLayout(layout)
 
+        # Initialize UI state
+        self.on_filter_method_changed()
+
+    def setup_median_filter_ui(self):
+        """Setup UI elements for median filter."""
+        layout = QVBoxLayout(self.median_filter_widget)
+
+        # Median filter kernel size
+        median_filter_layout = QHBoxLayout()
+        self.median_filter_label = QLabel("Median Filter Kernel Size: 3 x 3")
+        self.median_filter_spinbox = QSpinBox()
+        self.median_filter_spinbox.setMinimum(2)
+        self.median_filter_spinbox.setMaximum(99)
+        self.median_filter_spinbox.setValue(3)
+        median_filter_layout.addWidget(self.median_filter_label)
+        median_filter_layout.addWidget(self.median_filter_spinbox)
+        layout.addLayout(median_filter_layout)
+
+        # Median filter repetitions
+        repetitions_layout = QHBoxLayout()
+        repetitions_layout.addWidget(QLabel("Filter Repetitions:"))
+        self.median_filter_repetition_spinbox = QSpinBox()
+        self.median_filter_repetition_spinbox.setMinimum(0)
+        self.median_filter_repetition_spinbox.setValue(0)
+        repetitions_layout.addWidget(self.median_filter_repetition_spinbox)
+        layout.addLayout(repetitions_layout)
+
+    def setup_wavelet_filter_ui(self):
+        """Setup UI elements for wavelet filter."""
+        layout = QVBoxLayout(self.wavelet_filter_widget)
+
+        # Warning label for incompatible harmonics
+        self.harmonic_warning_label = QLabel()
+        self.harmonic_warning_label.setStyleSheet("color: orange; font-style: italic;")
+        self.harmonic_warning_label.setVisible(False)
+        layout.addWidget(self.harmonic_warning_label)
+
+        # Container for wavelet parameters (can be hidden when invalid)
+        self.wavelet_params_widget = QWidget()
+        params_layout = QVBoxLayout(self.wavelet_params_widget)
+
+        # Wavelet sigma parameter
+        sigma_layout = QHBoxLayout()
+        sigma_layout.addWidget(QLabel("Sigma:"))
+        self.wavelet_sigma_spinbox = QDoubleSpinBox()
+        self.wavelet_sigma_spinbox.setMinimum(0.1)
+        self.wavelet_sigma_spinbox.setMaximum(10.0)
+        self.wavelet_sigma_spinbox.setValue(2.0)
+        self.wavelet_sigma_spinbox.setSingleStep(0.1)
+        self.wavelet_sigma_spinbox.setDecimals(1)
+        sigma_layout.addWidget(self.wavelet_sigma_spinbox)
+        params_layout.addLayout(sigma_layout)
+
+        # Wavelet levels parameter
+        levels_layout = QHBoxLayout()
+        levels_layout.addWidget(QLabel("Levels:"))
+        self.wavelet_levels_spinbox = QSpinBox()
+        self.wavelet_levels_spinbox.setMinimum(1)
+        self.wavelet_levels_spinbox.setMaximum(10)
+        self.wavelet_levels_spinbox.setValue(1)
+        levels_layout.addWidget(self.wavelet_levels_spinbox)
+        params_layout.addLayout(levels_layout)
+
+        layout.addWidget(self.wavelet_params_widget)
+
+    def on_filter_method_changed(self):
+        """Callback when filter method is changed."""
+        method = self.filter_method_combobox.currentText()
+        
+        if method == "Median":
+            self.median_filter_widget.setVisible(True)
+            self.wavelet_filter_widget.setVisible(False)
+        elif method == "Wavelet":
+            self.median_filter_widget.setVisible(False)
+            self.wavelet_filter_widget.setVisible(True)
+            
+        if self.parent_widget._labels_layer_with_phasor_features is not None:
+            self.check_harmonics_compatibility()
+
+    def check_harmonics_compatibility(self):
+        """Check if current layer's harmonics are compatible with wavelet filtering."""
+        if self.parent_widget._labels_layer_with_phasor_features is None:
+            return
+            
+        labels_layer_name = (
+            self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
+        )
+        
+        if not labels_layer_name:
+            return
+            
+        layer_metadata = self.viewer.layers[labels_layer_name].metadata
+        phasor_features = layer_metadata['phasor_features_labels_layer'].features
+        harmonics = np.unique(phasor_features['harmonic'])
+        
+        is_valid = validate_harmonics_for_wavelet(harmonics)
+        
+        if not is_valid:
+            harmonics_str = ", ".join(map(str, sorted(harmonics)))
+            self.harmonic_warning_label.setText(
+                f"Warning: Harmonics [{harmonics_str}] are not compatible "
+                f"for Wavelet filtering.\n Each harmonic must have its double "
+                f"or half correspondent. No filtering will be applied."
+            )
+            self.harmonic_warning_label.setVisible(True)
+            self.wavelet_params_widget.setVisible(False)
+                
+        else:
+            self.harmonic_warning_label.setVisible(False)
+            self.wavelet_params_widget.setVisible(True)
+
+
+    def calculate_automatic_threshold(self, method, data):
+        """Calculate automatic threshold using the specified method.
+        
+        Parameters
+        ----------
+        method : str
+            Threshold method ('Otsu', 'Li', 'Yen')
+        data : np.ndarray
+            Image data to calculate threshold from
+            
+        Returns
+        -------
+        float
+            Calculated threshold value
+        """
+        # Remove NaN values for threshold calculation
+        clean_data = data[~np.isnan(data)]
+        
+        if len(clean_data) == 0:
+            return 0
+            
+        try:
+            if method == "Otsu":
+                return threshold_otsu(clean_data)
+            elif method == "Li":
+                return threshold_li(clean_data)
+            elif method == "Yen":
+                return threshold_yen(clean_data)
+        except Exception:
+            # Fallback to 10% of max if automatic method fails
+            return np.nanmax(data) * 0.1
+        
+        return 0
+
+    def on_threshold_method_changed(self):
+        """Callback when threshold method is changed."""
+        if self._updating_threshold or self.parent_widget._labels_layer_with_phasor_features is None:
+            return
+            
+        method = self.threshold_method_combobox.currentText()
+        
+        if method == "None":
+            self._updating_threshold = True
+            self.threshold_slider.setValue(0)
+            self.label_3.setText('Intensity threshold: 0')
+            self.update_threshold_line()
+            self._updating_threshold = False
+            
+        elif method != "Manual":
+            labels_layer_name = (
+                self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
+            )
+            mean_data = (
+                self.viewer.layers[labels_layer_name]
+                .metadata['original_mean']
+                .copy()
+            )
+            
+            threshold_value = self.calculate_automatic_threshold(method, mean_data)
+            
+            self._updating_threshold = True
+            self.threshold_slider.setValue(int(threshold_value * self.threshold_factor))
+            self.label_3.setText(
+                'Intensity threshold: '
+                + str(self.threshold_slider.value() / self.threshold_factor)
+            )
+            self.update_threshold_line()
+            self._updating_threshold = False
+
     def on_labels_layer_with_phasor_features_changed(self):
         """Callback function when the image layer combobox is changed."""
         labels_layer_name = (
@@ -163,45 +365,94 @@ class FilterWidget(QWidget):
         self.threshold_slider.setMaximum(
             ceil(max_mean_value * self.threshold_factor)
         )
+        
+        # Block threshold method updates while setting initial values
+        self._updating_threshold = True
+        
         if "settings" in layer_metadata.keys():
             settings = layer_metadata["settings"]
+            if "threshold_method" in settings.keys():
+                self.threshold_method_combobox.setCurrentText(settings["threshold_method"])
+            else:
+                self.threshold_method_combobox.setCurrentText("Otsu")
+            
             if "threshold" in settings.keys():
                 self.threshold_slider.setValue(
                     int(settings["threshold"] * self.threshold_factor)
                 )
-                self.on_threshold_slider_change()
+                self.label_3.setText(
+                    'Intensity threshold: '
+                    + str(self.threshold_slider.value() / self.threshold_factor)
+                )
             else:
                 self.threshold_slider.setValue(
                     int(max_mean_value * 0.1 * self.threshold_factor)
                 )
-                self.on_threshold_slider_change()
+                self.label_3.setText(
+                    'Intensity threshold: '
+                    + str(self.threshold_slider.value() / self.threshold_factor)
+                )
             if "filter" in settings.keys():
-                self.median_filter_spinbox.setValue(
-                    int(settings["filter"]["size"])
-                )
-                self.median_filter_repetition_spinbox.setValue(
-                    int(settings["filter"]["repeat"])
-                )
+                filter_settings = settings["filter"]
+                if "method" in filter_settings:
+                    method = filter_settings["method"]
+                    if method == "median":
+                        self.filter_method_combobox.setCurrentText("Median")
+                    elif method == "wavelet":
+                        phasor_features = layer_metadata['phasor_features_labels_layer'].features
+                        harmonics = np.unique(phasor_features['harmonic'])
+                        if validate_harmonics_for_wavelet(harmonics):
+                            self.filter_method_combobox.setCurrentText("Wavelet")
+                        else:
+                            self.filter_method_combobox.setCurrentText("Median")
+                
+                # Restore filter parameters
+                if "size" in filter_settings:
+                    self.median_filter_spinbox.setValue(int(filter_settings["size"]))
+                if "repeat" in filter_settings:
+                    self.median_filter_repetition_spinbox.setValue(int(filter_settings["repeat"]))
+                if "sigma" in filter_settings:
+                    self.wavelet_sigma_spinbox.setValue(float(filter_settings["sigma"]))
+                if "levels" in filter_settings:
+                    self.wavelet_levels_spinbox.setValue(int(filter_settings["levels"]))
         else:
+            self.threshold_method_combobox.setCurrentText("Otsu")
             self.threshold_slider.setValue(
                 int(max_mean_value * 0.1 * self.threshold_factor)
             )
-            self.on_threshold_slider_change()
+            self.label_3.setText(
+                'Intensity threshold: '
+                + str(self.threshold_slider.value() / self.threshold_factor)
+            )
 
+        self._updating_threshold = False
         self.plot_mean_histogram()
+        
+        self.check_harmonics_compatibility()
+        
+        current_method = self.threshold_method_combobox.currentText()
+        if current_method != "Manual":
+            self.on_threshold_method_changed()
 
     def on_threshold_slider_change(self):
         """Callback function when the threshold slider value changes."""
+        if not self._updating_threshold:
+            current_method = self.threshold_method_combobox.currentText()
+            slider_value = self.threshold_slider.value()
+            
+            if not (current_method == "None" and slider_value == 0):
+                self.threshold_method_combobox.setCurrentText("Manual")
+            
         self.label_3.setText(
             'Intensity threshold: '
             + str(self.threshold_slider.value() / self.threshold_factor)
         )
-        # Update the threshold line on the histogram
+
         self.update_threshold_line()
 
-    def on_kernel_size_change(self):
+    def on_median_kernel_size_change(self):
         kernel_value = self.median_filter_spinbox.value()
-        self.label_4.setText(
+        self.median_filter_label.setText(
             'Median Filter Kernel Size: ' + f'{kernel_value} x {kernel_value}'
         )
 
@@ -256,7 +507,6 @@ class FilterWidget(QWidget):
         if self.parent_widget._labels_layer_with_phasor_features is None:
             return
 
-        # Get the current threshold value
         threshold_value = self.threshold_slider.value() / self.threshold_factor
 
         # Remove existing threshold line if it exists
@@ -273,7 +523,6 @@ class FilterWidget(QWidget):
             label='Threshold',
         )
 
-        # Refresh the canvas
         self.hist_fig.canvas.draw_idle()
 
     def apply_button_clicked(self):
@@ -287,11 +536,29 @@ class FilterWidget(QWidget):
         labels_layer_name = (
             self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
         )
+        
+        layer = self.viewer.layers[labels_layer_name]
+        if "settings" not in layer.metadata:
+            layer.metadata["settings"] = {}
+        layer.metadata["settings"]["threshold_method"] = self.threshold_method_combobox.currentText()
+        
+        # Determine filter method and parameters
+        filter_method = self.filter_method_combobox.currentText().lower()
+        
+        # Get harmonics for wavelet filter
+        harmonics = None
+        if filter_method == "wavelet":
+            harmonics =  np.unique(layer.metadata['phasor_features_labels_layer'].features['harmonic'])
+        
         apply_filter_and_threshold(
-            self.viewer.layers[labels_layer_name],
+            layer,
             threshold=self.threshold_slider.value() / self.threshold_factor,
+            filter_method=filter_method,
             size=self.median_filter_spinbox.value(),
             repeat=self.median_filter_repetition_spinbox.value(),
+            sigma=self.wavelet_sigma_spinbox.value(),
+            levels=self.wavelet_levels_spinbox.value(),
+            harmonics=harmonics,
         )
         if self.parent_widget is not None:
             self.parent_widget.plot()


### PR DESCRIPTION
This PR proposes the addition of automatic threshold options for the mean intensity image, as well as the option to filter using the wavelet (binlet) method from the [pawflim library](https://github.com/maurosilber/pawflim) (implemented in phasorpy in `phasorpy.phasor.phasor_filter_pawflim`). The automatic threshold options were suggested in #64.

Also fixes a minor bug when reading OME-TIFF exported from the napari-phasors plugin, where the thresholded mean intensity image was stored instead of the original mean intensity image. This was the reason the threshold histogram was different after importing the pre-processed and exported data.

A checkbox was added to plot the Y-axis of the mean intensity histogram in Log Scale or linear (default).

Further methods for automatic thresholding can now be easily added.