### PR TITLE
Remove lifetime tab update from filter widget

### DIFF
--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -657,16 +657,3 @@ class FilterWidget(QWidget):
 
         if self.parent_widget is not None:
             self.parent_widget.plot()
-
-            # Update lifetime tab if it exists and has a lifetime type selected
-            if (
-                hasattr(self.parent_widget, 'lifetime_tab')
-                and self.parent_widget.lifetime_tab is not None
-            ):
-                current_lifetime_type = (
-                    self.parent_widget.lifetime_tab.lifetime_type_combobox.currentText()
-                )
-                if current_lifetime_type != "None":
-                    self.parent_widget.lifetime_tab._on_lifetime_type_changed(
-                        current_lifetime_type
-                    )


### PR DESCRIPTION
While testing updates with a mask, I noticed that, if I generate a lifetime layer, then create a mask and apply a filter, the lifetime layer data was being automatically updated. 

According to our new standards, this should not happen. To update layer results from a specific tab after adding a mask, a button in that tab must be clicked (in this case, the refresh button).

So I am suggesting here to remove this auto-update of the lifetime layer after filtering. Unless there was another intended effect for this, I think we can do that.