### PR TITLE
Add option to calculate Donor Lifetime in FRET tab from image layer

### DIFF
--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -23,12 +23,32 @@ def test_fret_widget_initialization(make_napari_viewer):
     # Test initial UI state
     assert widget.donor_line_edit.text() == ""
     assert widget.frequency_input.text() == ""
-    assert widget.background_real_edit.text() == "0.1"
-    assert widget.background_imag_edit.text() == "0.1"
+    assert widget.background_real_edit.text() == "0.0"
+    assert widget.background_imag_edit.text() == "0.0"
     assert (
         widget.calculate_fret_efficiency_button.text()
         == "Calculate FRET efficiency"
     )
+
+    # Test donor lifetime combobox
+    assert widget.donor_lifetime_combobox.currentText() in ["None", ""]
+    assert (
+        widget.lifetime_type_combobox.currentText()
+        == "Apparent Phase Lifetime"
+    )
+    assert widget.lifetime_type_combobox.count() == 3
+
+    # Verify all lifetime modes are present
+    lifetime_modes = [
+        widget.lifetime_type_combobox.itemText(i)
+        for i in range(widget.lifetime_type_combobox.count())
+    ]
+    expected_modes = [
+        "Apparent Phase Lifetime",
+        "Apparent Modulation Lifetime",
+        "Normal Lifetime",
+    ]
+    assert lifetime_modes == expected_modes
 
     # Test slider initial values
     assert widget.background_slider.value() == 10  # 0.1 * 100
@@ -52,7 +72,7 @@ def test_fret_widget_parameter_updates(make_napari_viewer):
     widget._on_parameters_changed()
 
     assert widget.donor_lifetime == 2.5
-    assert widget.frequency == 80 * parent.harmonic  # frequency * harmonic
+    assert widget.frequency == 80 * parent.harmonic
     assert widget.background_real == 0.2
     assert widget.background_imag == 0.3
 
@@ -117,8 +137,8 @@ def test_calculate_background_position_no_layer(make_napari_viewer):
     widget._calculate_background_position()
 
     # Values should remain at defaults
-    assert widget.background_real_edit.text() == "0.1"
-    assert widget.background_imag_edit.text() == "0.1"
+    assert widget.background_real_edit.text() == "0.0"
+    assert widget.background_imag_edit.text() == "0.0"
 
 
 def test_calculate_background_position_with_layer(make_napari_viewer):
