### PR TITLE
Fix bug showing FRET efficiency layer without donor lifetime input

### DIFF
--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -573,6 +573,21 @@ class FretWidget(QWidget):
 
     def calculate_fret_efficiency(self):
         """Calculate FRET efficiency based on donor intensities."""
+        if not self.donor_line_edit.text().strip():
+            show_error("Enter a Donor lifetime value.")
+            return
+
+        if not self.frequency_input.text().strip():
+            show_error("Enter a frequency value.")
+            return
+        try:
+            float(self.donor_line_edit.text().strip())
+            float(self.frequency_input.text().strip())
+        except ValueError:
+            show_error(
+                "Enter valid numeric values for donor lifetime and frequency."
+            )
+            return
         if self.parent_widget._labels_layer_with_phasor_features is None:
             return
         labels_layer_name = (

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -3,7 +3,7 @@ import numpy as np
 from matplotlib.collections import LineCollection
 from matplotlib.colors import LinearSegmentedColormap
 from napari.layers import Image
-from napari.utils.notifications import show_error
+from napari.utils.notifications import show_error, show_warning
 from phasorpy.lifetime import phasor_from_fret_donor
 from phasorpy.phasor import phasor_center, phasor_nearest_neighbor
 from qtpy.QtCore import Qt
@@ -574,11 +574,11 @@ class FretWidget(QWidget):
     def calculate_fret_efficiency(self):
         """Calculate FRET efficiency based on donor intensities."""
         if not self.donor_line_edit.text().strip():
-            show_error("Enter a Donor lifetime value.")
+            show_warning("Enter a Donor lifetime value.")
             return
 
         if not self.frequency_input.text().strip():
-            show_error("Enter a frequency value.")
+            show_warning("Enter a frequency value.")
             return
         try:
             float(self.donor_line_edit.text().strip())


### PR DESCRIPTION
This PR proposes a fix for the bug raised in the issue #133.

Added some checks and error messages being shown in the napari viewer if either the donor lifetime or frequency values are empty or invalid. Also added some test to check this behaviours.