### PR TITLE
Set `keepdims` parameter to `False` for PTU and FBD readers

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -29,7 +29,7 @@ extension_mapping = {
         ".ptu": lambda path, reader_options: _parse_and_call_io_function(
             path,
             io.signal_from_ptu,
-            {"frame": (-1, False), "keepdims": (True, False)},
+            {"frame": (-1, False), "keepdims": (False, False)},
             reader_options,
         ),
         ".fbd": lambda path, reader_options: _parse_and_call_io_function(
@@ -37,7 +37,7 @@ extension_mapping = {
             io.signal_from_fbd,
             {
                 "frame": (-1, False),
-                "keepdims": (True, False),
+                "keepdims": (False, False),
                 "channel": (None, False),
             },
             reader_options,
@@ -206,18 +206,24 @@ def raw_file_reader(
         and 'frequency' in raw_data.attrs.keys()
     ):
         settings['frequency'] = raw_data.attrs['frequency']
+
     layers = []
     iter_axis = iter_index_mapping[file_extension]
-    if iter_axis is None:
+
+    if iter_axis is None or iter_axis not in raw_data.dims:
+        # Handle files without iteration axis or when keepdims=False squeezed it out
         if file_extension == ".tif":
-            mean_intensity_image, G_image, S_image = phasor_from_signal(
-                raw_data, axis=0, harmonic=harmonics
-            )
+            axis = 0
+        elif iter_axis is None:
+            # Hyperspectral files - find "C" dimension
+            axis = raw_data.dims.index("C")
         else:
-            # Calculate phasor over channels if file is of hyperspectral type
-            mean_intensity_image, G_image, S_image = phasor_from_signal(
-                raw_data, axis=raw_data.dims.index("C"), harmonic=harmonics
-            )
+            # FLIM files without "C" dimension (single channel)
+            axis = raw_data.dims.index("H")
+
+        mean_intensity_image, G_image, S_image = phasor_from_signal(
+            raw_data, axis=axis, harmonic=harmonics
+        )
         labels_layer = make_phasors_labels_layer(
             mean_intensity_image,
             G_image,
@@ -225,8 +231,13 @@ def raw_file_reader(
             name=filename,
             harmonics=harmonics,
         )
+        channel_suffix = (
+            " Intensity Image"
+            if iter_axis is None
+            else " Intensity Image: Channel 0"
+        )
         add_kwargs = {
-            "name": f"{filename} Intensity Image",
+            "name": f"{filename}{channel_suffix}",
             "metadata": {
                 "phasor_features_labels_layer": labels_layer,
                 "original_mean": mean_intensity_image,
@@ -235,9 +246,9 @@ def raw_file_reader(
         }
         layers.append((mean_intensity_image, add_kwargs))
     else:
+        # Handle multi-channel files with iteration axis
         iter_axis_index = raw_data.dims.index(iter_axis)
         for channel in range(raw_data.shape[iter_axis_index]):
-            # Calculate phasor over photon counts dimension if file is FLIM
             mean_intensity_image, G_image, S_image = phasor_from_signal(
                 raw_data.sel(C=channel),
                 axis=raw_data.sel(C=channel).dims.index("H"),

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -19,7 +19,7 @@ def test_reader_ptu():
     assert isinstance(layer_data_tuple[0], np.ndarray) and isinstance(
         layer_data_tuple[1], dict
     )
-    assert layer_data_tuple[0].shape == (1, 256, 256)
+    assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"] == "test_file Intensity Image: Channel 0"
@@ -34,7 +34,7 @@ def test_reader_ptu():
         "phasor_features_labels_layer"
     ]
     assert isinstance(phasor_features, Labels)
-    assert phasor_features.data.shape == (1, 256, 256)
+    assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
@@ -63,7 +63,7 @@ def test_reader_fbd():
     assert isinstance(layer_data_tuple[0], np.ndarray) and isinstance(
         layer_data_tuple[1], dict
     )
-    assert layer_data_tuple[0].shape == (1, 256, 256)
+    assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"]
@@ -79,7 +79,7 @@ def test_reader_fbd():
         "phasor_features_labels_layer"
     ]
     assert isinstance(phasor_features, Labels)
-    assert phasor_features.data.shape == (1, 256, 256)
+    assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
@@ -99,7 +99,7 @@ def test_reader_fbd():
     assert isinstance(layer_data_tuple[0], np.ndarray) and isinstance(
         layer_data_tuple[1], dict
     )
-    assert layer_data_tuple[0].shape == (1, 256, 256)
+    assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"]
@@ -115,7 +115,7 @@ def test_reader_fbd():
         "phasor_features_labels_layer"
     ]
     assert isinstance(phasor_features, Labels)
-    assert phasor_features.data.shape == (1, 256, 256)
+    assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (131072, 6)
     expected_columns = [

--- a/src/napari_phasors/_tests/test_sample_data.py
+++ b/src/napari_phasors/_tests/test_sample_data.py
@@ -19,7 +19,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     assert isinstance(layer_data_tuple[0], np.ndarray) and isinstance(
         layer_data_tuple[1], dict
     )
-    assert layer_data_tuple[0].shape == (1, 256, 256)
+    assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"]
@@ -35,7 +35,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
         "phasor_features_labels_layer"
     ]
     assert isinstance(phasor_features, Labels)
-    assert phasor_features.data.shape == (1, 256, 256)
+    assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (131072, 6)
     expected_columns = [
@@ -55,7 +55,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     assert isinstance(layer_data_tuple[0], np.ndarray) and isinstance(
         layer_data_tuple[1], dict
     )
-    assert layer_data_tuple[0].shape == (1, 256, 256)
+    assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"]
@@ -71,7 +71,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
         "phasor_features_labels_layer"
     ]
     assert isinstance(phasor_features, Labels)
-    assert phasor_features.data.shape == (1, 256, 256)
+    assert phasor_features.data.shape == (256, 256)
     assert isinstance(phasor_features.features, pd.DataFrame)
     assert phasor_features.features.shape == (131072, 6)
     expected_columns = [

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -140,7 +140,7 @@ def test_phasor_transform_fbd_widget(make_napari_viewer):
     widget.btn.click()
     assert len(viewer.layers) == 1
     assert viewer.layers[0].name == "test_file$EI0S Intensity Image: Channel 0"
-    assert viewer.layers[0].data.shape == (1, 256, 256)
+    assert viewer.layers[0].data.shape == (256, 256)
     phasor_data = (
         viewer.layers[0].metadata["phasor_features_labels_layer"].features
     )
@@ -152,7 +152,7 @@ def test_phasor_transform_fbd_widget(make_napari_viewer):
     widget.btn.click()
     assert len(viewer.layers) == 3
     assert viewer.layers[2].name == "test_file$EI0S Intensity Image: Channel 1"
-    assert viewer.layers[2].data.shape == (1, 256, 256)
+    assert viewer.layers[2].data.shape == (256, 256)
     phasor_data = (
         viewer.layers[2].metadata["phasor_features_labels_layer"].features
     )
@@ -217,7 +217,7 @@ def test_phasor_transform_ptu_widget(make_napari_viewer):
     widget.btn.click()
     assert len(viewer.layers) == 1
     assert viewer.layers[0].name == "test_file Intensity Image: Channel 0"
-    assert viewer.layers[0].data.shape == (1, 256, 256)
+    assert viewer.layers[0].data.shape == (256, 256)
     phasor_data = (
         viewer.layers[0].metadata["phasor_features_labels_layer"].features
     )
@@ -229,7 +229,7 @@ def test_phasor_transform_ptu_widget(make_napari_viewer):
     widget.btn.click()
     assert len(viewer.layers) == 2
     assert viewer.layers[1].name == "test_file Intensity Image: Channel 0 [1]"
-    assert viewer.layers[1].data.shape == (1, 256, 256)
+    assert viewer.layers[1].data.shape == (256, 256)
     phasor_data = (
         viewer.layers[1].metadata["phasor_features_labels_layer"].features
     )


### PR DESCRIPTION
Perfoming some analysis on PTU and FBD files I realized that the arrays with the phasor coordinates and the mean intensity image contained an extra dimension of size 1 corresponding to the channel. This that the images are not 2D, but 3D and this in turn made the function `phasorpy.phasor.phasor_filter_median` to use the numpy implementation (which is used by default for more than 2D filtering). This implementation is very slow and also not as consistent for `NaN` handling as the 2D cython implementation is.

By setting the `keepdims` parameter in the FBD and PTU file readers to false by default, this was fixed, because now the extra axis of size one is not created.

The raw file reader was also updated to handle the cases where no channel dimension is present, as well as the tests to account for this dimension that was removed.