### PR TITLE
Fix OME-TIFF export crash with numpy types in settings (#178)

### DIFF
--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -9,7 +9,109 @@ from napari_phasors._synthetic_generator import (
     make_intensity_layer_with_phasors,
     make_raw_flim_data,
 )
-from napari_phasors._writer import write_ome_tiff
+from napari_phasors._writer import _convert_numpy_types, write_ome_tiff
+
+
+def test_convert_numpy_types_scalars():
+    """Test that numpy scalars are converted to native Python types."""
+    assert _convert_numpy_types(np.int64(42)) == 42
+    assert type(_convert_numpy_types(np.int64(42))) is int
+    assert _convert_numpy_types(np.float64(3.14)) == 3.14
+    assert type(_convert_numpy_types(np.float64(3.14))) is float
+    assert _convert_numpy_types(np.bool_(True)) is True
+    assert type(_convert_numpy_types(np.bool_(True))) is bool
+
+
+def test_convert_numpy_types_dict_keys():
+    """Test that numpy types in dict keys are converted (Issue #178)."""
+    data = {np.int64(1): {'real': np.float64(0.5), 'imag': np.float64(0.3)}}
+    result = _convert_numpy_types(data)
+    assert result == {1: {'real': 0.5, 'imag': 0.3}}
+    for key in result:
+        assert type(key) is int
+    for val in result[1].values():
+        assert type(val) is float
+
+
+def test_convert_numpy_types_nested():
+    """Test recursive conversion of complex nested structures."""
+    data = {
+        'harmonics': np.array([1, 2, 3]),
+        'positions': {
+            np.int64(1): [np.float64(0.1), np.float64(0.2)],
+            np.int64(2): (np.float64(0.3), np.float64(0.4)),
+        },
+        'plain': 'string_value',
+        'count': np.int32(10),
+    }
+    result = _convert_numpy_types(data)
+    assert result['harmonics'] == [1, 2, 3]
+    assert 1 in result['positions']
+    assert 2 in result['positions']
+    assert result['positions'][1] == [0.1, 0.2]
+    assert result['positions'][2] == (0.3, 0.4)
+    assert result['plain'] == 'string_value'
+    assert result['count'] == 10
+    assert type(result['count']) is int
+
+
+def test_convert_numpy_types_passthrough():
+    """Test that non-numpy types pass through unchanged."""
+    assert _convert_numpy_types('hello') == 'hello'
+    assert _convert_numpy_types(42) == 42
+    assert _convert_numpy_types(None) is None
+
+
+def test_write_ometif_with_numpy_settings(tmp_path):
+    """Test that OME-TIFF export works when settings contain numpy types.
+
+    Regression test for Issue #178: TypeError with numpy.int64 dict keys.
+    """
+    time_constants = [0.1, 1, 10]
+    raw_flim_data = make_raw_flim_data(time_constants=time_constants)
+    harmonic = [1, 2, 3]
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+
+    # Simulate FRET tab storing numpy-typed keys and values in settings
+    if "settings" not in intensity_image_layer.metadata:
+        intensity_image_layer.metadata["settings"] = {}
+    intensity_image_layer.metadata["settings"]["fret"] = {
+        "background_positions_by_harmonic": {
+            np.int64(1): {"real": np.float64(0.5), "imag": np.float64(0.3)},
+            np.int64(2): {"real": np.float64(0.6), "imag": np.float64(0.4)},
+        },
+        "donor_lifetime": np.float64(4.0),
+        "frequency": np.float64(80.0),
+    }
+
+    filepath = os.path.join(tmp_path, "test_numpy_settings.ome.tif")
+
+    # This should NOT raise TypeError
+    result = write_ome_tiff(
+        filepath,
+        [
+            (
+                intensity_image_layer.data,
+                {"metadata": intensity_image_layer.metadata},
+            )
+        ],
+    )
+
+    assert os.path.exists(filepath)
+    assert result == [filepath]
+
+    # Read back and verify settings survived the roundtrip
+    reader = napari_get_reader(filepath, harmonics=harmonic)
+    layer_data_list = reader(filepath)
+    metadata = layer_data_list[0][1]["metadata"]
+    fret = metadata["settings"]["fret"]
+    assert fret["donor_lifetime"] == 4.0
+    assert fret["frequency"] == 80.0
+    positions = fret["background_positions_by_harmonic"]
+    # JSON keys become strings, so verify they're accessible
+    assert "1" in positions or 1 in positions
 
 
 def test_write_ometif(tmp_path):

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -22,6 +22,42 @@ if TYPE_CHECKING:
     FullLayerData = Tuple[DataType, dict, str]
 
 
+def _convert_numpy_types(obj):
+    """Recursively convert numpy types to native Python types.
+
+    Handles numpy scalars in both dict keys and values, making
+    the data structure safe for ``json.dumps``.
+
+    Parameters
+    ----------
+    obj : any
+        The object to convert. Can be a dict, list, tuple,
+        numpy scalar, numpy array, or any other type.
+
+    Returns
+    -------
+    any
+        The converted object with all numpy types replaced
+        by their native Python equivalents.
+    """
+    if isinstance(obj, dict):
+        return {
+            _convert_numpy_types(k): _convert_numpy_types(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_convert_numpy_types(item) for item in obj)
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    return obj
+
+
 def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
     """Save image layer with phasor coordinates as 'OME-TIFF'.
 
@@ -85,6 +121,7 @@ def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
     if not path.endswith(".ome.tif"):
         path += ".ome.tif"
     settings["version"] = str(importlib.metadata.version('napari-phasors'))
+    settings = _convert_numpy_types(settings)
     description = json.dumps({"napari_phasors_settings": json.dumps(settings)})
     phasor_to_ometiff(
         path,
@@ -94,7 +131,7 @@ def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
         harmonic=harmonics,
         description=description,
     )
-    return path
+    return [path]
 
 
 def export_layer_as_image(


### PR DESCRIPTION
## Description

Fixes #178.

When exporting a layer as OME-TIFF, `write_ome_tiff()` calls `json.dumps()` on the settings dictionary. This crashes with:

TypeError: keys must be str, int, float, bool or None, not numpy.int64


### Root cause

The FRET tab stores harmonic numbers as dictionary keys in `background_positions_by_harmonic`. These harmonics originate from numpy arrays and retain their `np.int64` dtype. The values in the dict also carry `np.float64` types. Python's `json.dumps()` cannot serialize numpy scalar types — and a custom `JSONEncoder` only handles **values**, not **keys**, so a standard encoder subclass is insufficient here.

### Fix

Added `_convert_numpy_types()` to `_writer.py` — a recursive function that walks the entire settings structure before serialization and converts:
- `np.integer` → `int`
- `np.floating` → `float`
- `np.bool_` → `bool`
- `np.ndarray` → `list`

This handles numpy types in both dict keys and values, nested at any depth.

Also fixed `write_ome_tiff()` return type: it was returning a bare string instead of `[path]`, which didn't match its `List[str]` type annotation.

### Tests added

| Test | What it verifies |
|------|-----------------|
| `test_convert_numpy_types_scalars` | int64, float64, bool_ → native types |
| `test_convert_numpy_types_dict_keys` | Exact crash scenario from #178 (numpy int as dict key) |
| `test_convert_numpy_types_nested` | Complex nested dicts/lists/tuples with mixed numpy types |
| `test_convert_numpy_types_passthrough` | Non-numpy types pass through unchanged |
| `test_write_ometif_with_numpy_settings` | Full write→read roundtrip with numpy-typed FRET settings |

All 346 tests pass (341 existing + 5 new).

### Files changed

- `src/napari_phasors/_writer.py` — added `_convert_numpy_types()`, applied it before `json.dumps()`, fixed return type
- `src/napari_phasors/_tests/test_writer.py` — 5 new tests