### PR TITLE
Store all settings metadata

### DIFF
--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -81,12 +81,12 @@ def _apply_filter_and_threshold_to_phasor_arrays(
     imag: np.ndarray,
     harmonics: np.ndarray,
     *,
-    threshold: float = 0,
-    filter_method: str = "median",
-    size: int = 3,
-    repeat: int = 1,
-    sigma: float = 1.0,
-    levels: int = 3,
+    threshold: float = None,
+    filter_method: str = None,
+    size: int = None,
+    repeat: int = None,
+    sigma: float = None,
+    levels: int = None,
 ):
     """Apply filter and threshold to phasor arrays.
 
@@ -100,31 +100,34 @@ def _apply_filter_and_threshold_to_phasor_arrays(
         Imaginary part of phasor (S).
     harmonics : np.ndarray
         Harmonic values.
-    threshold : float
+    threshold : float, optional
         Threshold value for the mean value to be applied to G and S.
-    filter_method : str
+        If None, no threshold is applied.
+    filter_method : str, optional
         Filter method. Options are 'median' or 'wavelet'.
-    size : int
-        Size of the median filter.
-    repeat : int
-        Number of times to apply the median filter.
-    sigma : float
-        Sigma parameter for wavelet filter.
-    levels : int
-        Number of levels for wavelet filter.
+        If None, no filter is applied.
+    size : int, optional
+        Size of the median filter. Only used if filter_method is 'median'.
+    repeat : int, optional
+        Number of times to apply the median filter. Only used if filter_method is 'median'.
+    sigma : float, optional
+        Sigma parameter for wavelet filter. Only used if filter_method is 'wavelet'.
+    levels : int, optional
+        Number of levels for wavelet filter. Only used if filter_method is 'wavelet'.
 
     Returns
     -------
     tuple
         (mean, real, imag) filtered and thresholded arrays
     """
-    if filter_method == "median" and repeat > 0:
+    # Apply filter only if filter_method is specified
+    if filter_method == "median" and repeat is not None and repeat > 0:
         mean, real, imag = phasor_filter_median(
             mean,
             real,
             imag,
             repeat=repeat,
-            size=size,
+            size=size if size is not None else 3,
         )
     elif filter_method == "wavelet" and validate_harmonics_for_wavelet(
         harmonics
@@ -133,14 +136,15 @@ def _apply_filter_and_threshold_to_phasor_arrays(
             mean,
             real,
             imag,
-            sigma=sigma,
-            levels=levels,
+            sigma=sigma if sigma is not None else 1.0,
+            levels=levels if levels is not None else 3,
             harmonic=harmonics,
         )
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=RuntimeWarning)
-        mean, real, imag = phasor_threshold(mean, real, imag, threshold)
+    if threshold is not None and threshold > 0:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            mean, real, imag = phasor_threshold(mean, real, imag, threshold)
 
     return mean, real, imag
 
@@ -149,12 +153,13 @@ def apply_filter_and_threshold(
     layer: Image,
     /,
     *,
-    threshold: float = 0,
-    filter_method: str = "median",
-    size: int = 3,
-    repeat: int = 1,
-    sigma: float = 1.0,
-    levels: int = 3,
+    threshold: float = None,
+    threshold_method: str = None,
+    filter_method: str = None,
+    size: int = None,
+    repeat: int = None,
+    sigma: float = None,
+    levels: int = None,
     harmonics: np.ndarray = None,
 ):
     """Apply filter to an image layer.
@@ -163,28 +168,30 @@ def apply_filter_and_threshold(
     ----------
     layer : napari.layers.Image
         Napari image layer with phasor features.
-    threshold : float
+    threshold : float, optional
         Threshold value for the mean value to be applied to G and S.
-    filter_method : str
+        If None, no threshold is applied.
+    threshold_method : str, optional
+        Threshold method used. If None, no threshold method is saved.
+    filter_method : str, optional
         Filter method. Options are 'median' or 'wavelet'.
-    size : int
-        Size of the median filter.
-    repeat : int
-        Number of times to apply the median filter.
-    sigma : float
-        Sigma parameter for wavelet filter.
-    levels : int
-        Number of levels for wavelet filter.
+        If None, no filter is applied.
+    size : int, optional
+        Size of the median filter. Only used if filter_method is 'median'.
+    repeat : int, optional
+        Number of times to apply the median filter. Only used if filter_method is 'median'.
+    sigma : float, optional
+        Sigma parameter for wavelet filter. Only used if filter_method is 'wavelet'.
+    levels : int, optional
+        Number of levels for wavelet filter. Only used if filter_method is 'wavelet'.
     harmonics : np.ndarray, optional
         Harmonic values for wavelet filter. If None, will be extracted from layer.
 
     """