@@ -742,3 +762,360 @@ def test_background_position_manual_changes_stored_by_harmonic(
     # Should restore harmonic 1 values
     assert float(widget.background_real_edit.text()) == 0.15
     assert float(widget.background_imag_edit.text()) == 0.25
+
+
+def test_donor_lifetime_combobox_initialization(make_napari_viewer):
+    """Test that donor lifetime combobox is properly initialized."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Initially should have "None" option
+    assert widget.donor_lifetime_combobox.count() >= 1
+    assert widget.donor_lifetime_combobox.itemText(0) == "None"
+
+
+def test_donor_lifetime_combobox_updates_with_layers(make_napari_viewer):
+    """Test that donor lifetime combobox updates when layers are added/removed."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Initial state
+    initial_count = widget.donor_lifetime_combobox.count()
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Combobox should be updated
+    new_count = widget.donor_lifetime_combobox.count()
+    assert new_count == initial_count + 1
+
+    # Check that the new layer is in the combobox
+    combobox_items = [
+        widget.donor_lifetime_combobox.itemText(i)
+        for i in range(widget.donor_lifetime_combobox.count())
+    ]
+    assert "test_layer" in combobox_items
+
+    # Remove layer
+    viewer.layers.remove(test_layer)
+
+    # Combobox should be updated back to original count
+    assert widget.donor_lifetime_combobox.count() == initial_count
+
+
+def test_lifetime_type_combobox_modes(make_napari_viewer):
+    """Test the lifetime type combobox modes."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Test changing modes
+    widget.lifetime_type_combobox.setCurrentText(
+        "Apparent Modulation Lifetime"
+    )
+    assert (
+        widget.lifetime_type_combobox.currentText()
+        == "Apparent Modulation Lifetime"
+    )
+
+    widget.lifetime_type_combobox.setCurrentText("Normal Lifetime")
+    assert widget.lifetime_type_combobox.currentText() == "Normal Lifetime"
+
+    widget.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
+    assert (
+        widget.lifetime_type_combobox.currentText()
+        == "Apparent Phase Lifetime"
+    )
+
+
+def test_calculate_donor_lifetime_no_layer_selected(make_napari_viewer):
+    """Test donor lifetime calculation with no layer selected."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Set frequency for calculations
+    widget.frequency_input.setText("80")
+
+    # Should return without error when "None" is selected
+    widget.donor_lifetime_combobox.setCurrentText("None")
+    initial_lifetime = widget.donor_line_edit.text()
+
+    widget._calculate_donor_lifetime()
+
+    # Lifetime should remain unchanged
+    assert widget.donor_line_edit.text() == initial_lifetime
+
+
+def test_calculate_donor_lifetime_no_frequency(make_napari_viewer):
+    """Test donor lifetime calculation with no frequency set."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Select the layer but don't set frequency
+    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    widget.frequency_input.setText("")  # No frequency
+
+    initial_lifetime = widget.donor_line_edit.text()
+
+    # Should return without error
+    widget._calculate_donor_lifetime()
+
+    # Lifetime should remain unchanged
+    assert widget.donor_line_edit.text() == initial_lifetime
+
+
+def test_calculate_donor_lifetime_apparent_phase(make_napari_viewer):
+    """Test donor lifetime calculation using apparent phase lifetime."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Set up parameters
+    widget.frequency_input.setText("80")
+    widget.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
+    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+
+    # Set up parent widget properly
+    parent.harmonic = 1
+
+    # Calculate donor lifetime
+    widget._calculate_donor_lifetime()
+
+    # Should have updated the donor lifetime
+    assert widget.donor_line_edit.text() != ""
+    lifetime_value = float(widget.donor_line_edit.text())
+    assert lifetime_value > 0
+    assert widget.donor_lifetime == lifetime_value
+
+
+def test_calculate_donor_lifetime_apparent_modulation(make_napari_viewer):
+    """Test donor lifetime calculation using apparent modulation lifetime."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Set up parameters
+    widget.frequency_input.setText("80")
+    widget.lifetime_type_combobox.setCurrentText(
+        "Apparent Modulation Lifetime"
+    )
+    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+
+    # Set up parent widget properly
+    parent.harmonic = 1
+
+    # Calculate donor lifetime
+    widget._calculate_donor_lifetime()
+
+    # Should have updated the donor lifetime
+    assert widget.donor_line_edit.text() != ""
+    lifetime_value = float(widget.donor_line_edit.text())
+    assert lifetime_value > 0
+    assert widget.donor_lifetime == lifetime_value
+
+
+def test_calculate_donor_lifetime_normal_lifetime(make_napari_viewer):
+    """Test donor lifetime calculation using normal lifetime."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Set up parameters
+    widget.frequency_input.setText("80")
+    widget.lifetime_type_combobox.setCurrentText("Normal Lifetime")
+    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+
+    # Set up parent widget properly
+    parent.harmonic = 1
+
+    # Calculate donor lifetime
+    widget._calculate_donor_lifetime()
+
+    # Should have updated the donor lifetime
+    assert widget.donor_line_edit.text() != ""
+    lifetime_value = float(widget.donor_line_edit.text())
+    assert lifetime_value > 0
+    assert widget.donor_lifetime == lifetime_value
+
+
+def test_calculate_donor_lifetime_different_harmonics(make_napari_viewer):
+    """Test donor lifetime calculation with different harmonics."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Set up parameters
+    widget.frequency_input.setText("80")
+    widget.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
+    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+
+    # Test with harmonic 1
+    parent.harmonic = 1
+    widget._calculate_donor_lifetime()
+    lifetime_h1 = widget.donor_line_edit.text()
+
+    # Test with harmonic 2
+    parent.harmonic = 2
+    widget._calculate_donor_lifetime()
+    lifetime_h2 = widget.donor_line_edit.text()
+
+    # Test with harmonic 3
+    parent.harmonic = 3
+    widget._calculate_donor_lifetime()
+    lifetime_h3 = widget.donor_line_edit.text()
+
+    # Lifetimes should be different for different harmonics
+    assert lifetime_h1 != lifetime_h2
+    assert lifetime_h1 != lifetime_h3
+    assert lifetime_h2 != lifetime_h3
+
+
+def test_calculate_donor_lifetime_mode_differences(make_napari_viewer):
+    """Test that different lifetime modes give different results."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add layer with phasor data
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    # Set up parameters
+    widget.frequency_input.setText("80")
+    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    parent.harmonic = 1
+
+    # Test apparent phase lifetime
+    widget.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
+    widget._calculate_donor_lifetime()
+    phase_lifetime = widget.donor_line_edit.text()
+
+    # Test apparent modulation lifetime
+    widget.lifetime_type_combobox.setCurrentText(
+        "Apparent Modulation Lifetime"
+    )
+    widget._calculate_donor_lifetime()
+    mod_lifetime = widget.donor_line_edit.text()
+
+    # Test normal lifetime
+    widget.lifetime_type_combobox.setCurrentText("Normal Lifetime")
+    widget._calculate_donor_lifetime()
+    normal_lifetime = widget.donor_line_edit.text()
+
+    # All should be valid numbers
+    assert phase_lifetime != ""
+    assert mod_lifetime != ""
+    assert normal_lifetime != ""
+
+    phase_val = float(phase_lifetime)
+    mod_val = float(mod_lifetime)
+    normal_val = float(normal_lifetime)
+
+    assert phase_val > 0
+    assert mod_val > 0
+    assert normal_val > 0
+
+    # They should generally be different (though could be close)
+    # At least one should be different from the others
+    assert not (phase_val == mod_val == normal_val)
+
+
+def test_donor_lifetime_combobox_layer_selection_persistence(
+    make_napari_viewer,
+):
+    """Test that donor lifetime combobox selection persists when layers change."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Add first layer
+    test_layer1 = create_image_layer_with_phasors()
+    test_layer1.name = "test_layer1"
+    viewer.add_layer(test_layer1)
+
+    # Select first layer
+    widget.donor_lifetime_combobox.setCurrentText("test_layer1")
+    assert widget.donor_lifetime_combobox.currentText() == "test_layer1"
+
+    # Add second layer
+    test_layer2 = create_image_layer_with_phasors()
+    test_layer2.name = "test_layer2"
+    viewer.add_layer(test_layer2)
+
+    # Selection should persist
+    assert widget.donor_lifetime_combobox.currentText() == "test_layer1"
+
+    # Change to second layer
+    widget.donor_lifetime_combobox.setCurrentText("test_layer2")
+    assert widget.donor_lifetime_combobox.currentText() == "test_layer2"
+
+    # Remove first layer
+    viewer.layers.remove(test_layer1)
+
+    # Selection should still be test_layer2
+    assert widget.donor_lifetime_combobox.currentText() == "test_layer2"
+
+    # Remove second layer
+    viewer.layers.remove(test_layer2)
+
+    # Should revert to "None"
+    assert widget.donor_lifetime_combobox.currentText() == "None"
+
+
+def test_calculate_donor_lifetime_error_handling(make_napari_viewer):
+    """Test error handling in donor lifetime calculation."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    # Create a layer without proper phasor data
+    import numpy as np
+    from napari.layers import Image
+
+    bad_layer = Image(np.random.random((10, 10)), name="bad_layer")
+    viewer.add_layer(bad_layer)
+
+    # Try to calculate with bad layer
+    widget.frequency_input.setText("80")
+    widget.donor_lifetime_combobox.setCurrentText("bad_layer")
+    parent.harmonic = 1
+
+    initial_lifetime = widget.donor_line_edit.text()
+
+    # Should handle error gracefully
+    widget._calculate_donor_lifetime()
+
+    # Should not crash and lifetime should remain unchanged
+    assert widget.donor_line_edit.text() == initial_lifetime


### PR DESCRIPTION
This PR proposes the addition of two comboboxes in the FRET tab to get the donor lifetime from an image layer, similar to what can be done to get the background position. One comobobx was added to select the layer containing the donor phasor features, and another combobox was added to select which mode or type of lifetime wants to be used to get the lifetime value: apparent phase, apparent modulation or normal lifetime.

 Also, this PR proposes some rearrangement of the UI of the FRET tab to make it more concise, moving many elements to be in the same line, instead of being in separate lines as before.