-    # Extract phasor arrays from layer
     mean, real, imag, harmonics = _extract_phasor_arrays_from_layer(
         layer, harmonics
     )
 
-    # Apply filter and threshold to phasor arrays
     mean, real, imag = _apply_filter_and_threshold_to_phasor_arrays(
         mean,
         real,
@@ -198,7 +205,6 @@ def apply_filter_and_threshold(
         levels=levels,
     )
 
-    # Update layer data and metadata
     layer.metadata['phasor_features_labels_layer'].features[
         'G'
     ] = real.flatten()
@@ -207,17 +213,31 @@ def apply_filter_and_threshold(
     ] = imag.flatten()
     layer.data = mean
 
-    # Update the settings dictionary of the layer
     if "settings" not in layer.metadata:
         layer.metadata["settings"] = {}
-    layer.metadata["settings"]["filter"] = {
-        "method": filter_method,
-        "size": size,
-        "repeat": repeat,
-        "sigma": sigma,
-        "levels": levels,
-    }
-    layer.metadata["settings"]["threshold"] = threshold
+    
+    # Only save filter settings if a filter was actually applied
+    if filter_method is not None:
+        layer.metadata["settings"]["filter"] = {}
+        layer.metadata["settings"]["filter"]["method"] = filter_method
+        
+        if filter_method == "median":
+            if size is not None:
+                layer.metadata["settings"]["filter"]["size"] = size
+            if repeat is not None:
+                layer.metadata["settings"]["filter"]["repeat"] = repeat
+        elif filter_method == "wavelet":
+            if sigma is not None:
+                layer.metadata["settings"]["filter"]["sigma"] = sigma
+            if levels is not None:
+                layer.metadata["settings"]["filter"]["levels"] = levels
+    
+    # Only save threshold settings if a threshold was actually applied
+    if threshold is not None and threshold > 0:
+        layer.metadata["settings"]["threshold"] = threshold
+    if threshold_method is not None and threshold_method != "None":
+        layer.metadata["settings"]["threshold_method"] = threshold_method
+    
     layer.refresh()
     return
 

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -71,6 +71,10 @@ class CalibrationWidget(QWidget):
                 layer.name
             )
 
+    def _on_image_layer_changed(self):
+        """Update button state when the selected image layer changes."""
+        self._update_button_state()
+
     def _update_button_state(self):
         """Update button text and state based on current layer's calibration status."""
         sample_name = (

--- a/src/napari_phasors/lifetime_tab.py
+++ b/src/napari_phasors/lifetime_tab.py
@@ -7,7 +7,7 @@ from matplotlib.backends.backend_qt5agg import (
 )
 from matplotlib.colors import LinearSegmentedColormap
 from napari.layers import Image
-from napari.utils.notifications import show_error
+from napari.utils.notifications import show_warning
 from phasorpy.lifetime import (
     phasor_to_apparent_lifetime,
     phasor_to_normal_lifetime,
@@ -60,6 +60,7 @@ class LifetimeWidget(QWidget):
         self._updating_contrast_limits = (
             False  # Flag to track contrast limits updates
         )
+        self._updating_settings = False  # Flag to prevent recursive updates
 
         # Style the histogram axes and figure initially
         self.style_histogram_axes()
@@ -102,8 +103,12 @@ class LifetimeWidget(QWidget):
         self.lifetime_type_combobox.setCurrentText("None")
         self.main_layout.addWidget(self.lifetime_type_combobox)
 
+        # Connect signals
         self.lifetime_type_combobox.currentTextChanged.connect(
             self._on_lifetime_type_changed
+        )
+        self.frequency_input.editingFinished.connect(
+            self._on_frequency_changed
         )
 
         # Add lifetime range slider
@@ -163,6 +168,84 @@ class LifetimeWidget(QWidget):
         self.main_layout.addWidget(self.histogram_widget)
         self.histogram_widget.hide()
 
+    def _get_default_lifetime_settings(self):
+        """Get default settings dictionary for lifetime parameters."""
+        return {
+            'frequency': None,
+            'lifetime_type': 'None',
+            'lifetime_range_min': None,
+            'lifetime_range_max': None
+        }
+
+    def _initialize_lifetime_settings_in_metadata(self, layer):
+        """Initialize lifetime settings in layer metadata if not present."""
+        if 'settings' not in layer.metadata:
+            layer.metadata['settings'] = {}
+        if 'lifetime' not in layer.metadata['settings']:
+            layer.metadata['settings']['lifetime'] = {}
+        
+        default_settings = self._get_default_lifetime_settings()
+        for key, default_value in default_settings.items():
+            if key not in layer.metadata['settings']['lifetime']:
+                layer.metadata['settings']['lifetime'][key] = default_value
+
+    def _update_lifetime_setting_in_metadata(self, key, value):
+        """Update a specific lifetime setting in the current layer's metadata."""
+        if self._updating_settings:
+            return
+            
+        layer_name = self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
+        if layer_name:
+            layer = self.viewer.layers[layer_name]
+            if 'settings' not in layer.metadata:
+                layer.metadata['settings'] = {}
+            if 'lifetime' not in layer.metadata['settings']:
+                layer.metadata['settings']['lifetime'] = {}
+            layer.metadata['settings']['lifetime'][key] = value
+
+    def _restore_lifetime_settings_from_metadata(self):
+        """Restore all lifetime settings from the current layer's metadata."""
+        layer_name = self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
+        if not layer_name:
+            return
+            
+        layer = self.viewer.layers[layer_name]
+        if 'settings' not in layer.metadata or 'lifetime' not in layer.metadata['settings']:
+            self._initialize_lifetime_settings_in_metadata(layer)
+            return
+            
+        self._updating_settings = True
+        try:
+            settings = layer.metadata['settings']['lifetime']
+            
+            if 'frequency' in settings and settings['frequency'] is not None:
+                self.frequency_input.setText(str(settings['frequency']))
+            else:
+                self.frequency_input.setText("")
+            
+            if 'lifetime_type' in settings:
+                self.lifetime_type_combobox.setCurrentText(settings['lifetime_type'])
+            
+        finally:
+            self._updating_settings = False
+
+        if 'lifetime_type' in settings and settings['lifetime_type'] != 'None':
+            self._on_lifetime_type_changed(settings['lifetime_type'])
+
+    def _on_frequency_changed(self):
+        """Callback for frequency input change."""
+        frequency_text = self.frequency_input.text().strip()
+        if frequency_text:
+            try:
+                frequency = float(frequency_text)
+                self._update_lifetime_setting_in_metadata('frequency', frequency)
+                if not self._updating_settings and self.lifetime_type_combobox.currentText() != "None":
+                    self._on_lifetime_type_changed(self.lifetime_type_combobox.currentText())
+            except ValueError:
+                pass
+        else:
+            self._update_lifetime_setting_in_metadata('frequency', None)
+
     def style_histogram_axes(self):
         """Apply consistent styling to the histogram axes and figure."""
         self.hist_ax.patch.set_alpha(0)
@@ -214,33 +297,11 @@ class LifetimeWidget(QWidget):
         min_lifetime = min_val / self.lifetime_range_factor
         max_lifetime = max_val / self.lifetime_range_factor
 
-        # Apply clipping to the lifetime data
-        if self.lifetime_data_original is not None:
-            self.lifetime_data = np.clip(
-                self.lifetime_data_original, min_lifetime, max_lifetime
-            )
+        if not self._updating_settings:
+            self._update_lifetime_setting_in_metadata('lifetime_range_min', min_lifetime)
+            self._update_lifetime_setting_in_metadata('lifetime_range_max', max_lifetime)
 
-            # Update the lifetime layer if it exists
-            if self.lifetime_layer is not None:
-                self.lifetime_layer.data = self.lifetime_data
-
-                # Set flag to prevent recursive updates from colormap change event
-                self._updating_contrast_limits = True
-                try:
-                    self.lifetime_layer.contrast_limits = [
-                        min_lifetime,
-                        max_lifetime,
-                    ]
-                    # Update our stored contrast limits to match
-                    self.colormap_contrast_limits = [
-                        min_lifetime,
-                        max_lifetime,
-                    ]
-                finally:
-                    self._updating_contrast_limits = False
-
-            # Update histogram with clipped data
-            self.plot_lifetime_histogram()
+        self._apply_lifetime_range_change(min_val, max_val)
 
     def calculate_lifetimes(self):
         """Calculate the lifetimes for all harmonics."""
@@ -249,7 +310,7 @@ class LifetimeWidget(QWidget):
 
         frequency_text = self.frequency_input.text().strip()
         if not frequency_text:
-            show_error("Enter frequency")
+            show_warning("Enter frequency")
             return
 
         self.frequency = float(frequency_text)
@@ -368,7 +429,6 @@ class LifetimeWidget(QWidget):
         min_val = float(self.lifetime_min_edit.text())
         max_val = float(self.lifetime_max_edit.text())
 
-        # Clamp to valid range
         min_val = max(0.0, min(min_val, self.max_lifetime or 0))
         max_val = max(0.0, min(max_val, self.max_lifetime or 0))
 
@@ -379,13 +439,13 @@ class LifetimeWidget(QWidget):
         min_slider = int(min_val * self.lifetime_range_factor)
         max_slider = int(max_val * self.lifetime_range_factor)
         self.lifetime_range_slider.setValue((min_slider, max_slider))
-        self._on_lifetime_range_changed((min_slider, max_slider))
+        if not self._updating_settings:
+            self._on_lifetime_range_changed((min_slider, max_slider))
 
     def _on_lifetime_max_edit(self):
         min_val = float(self.lifetime_min_edit.text())
         max_val = float(self.lifetime_max_edit.text())
 
-        # Clamp to valid range
         min_val = max(0.0, min(min_val, self.max_lifetime or 0))
         max_val = max(0.0, min(max_val, self.max_lifetime or 0))
 
@@ -396,7 +456,8 @@ class LifetimeWidget(QWidget):
         min_slider = int(min_val * self.lifetime_range_factor)
         max_slider = int(max_val * self.lifetime_range_factor)
         self.lifetime_range_slider.setValue((min_slider, max_slider))
-        self._on_lifetime_range_changed((min_slider, max_slider))
+        if not self._updating_settings:
+            self._on_lifetime_range_changed((min_slider, max_slider))
 
     def plot_lifetime_histogram(self):
         """Plot the histogram of the lifetime data as a line plot."""
@@ -432,7 +493,7 @@ class LifetimeWidget(QWidget):
         self.bin_centers = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2
 
         self._update_lifetime_histogram()
-        self.histogram_widget.show()
+        self.histogram_widget.show() 
 
     def create_lifetime_layer(self):
         """Create or update the lifetime layer for all harmonics."""
@@ -525,23 +586,28 @@ class LifetimeWidget(QWidget):
 
     def _on_image_layer_changed(self):
         """Callback whenever the image layer with phasor features changes."""
-        # Hide histogram and clears previous data
-        self.lifetime_type_combobox.setCurrentText("None")
-
-        frequency_text = self.frequency_input.text().strip()
-        if frequency_text:  # Only calculate if not empty
-            self.frequency = (
-                float(frequency_text) * self.parent_widget.harmonic
-            )
-        else:
-            self.frequency = None
-
-        # Clear histogram plot
+        layer_name = self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
+        if layer_name:
+            layer = self.viewer.layers[layer_name]
+            self._initialize_lifetime_settings_in_metadata(layer)
+            
+            self._restore_lifetime_settings_from_metadata()
+        
+        self.lifetime_data = None
+        self.lifetime_data_original = None
+        self.lifetime_layer = None
+        
         self.hist_ax.clear()
         self.hist_fig.canvas.draw_idle()
+        self.histogram_widget.hide()
 
     def _on_lifetime_type_changed(self, text):
         """Callback when lifetime type combobox selection changes."""
+        # Only update metadata if not currently restoring settings
+        if not self._updating_settings:
+            self._update_lifetime_setting_in_metadata('lifetime_type', text)
+        
+        # Always execute the plotting logic regardless of _updating_settings
         if text == "None":
             # Hide histogram and clear any existing lifetime layer
             self.histogram_widget.hide()
@@ -558,13 +624,94 @@ class LifetimeWidget(QWidget):
                 return
             frequency = self.frequency_input.text().strip()
             if frequency == "":
-                show_error("Enter frequency")
+                show_warning("Enter frequency")
+                self.histogram_widget.hide()  # Hide if no frequency
                 return
 
             self.calculate_lifetimes()
             self._update_lifetime_range_slider()
             self.create_lifetime_layer()
+            
+            # Restore saved range if available
+            self._restore_lifetime_range_from_metadata()
+            
+            # Apply current range and ensure histogram is plotted and shown
             self._on_lifetime_range_changed(self.lifetime_range_slider.value())
-            update_frequency_in_metadata(
-                self.viewer.layers[sample_name], frequency
+            
+            # Explicitly ensure histogram is shown after all calculations
+            if self.lifetime_data is not None:
+                self.plot_lifetime_histogram()
+            
+            # Only update frequency in metadata if not restoring settings
+            if not self._updating_settings:
+                update_frequency_in_metadata(
+                    self.viewer.layers[sample_name], frequency
+                )
+
+    def _restore_lifetime_range_from_metadata(self):
+        """Restore lifetime range from metadata after calculation."""
+        layer_name = self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
+        if not layer_name:
+            return
+            
+        layer = self.viewer.layers[layer_name]
+        if ('settings' in layer.metadata and 
+            'lifetime' in layer.metadata['settings']):
+            settings = layer.metadata['settings']['lifetime']
+            
+            if ('lifetime_range_min' in settings and 
+                'lifetime_range_max' in settings and
+                settings['lifetime_range_min'] is not None and
+                settings['lifetime_range_max'] is not None):
+                
+                min_val = settings['lifetime_range_min']
+                max_val = settings['lifetime_range_max']
+                
+                # Validate range against current data
+                if (self.min_lifetime is not None and self.max_lifetime is not None and
+                    min_val >= self.min_lifetime and max_val <= self.max_lifetime):
+                    
+                    min_slider = int(min_val * self.lifetime_range_factor)
+                    max_slider = int(max_val * self.lifetime_range_factor)
+                    
+                    self._updating_settings = True
+                    try:
+                        self.lifetime_range_slider.setValue((min_slider, max_slider))
+                        self.lifetime_min_edit.setText(f"{min_val:.2f}")
+                        self.lifetime_max_edit.setText(f"{max_val:.2f}")
+                        self.lifetime_range_label.setText(
+                            f"Lifetime range (ns): {min_val:.2f} - {max_val:.2f}"
+                        )
+                    finally:
+                        self._updating_settings = False
+                    
+                    self._apply_lifetime_range_change(min_slider, max_slider)
+
+
+    def _apply_lifetime_range_change(self, min_slider, max_slider):
+        """Apply lifetime range change without updating metadata."""
+        min_lifetime = min_slider / self.lifetime_range_factor
+        max_lifetime = max_slider / self.lifetime_range_factor
+
+        if self.lifetime_data_original is not None:
+            self.lifetime_data = np.clip(
+                self.lifetime_data_original, min_lifetime, max_lifetime
             )
+
+            if self.lifetime_layer is not None:
+                self.lifetime_layer.data = self.lifetime_data
+
+                self._updating_contrast_limits = True
+                try:
+                    self.lifetime_layer.contrast_limits = [
+                        min_lifetime,
+                        max_lifetime,
+                    ]
+                    self.colormap_contrast_limits = [
+                        min_lifetime,
+                        max_lifetime,
+                    ]
+                finally:
+                    self._updating_contrast_limits = False
+
+            self.plot_lifetime_histogram()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1145,15 +1145,23 @@ class PlotterWidget(QWidget):
             
             # Update filter widget when layer changes
             if hasattr(self, 'filter_tab'):
-                self.filter_tab.on_labels_layer_with_phasor_features_changed()
+                self.filter_tab._on_image_layer_changed()
 
             # Update calibration button state when layer changes
             if hasattr(self, 'calibration_tab'):
-                self.calibration_tab._update_button_state()
+                self.calibration_tab._on_image_layer_changed()
 
             # Update lifetime tab when layer changes
             if hasattr(self, 'lifetime_tab'):
                 self.lifetime_tab._on_image_layer_changed()
+
+            # Update components tab when layer changes
+            if hasattr(self, 'components_tab'):
+                self.components_tab._on_image_layer_changed()
+
+            # Update FRET tab when layer changes
+            if hasattr(self, 'fret_tab'):
+                self.fret_tab._on_image_layer_changed()
 
             self.plot()
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -537,9 +537,6 @@ class PlotterWidget(QWidget):
         self.harmonic_spinbox.valueChanged.connect(
             self.lifetime_tab._on_harmonic_changed
         )
-        self.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
-            self.lifetime_tab._on_image_layer_changed
-        )
         self.lifetime_tab.frequency_input.editingFinished.connect(
             lambda: self._broadcast_frequency_value_across_tabs(
                 self.lifetime_tab.frequency_input.text()
@@ -1153,6 +1150,10 @@ class PlotterWidget(QWidget):
             # Update calibration button state when layer changes
             if hasattr(self, 'calibration_tab'):
                 self.calibration_tab._update_button_state()
+
+            # Update lifetime tab when layer changes
+            if hasattr(self, 'lifetime_tab'):
+                self.lifetime_tab._on_image_layer_changed()
 
             self.plot()
 


### PR DESCRIPTION
This PR proposes storing and restoring all relevan values for the plugin in the "settings" dictionary, which is stored in the metadata of the napari layer and in case the layer is exported in OME-TIF, the settings dictionary is stored in the "description" attribute.

This change was suggested in #128, and the idea is to use this information to facilitate the batch processing later on when it is implemented.

Also, this comes with an enhancement to the experience of the plugin with this implementation because it was also updated how each tab handles the stored metadata to restore the values for the analysis. For example, if a user changes values in the lifetime tab and then changes the selection of the Image Layer with phasor features in the main combobox of the plotter widget, and then selects again the layer with the analysis, the values and the lifetime analysis are restored. As of now, this values are "lost" once the layer selected in the combobox is changed. 

Also, when exporting to OME-TIF this values of the "workspace" are stored, so all analysis can be restored when reading the exported OME-TIF file with the napari-phasors settings dictionary.

Tests need to be implemented, but I wanted to open this PR draft to start the discussion of this implementation. 

One important thing to discuss is that with this implementation, all analysis (and preprocessing) are run when reading the OME-TIF, all at once. The same when selecting the layer in the combobox. This can be a problem with big images, I think. Maybe restore the values for the analysis when reading but don't perform the analysis until the respective tab is selected?