### PR TITLE
Add support in FRET widget to multiple layer selection in donor and background sources

### DIFF
--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -39,11 +39,8 @@ def test_fret_widget_initialization(make_napari_viewer):
     assert widget.donor_stack.currentIndex() == 0  # Manual page
     assert widget.bg_stack.currentIndex() == 0  # Manual page
 
-    # Test donor lifetime combobox
-    assert widget.donor_lifetime_combobox.currentText() in [
-        "Select layer...",
-        "",
-    ]
+    # Test donor lifetime combobox (CheckableComboBox: empty when no items checked)
+    assert widget.donor_lifetime_combobox.currentText() == ""
     assert (
         widget.lifetime_type_combobox.currentText()
         == "Apparent Phase Lifetime"
@@ -175,17 +172,17 @@ def test_calculate_background_position_with_layer(make_napari_viewer):
     # Update the background combobox to include the new layer
     widget._update_background_combobox()
 
-    # Check that the combobox has been populated correctly
+    # Check that the combobox has been populated correctly (CheckableComboBox: no placeholder item)
     combobox_items = [
         widget.background_image_combobox.itemText(i)
         for i in range(widget.background_image_combobox.count())
     ]
-    assert "Select layer..." in combobox_items
+    assert "Select layer..." not in combobox_items
     assert "test_layer" in combobox_items
 
-    # Switch to "From layer" mode and select the test layer
-    widget.bg_source_selector.setCurrentText("From layer")
-    widget.background_image_combobox.setCurrentText("test_layer")
+    # Switch to "From layer(s)" mode and check the test layer
+    widget.bg_source_selector.setCurrentText("From layer(s)")
+    widget.background_image_combobox.setCheckedItems(["test_layer"])
 
     # Set up the parent widget properly
     parent.harmonic = 1
@@ -217,11 +214,11 @@ def test_calculate_background_position_with_layer(make_napari_viewer):
     expected_label = f"Background position: G={stored_position['real']:.2f}, S={stored_position['imag']:.2f}"
     assert widget.background_position_label.text() == expected_label
 
-    # Test with "Select layer..." selected - should not crash
-    widget.background_image_combobox.setCurrentText("Select layer...")
+    # Test with no layer checked - should not crash
+    widget.background_image_combobox.deselectAll()
     widget._calculate_background_position()
 
-    # Label should revert to default when no valid layer is selected
+    # Label should revert to default when no layer is selected
     assert widget.background_position_label.text() == "Background position:"
 
 
@@ -889,9 +886,9 @@ def test_donor_lifetime_combobox_initialization(make_napari_viewer):
     parent = PlotterWidget(viewer)
     widget = parent.fret_tab
 
-    # Initially should have "Select layer..." option
-    assert widget.donor_lifetime_combobox.count() >= 1
-    assert widget.donor_lifetime_combobox.itemText(0) == "Select layer..."
+    # CheckableComboBox: starts empty (no placeholder item), shows placeholder text
+    assert widget.donor_lifetime_combobox.count() == 0
+    assert widget.donor_lifetime_combobox.currentText() == ""
 
 
 def test_donor_lifetime_combobox_updates_with_layers(make_napari_viewer):
@@ -960,8 +957,7 @@ def test_calculate_donor_lifetime_no_layer_selected(make_napari_viewer):
     # Set frequency for calculations
     widget.frequency_input.setText("80")
 
-    # Should return without error when "None" is selected
-    widget.donor_lifetime_combobox.setCurrentText("None")
+    # Should return without error when no layer is checked
     initial_lifetime = widget.donor_line_edit.text()
 
     widget._calculate_donor_lifetime()
@@ -981,8 +977,8 @@ def test_calculate_donor_lifetime_no_frequency(make_napari_viewer):
     test_layer.name = "test_layer"
     viewer.add_layer(test_layer)
 
-    # Select the layer but don't set frequency
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    # Check the layer but don't set frequency
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
     widget.frequency_input.setText("")  # No frequency
 
     initial_lifetime = widget.donor_line_edit.text()
@@ -1008,7 +1004,7 @@ def test_calculate_donor_lifetime_apparent_phase(make_napari_viewer):
     # Set up parameters
     widget.frequency_input.setText("80")
     widget.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
 
     # Set up parent widget properly
     parent.harmonic = 1
@@ -1039,7 +1035,7 @@ def test_calculate_donor_lifetime_apparent_modulation(make_napari_viewer):
     widget.lifetime_type_combobox.setCurrentText(
         "Apparent Modulation Lifetime"
     )
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
 
     # Set up parent widget properly
     parent.harmonic = 1
@@ -1068,7 +1064,7 @@ def test_calculate_donor_lifetime_normal_lifetime(make_napari_viewer):
     # Set up parameters
     widget.frequency_input.setText("80")
     widget.lifetime_type_combobox.setCurrentText("Normal Lifetime")
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
 
     # Set up parent widget properly
     parent.harmonic = 1
@@ -1097,7 +1093,7 @@ def test_calculate_donor_lifetime_different_harmonics(make_napari_viewer):
     # Set up parameters
     widget.frequency_input.setText("80")
     widget.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
 
     # Test with harmonic 1
     parent.harmonic = 1
@@ -1133,7 +1129,7 @@ def test_calculate_donor_lifetime_mode_differences(make_napari_viewer):
 
     # Set up parameters
     widget.frequency_input.setText("80")
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
     parent.harmonic = 1
 
     # Test apparent phase lifetime
@@ -1174,7 +1170,7 @@ def test_calculate_donor_lifetime_mode_differences(make_napari_viewer):
 def test_donor_lifetime_combobox_layer_selection_persistence(
     make_napari_viewer,
 ):
-    """Test that donor lifetime combobox selection persists when layers change."""
+    """Test that donor lifetime combobox checked selection persists when layers change."""
     viewer = make_napari_viewer()
     parent = PlotterWidget(viewer)
     widget = parent.fret_tab
@@ -1184,33 +1180,34 @@ def test_donor_lifetime_combobox_layer_selection_persistence(
     test_layer1.name = "test_layer1"
     viewer.add_layer(test_layer1)
 
-    # Select first layer
-    widget.donor_lifetime_combobox.setCurrentText("test_layer1")
-    assert widget.donor_lifetime_combobox.currentText() == "test_layer1"
+    # Check first layer
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer1"])
+    assert widget.donor_lifetime_combobox.checkedItems() == ["test_layer1"]
 
     # Add second layer
     test_layer2 = create_image_layer_with_phasors()
     test_layer2.name = "test_layer2"
     viewer.add_layer(test_layer2)
 
-    # Selection should persist
-    assert widget.donor_lifetime_combobox.currentText() == "test_layer1"
+    # Checked selection should persist after combobox refresh
+    assert "test_layer1" in widget.donor_lifetime_combobox.checkedItems()
 
-    # Change to second layer
-    widget.donor_lifetime_combobox.setCurrentText("test_layer2")
-    assert widget.donor_lifetime_combobox.currentText() == "test_layer2"
+    # Switch check to second layer
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer2"])
+    assert widget.donor_lifetime_combobox.checkedItems() == ["test_layer2"]
 
     # Remove first layer
     viewer.layers.remove(test_layer1)
 
-    # Selection should still be test_layer2
-    assert widget.donor_lifetime_combobox.currentText() == "test_layer2"
+    # Checked selection should still be test_layer2
+    assert widget.donor_lifetime_combobox.checkedItems() == ["test_layer2"]
 
     # Remove second layer
     viewer.layers.remove(test_layer2)
 
-    # Should revert to "Select layer..."
-    assert widget.donor_lifetime_combobox.currentText() == "Select layer..."
+    # Should have no checked items and empty display text
+    assert widget.donor_lifetime_combobox.checkedItems() == []
+    assert widget.donor_lifetime_combobox.currentText() == ""
 
 
 def test_calculate_donor_lifetime_error_handling(make_napari_viewer):
@@ -1226,14 +1223,16 @@ def test_calculate_donor_lifetime_error_handling(make_napari_viewer):
     bad_layer = Image(np.random.random((10, 10)), name="bad_layer")
     viewer.add_layer(bad_layer)
 
-    # Try to calculate with bad layer
+    # bad_layer will NOT be added to the CheckableComboBox (no phasor metadata)
+    assert "bad_layer" not in widget.donor_lifetime_combobox.allItems()
+
+    # Calling _calculate_donor_lifetime with no checked layers should be a no-op
     widget.frequency_input.setText("80")
-    widget.donor_lifetime_combobox.setCurrentText("bad_layer")
     parent.harmonic = 1
 
     initial_lifetime = widget.donor_line_edit.text()
 
-    # Should handle error gracefully
+    # Should handle gracefully: no checked layers → no-op
     widget._calculate_donor_lifetime()
 
     # Should not crash and lifetime should remain unchanged
@@ -1241,7 +1240,7 @@ def test_calculate_donor_lifetime_error_handling(make_napari_viewer):
 
 
 def test_donor_source_selector_functionality(make_napari_viewer):
-    """Test the donor source selector switches between Manual and From layer modes."""
+    """Test the donor source selector switches between Manual and From layer(s) modes."""
     viewer = make_napari_viewer()
     parent = PlotterWidget(viewer)
     widget = parent.fret_tab
@@ -1251,11 +1250,11 @@ def test_donor_source_selector_functionality(make_napari_viewer):
     assert widget.donor_stack.currentIndex() == 0  # Manual page
     assert widget.donor_label.text() == "Donor lifetime (ns):"
 
-    # Switch to "From layer" mode
-    widget.donor_source_selector.setCurrentText("From layer")
+    # Switch to "From layer(s)" mode
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
 
-    assert widget.donor_stack.currentIndex() == 1  # From layer page
+    assert widget.donor_stack.currentIndex() == 1  # From layer(s) page
     assert widget.donor_label.text() == "Donor lifetime (ns):"
 
     # Switch back to Manual mode
@@ -1267,7 +1266,7 @@ def test_donor_source_selector_functionality(make_napari_viewer):
 
 
 def test_background_source_selector_functionality(make_napari_viewer):
-    """Test the background source selector switches between Manual and From layer modes."""
+    """Test the background source selector switches between Manual and From layer(s) modes."""
     viewer = make_napari_viewer()
     parent = PlotterWidget(viewer)
     widget = parent.fret_tab
@@ -1277,11 +1276,11 @@ def test_background_source_selector_functionality(make_napari_viewer):
     assert widget.bg_stack.currentIndex() == 0  # Manual page
     assert widget.background_position_label.text() == "Background position:"
 
-    # Switch to "From layer" mode
-    widget.bg_source_selector.setCurrentText("From layer")
+    # Switch to "From layer(s)" mode
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
 
-    assert widget.bg_stack.currentIndex() == 1  # From layer page
+    assert widget.bg_stack.currentIndex() == 1  # From layer(s) page
     assert widget.background_position_label.text() == "Background position:"
 
     # Switch back to Manual mode
@@ -1309,19 +1308,19 @@ def test_donor_lifetime_label_updates_with_layer_calculation(
     widget.frequency_input.setText("80")
     parent.harmonic = 1
 
-    # Switch to "From layer" mode
-    widget.donor_source_selector.setCurrentText("From layer")
+    # Switch to "From layer(s)" mode
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
 
-    # Select the test layer
-    widget.donor_lifetime_combobox.setCurrentText("test_layer")
+    # Check the test layer
+    widget.donor_lifetime_combobox.setCheckedItems(["test_layer"])
 
     # Calculate donor lifetime
     widget._calculate_donor_lifetime()
 
     # Label should now show the calculated lifetime value
     label_text = widget.donor_label.text()
-    assert "Donor lifetime (from layer):" in label_text
+    assert "Donor lifetime (from layer(s)):" in label_text
     assert "ns" in label_text
 
     # Switch back to Manual mode
@@ -1348,12 +1347,12 @@ def test_background_position_label_updates_with_layer_calculation(
     # Set up parameters
     parent.harmonic = 1
 
-    # Switch to "From layer" mode
-    widget.bg_source_selector.setCurrentText("From layer")
+    # Switch to "From layer(s)" mode
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
 
-    # Select the test layer
-    widget.background_image_combobox.setCurrentText("test_layer")
+    # Check the test layer
+    widget.background_image_combobox.setCheckedItems(["test_layer"])
 
     # Calculate background position
     widget._calculate_background_position()
@@ -1388,11 +1387,9 @@ def test_layer_selection_with_no_valid_layers(make_napari_viewer):
     widget._update_donor_lifetime_combobox()
     widget._update_background_combobox()
 
-    # Should only have "Select layer..." option
-    assert widget.donor_lifetime_combobox.count() == 1
-    assert widget.donor_lifetime_combobox.itemText(0) == "Select layer..."
-    assert widget.background_image_combobox.count() == 1
-    assert widget.background_image_combobox.itemText(0) == "Select layer..."
+    # CheckableComboBox: no items added since invalid_layer has no phasor data
+    assert widget.donor_lifetime_combobox.count() == 0
+    assert widget.background_image_combobox.count() == 0
 
 
 def test_calculate_values_with_select_layer_option(make_napari_viewer):
@@ -1405,15 +1402,13 @@ def test_calculate_values_with_select_layer_option(make_napari_viewer):
     widget.frequency_input.setText("80")
     parent.harmonic = 1
 
-    # Switch to From layer modes
-    widget.donor_source_selector.setCurrentText("From layer")
+    # Switch to From layer(s) modes
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
-    widget.bg_source_selector.setCurrentText("From layer")
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
 
-    # Ensure "Select layer..." is selected
-    widget.donor_lifetime_combobox.setCurrentText("Select layer...")
-    widget.background_image_combobox.setCurrentText("Select layer...")
+    # Ensure nothing is checked (comboboxes start empty)
 
     # Store initial values
     initial_donor_text = widget.donor_line_edit.text()
@@ -1445,13 +1440,13 @@ def test_ui_mode_switching_preserves_manual_values(make_napari_viewer):
     widget.background_real_edit.setText("0.3")
     widget.background_imag_edit.setText("0.4")
 
-    # Switch to From layer mode and back
-    widget.donor_source_selector.setCurrentText("From layer")
+    # Switch to From layer(s) mode and back
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
     widget.donor_source_selector.setCurrentText("Manual")
     widget._on_donor_source_changed(0)
 
-    widget.bg_source_selector.setCurrentText("From layer")
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
     widget.bg_source_selector.setCurrentText("Manual")
     widget._on_bg_source_changed(0)
@@ -1627,24 +1622,24 @@ def test_metadata_storage_from_layer_mode(make_napari_viewer):
     widget._on_image_layer_changed()
     widget.frequency_input.setText("80")
 
-    # Switch to From layer mode for donor
-    widget.donor_source_selector.setCurrentText("From layer")
+    # Switch to From layer(s) mode for donor
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
-    widget.donor_lifetime_combobox.setCurrentText("donor_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["donor_layer"])
     widget.lifetime_type_combobox.setCurrentText("Normal Lifetime")
 
-    # Switch to From layer mode for background
-    widget.bg_source_selector.setCurrentText("From layer")
+    # Switch to From layer(s) mode for background
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
-    widget.background_image_combobox.setCurrentText("bg_layer")
+    widget.background_image_combobox.setCheckedItems(["bg_layer"])
 
     # Check metadata
     fret_settings = donor_layer.metadata['settings']['fret']
-    assert fret_settings['donor_source'] == 'From layer'
-    assert fret_settings['donor_layer_name'] == 'donor_layer'
+    assert fret_settings['donor_source'] == 'From layer(s)'
+    assert fret_settings['donor_layer_names'] == ['donor_layer']
     assert fret_settings['donor_lifetime_type'] == 'Normal Lifetime'
-    assert fret_settings['background_source'] == 'From layer'
-    assert fret_settings['background_layer_name'] == 'bg_layer'
+    assert fret_settings['background_source'] == 'From layer(s)'
+    assert fret_settings['background_layer_names'] == ['bg_layer']
 
 
 def test_metadata_restoration_manual_values(make_napari_viewer):
@@ -1787,17 +1782,17 @@ def test_metadata_restoration_from_layer_mode(make_napari_viewer):
     widget._on_image_layer_changed()
     widget.frequency_input.setText("80")
 
-    # Configure From layer mode
-    widget.donor_source_selector.setCurrentText("From layer")
+    # Configure From layer(s) mode
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
-    widget.donor_lifetime_combobox.setCurrentText("donor_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["donor_layer"])
     widget.lifetime_type_combobox.setCurrentText(
         "Apparent Modulation Lifetime"
     )
 
-    widget.bg_source_selector.setCurrentText("From layer")
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
-    widget.background_image_combobox.setCurrentText("bg_layer")
+    widget.background_image_combobox.setCheckedItems(["bg_layer"])
 
     # Switch away and back
     parent.image_layer_with_phasor_features_combobox.setCurrentText("")
@@ -1809,14 +1804,14 @@ def test_metadata_restoration_from_layer_mode(make_napari_viewer):
     widget._on_image_layer_changed()
 
     # Verify restoration
-    assert widget.donor_source_selector.currentText() == "From layer"
-    assert widget.donor_lifetime_combobox.currentText() == "donor_layer"
+    assert widget.donor_source_selector.currentText() == "From layer(s)"
+    assert widget.donor_lifetime_combobox.checkedItems() == ["donor_layer"]
     assert (
         widget.lifetime_type_combobox.currentText()
         == "Apparent Modulation Lifetime"
     )
-    assert widget.bg_source_selector.currentText() == "From layer"
-    assert widget.background_image_combobox.currentText() == "bg_layer"
+    assert widget.bg_source_selector.currentText() == "From layer(s)"
+    assert widget.background_image_combobox.checkedItems() == ["bg_layer"]
 
 
 def test_metadata_restoration_reverts_to_manual_when_layer_missing(
@@ -1841,16 +1836,16 @@ def test_metadata_restoration_reverts_to_manual_when_layer_missing(
     )
     widget._on_image_layer_changed()
 
-    # Configure From layer mode
+    # Configure From layer(s) mode
     widget.frequency_input.setText("80")
     widget.donor_line_edit.setText("2.5")
-    widget.donor_source_selector.setCurrentText("From layer")
+    widget.donor_source_selector.setCurrentText("From layer(s)")
     widget._on_donor_source_changed(1)
-    widget.donor_lifetime_combobox.setCurrentText("donor_layer")
+    widget.donor_lifetime_combobox.setCheckedItems(["donor_layer"])
 
-    widget.bg_source_selector.setCurrentText("From layer")
+    widget.bg_source_selector.setCurrentText("From layer(s)")
     widget._on_bg_source_changed(1)
-    widget.background_image_combobox.setCurrentText("bg_layer")
+    widget.background_image_combobox.setCheckedItems(["bg_layer"])
 
     # Remove the referenced layer
     viewer.layers.remove(bg_layer)
@@ -1867,8 +1862,8 @@ def test_metadata_restoration_reverts_to_manual_when_layer_missing(
     # Background should revert to Manual since bg_layer is missing
     assert widget.bg_source_selector.currentText() == "Manual"
 
-    # Donor should still be From layer since donor_layer exists
-    assert widget.donor_source_selector.currentText() == "From layer"
+    # Donor should still be From layer(s) since donor_layer exists
+    assert widget.donor_source_selector.currentText() == "From layer(s)"
 
 
 def test_metadata_colormap_settings_storage(make_napari_viewer):

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -679,7 +679,7 @@ class CheckableComboBox(QComboBox):
         self.setModel(QStandardItemModel(self))
         self.setEditable(True)
         self.lineEdit().setReadOnly(True)
-        self.lineEdit().setPlaceholderText("Select layers...")
+        self.lineEdit().setPlaceholderText("Select Layers...")
 
         self._enable_primary_layer = enable_primary_layer
 
@@ -943,7 +943,7 @@ class CheckableComboBox(QComboBox):
 
         if not checked:
             line_edit.setText("")
-            line_edit.setPlaceholderText("Select layers...")
+            line_edit.setPlaceholderText("Select Layers...")
         elif len(checked) == 1:
             line_edit.setText(checked[0])
         else:

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ._utils import update_frequency_in_metadata
+from ._utils import CheckableComboBox, update_frequency_in_metadata
 
 
 class FretWidget(QWidget):
@@ -110,7 +110,7 @@ class FretWidget(QWidget):
         # Donor lifetime source selector
         donor_source_row = QHBoxLayout()
         self.donor_source_selector = QComboBox()
-        self.donor_source_selector.addItems(["Manual", "From layer"])
+        self.donor_source_selector.addItems(["Manual", "From layer(s)"])
         self.donor_source_selector.setMinimumContentsLength(8)
         self.donor_source_selector.setSizeAdjustPolicy(
             QComboBox.AdjustToMinimumContentsLengthWithIcon
@@ -152,16 +152,14 @@ class FretWidget(QWidget):
         donor_layer_layout = QHBoxLayout(donor_layer_page)
         donor_layer_layout.setContentsMargins(0, 0, 0, 0)
 
-        self.donor_lifetime_combobox = QComboBox()
-        self.donor_lifetime_combobox.setMinimumContentsLength(8)
-        self.donor_lifetime_combobox.setSizeAdjustPolicy(
-            QComboBox.AdjustToMinimumContentsLengthWithIcon
+        self.donor_lifetime_combobox = CheckableComboBox(
+            enable_primary_layer=False
         )
-        self.donor_lifetime_combobox.currentIndexChanged.connect(
+        self.donor_lifetime_combobox.selectionChanged.connect(
             self._calculate_donor_lifetime
         )
         self.donor_lifetime_combobox.setToolTip(
-            "Select the layer from which to derive the donor lifetime"
+            "Select one or more layers from which to derive the donor lifetime (averaged)"
         )
         self.lifetime_type_combobox = QComboBox()
         self.lifetime_type_combobox.setMinimumContentsLength(8)
@@ -213,7 +211,7 @@ class FretWidget(QWidget):
         # Background position source selector
         bg_source_row = QHBoxLayout()
         self.bg_source_selector = QComboBox()
-        self.bg_source_selector.addItems(["Manual", "From layer"])
+        self.bg_source_selector.addItems(["Manual", "From layer(s)"])
         self.bg_source_selector.setMinimumContentsLength(8)
         self.bg_source_selector.setSizeAdjustPolicy(
             QComboBox.AdjustToMinimumContentsLengthWithIcon
@@ -265,16 +263,14 @@ class FretWidget(QWidget):
         bg_image_layout = QHBoxLayout(bg_image_page)
         bg_image_layout.setContentsMargins(0, 0, 0, 0)
 
-        self.background_image_combobox = QComboBox()
-        self.background_image_combobox.setMinimumContentsLength(8)
-        self.background_image_combobox.setSizeAdjustPolicy(
-            QComboBox.AdjustToMinimumContentsLengthWithIcon
+        self.background_image_combobox = CheckableComboBox(
+            enable_primary_layer=False
         )
-        self.background_image_combobox.currentIndexChanged.connect(
+        self.background_image_combobox.selectionChanged.connect(
             self._calculate_background_position
         )
         self.background_image_combobox.setToolTip(
-            "Select the layer from which to derive the background position"
+            "Select one or more layers from which to derive the background position (averaged)"
         )
         bg_image_layout.addWidget(self.background_image_combobox)
         self.bg_stack.addWidget(bg_image_page)
@@ -355,7 +351,7 @@ class FretWidget(QWidget):
             not hasattr(self, '_updating_settings')
             or not self._updating_settings
         ):
-            source_text = 'Manual' if index == 0 else 'From layer'
+            source_text = 'Manual' if index == 0 else 'From layer(s)'
             self._update_fret_setting_in_metadata('donor_source', source_text)
 
         if index == 1:
@@ -375,7 +371,7 @@ class FretWidget(QWidget):
             not hasattr(self, '_updating_settings')
             or not self._updating_settings
         ):
-            source_text = 'Manual' if index == 0 else 'From layer'
+            source_text = 'Manual' if index == 0 else 'From layer(s)'
             self._update_fret_setting_in_metadata(
                 'background_source', source_text
             )
@@ -634,11 +630,9 @@ class FretWidget(QWidget):
         self._updating_background_combobox = True
 
         try:
-            current_text = self.background_image_combobox.currentText()
+            previously_checked = self.background_image_combobox.checkedItems()
             self.background_image_combobox.blockSignals(True)
             self.background_image_combobox.clear()
-
-            self.background_image_combobox.addItem("Select layer...")
 
             layer_names = [
                 layer.name
@@ -646,16 +640,13 @@ class FretWidget(QWidget):
                 if isinstance(layer, Image)
                 and "G" in layer.metadata
                 and "S" in layer.metadata
+                and "G_original" in layer.metadata
+                and "S_original" in layer.metadata
             ]
 
-            self.background_image_combobox.addItems(layer_names)
-
-            if current_text in layer_names:
-                index = self.background_image_combobox.findText(current_text)
-                if index >= 0:
-                    self.background_image_combobox.setCurrentIndex(index)
-            elif current_text == "Select layer..." or current_text == "":
-                self.background_image_combobox.setCurrentIndex(0)
+            for name in layer_names:
+                checked = name in previously_checked
+                self.background_image_combobox.addItem(name, checked)
 
             self.background_image_combobox.blockSignals(False)
 
@@ -680,11 +671,9 @@ class FretWidget(QWidget):
         self._updating_donor_combobox = True
 
         try:
-            current_text = self.donor_lifetime_combobox.currentText()
+            previously_checked = self.donor_lifetime_combobox.checkedItems()
             self.donor_lifetime_combobox.blockSignals(True)
             self.donor_lifetime_combobox.clear()
-
-            self.donor_lifetime_combobox.addItem("Select layer...")
 
             layer_names = [
                 layer.name
@@ -692,16 +681,13 @@ class FretWidget(QWidget):
                 if isinstance(layer, Image)
                 and "G" in layer.metadata
                 and "S" in layer.metadata
+                and "G_original" in layer.metadata
+                and "S_original" in layer.metadata
             ]
 
-            self.donor_lifetime_combobox.addItems(layer_names)
-
-            if current_text in layer_names:
-                index = self.donor_lifetime_combobox.findText(current_text)
-                if index >= 0:
-                    self.donor_lifetime_combobox.setCurrentIndex(index)
-            elif current_text == "Select layer..." or current_text == "":
-                self.donor_lifetime_combobox.setCurrentIndex(0)
+            for name in layer_names:
+                checked = name in previously_checked
+                self.donor_lifetime_combobox.addItem(name, checked)
 
             self.donor_lifetime_combobox.blockSignals(False)
 
@@ -726,12 +712,13 @@ class FretWidget(QWidget):
         self._update_donor_lifetime_combobox()
 
     def _calculate_background_position(self):
-        """Calculate the background position from selected background image layer for all harmonics."""
-        background_layer_name = self.background_image_combobox.currentText()
-        if (
-            not background_layer_name
-            or background_layer_name == "Select layer..."
-        ):
+        """Calculate the background position from selected background image layers for all harmonics.
+
+        When multiple layers are selected, the phasor center is computed for each layer
+        and the results are averaged across all selected layers.
+        """
+        selected_layer_names = self.background_image_combobox.checkedItems()
+        if not selected_layer_names:
             if self.bg_source_selector.currentIndex() == 1:
                 self.background_position_label.setText("Background position:")
             return
@@ -741,53 +728,66 @@ class FretWidget(QWidget):
             or not self._updating_settings
         ):
             self._update_fret_setting_in_metadata(
-                'background_layer_name', background_layer_name
+                'background_layer_names', selected_layer_names
             )
 
-        try:
-            background_layer = self.viewer.layers[background_layer_name]
-            # Retrieve arrays from metadata
-            g_array = background_layer.metadata.get("G")
-            s_array = background_layer.metadata.get("S")
-            harmonics = background_layer.metadata.get("harmonics")
-            mean = background_layer.metadata.get("original_mean")
+        # Collect phasor centers per harmonic across all selected layers
+        positions_by_harmonic = {}  # harmonic -> list of (real, imag)
 
-            if g_array is None or s_array is None or harmonics is None:
-                raise ValueError("Missing phasor data")
+        for background_layer_name in selected_layer_names:
+            try:
+                background_layer = self.viewer.layers[background_layer_name]
+                g_array = background_layer.metadata.get("G")
+                s_array = background_layer.metadata.get("S")
+                harmonics = background_layer.metadata.get("harmonics")
+                mean = background_layer.metadata.get("original_mean")
 
-        except (KeyError, AttributeError, ValueError):
+                if g_array is None or s_array is None or harmonics is None:
+                    continue
+
+            except (KeyError, AttributeError):
+                continue
+
+            harmonics = np.atleast_1d(harmonics)
+            for harmonic in harmonics:
+                try:
+                    harmonic_idx = np.where(harmonics == harmonic)[0]
+                    if len(harmonic_idx) == 0:
+                        continue
+                    harmonic_idx = harmonic_idx[0]
+
+                    if g_array.ndim >= 3:
+                        real = g_array[harmonic_idx]
+                        imag = s_array[harmonic_idx]
+                    else:
+                        real = g_array
+                        imag = s_array
+
+                    _, center_real, center_imag = phasor_center(
+                        mean, real, imag
+                    )
+
+                    if harmonic not in positions_by_harmonic:
+                        positions_by_harmonic[harmonic] = []
+                    positions_by_harmonic[harmonic].append(
+                        (center_real, center_imag)
+                    )
+                except Exception:
+                    continue
+
+        if not positions_by_harmonic:
             if self.bg_source_selector.currentIndex() == 1:
                 self.background_position_label.setText("Background position:")
             return
 
-        # Ensure harmonics is at least 1D for iteration and np.where
-        harmonics = np.atleast_1d(harmonics)
-        unique_harmonics = harmonics
-
-        for harmonic in unique_harmonics:
-            try:
-                harmonic_idx = np.where(harmonics == harmonic)[0]
-
-                if len(harmonic_idx) == 0:
-                    continue
-
-                harmonic_idx = harmonic_idx[0]
-
-                if g_array.ndim >= 3:
-                    real = g_array[harmonic_idx]
-                    imag = s_array[harmonic_idx]
-                else:
-                    real = g_array
-                    imag = s_array
-
-                _, center_real, center_imag = phasor_center(mean, real, imag)
-
-                self.background_positions_by_harmonic[harmonic] = {
-                    'real': center_real,
-                    'imag': center_imag,
-                }
-            except Exception:
-                continue
+        # Average positions across layers for each harmonic
+        for harmonic, coords in positions_by_harmonic.items():
+            avg_real = float(np.mean([c[0] for c in coords]))
+            avg_imag = float(np.mean([c[1] for c in coords]))
+            self.background_positions_by_harmonic[harmonic] = {
+                'real': avg_real,
+                'imag': avg_imag,
+            }
 
         if (
             not hasattr(self, '_updating_settings')
@@ -824,9 +824,13 @@ class FretWidget(QWidget):
         self.plot_donor_trajectory()
 
     def _calculate_donor_lifetime(self):
-        """Calculate the donor lifetime from selected layer for current harmonic."""
-        donor_layer_name = self.donor_lifetime_combobox.currentText()
-        if not donor_layer_name or donor_layer_name == "Select layer...":
+        """Calculate the donor lifetime from selected layers for current harmonic.
+
+        When multiple layers are selected, the phasor center is computed for each layer
+        and the resulting lifetimes are averaged.
+        """
+        selected_layer_names = self.donor_lifetime_combobox.checkedItems()
+        if not selected_layer_names:
             if self.donor_source_selector.currentIndex() == 1:
                 self.donor_label.setText("Donor lifetime (ns):")
             return
@@ -836,113 +840,105 @@ class FretWidget(QWidget):
             or not self._updating_settings
         ):
             self._update_fret_setting_in_metadata(
-                'donor_layer_name', donor_layer_name
+                'donor_layer_names', selected_layer_names
             )
 
-        try:
-            donor_layer = self.viewer.layers[donor_layer_name]
-            # Retrieve arrays from metadata
-            g_array = donor_layer.metadata.get("G")
-            s_array = donor_layer.metadata.get("S")
-            harmonics = donor_layer.metadata.get("harmonics")
-            mean = donor_layer.metadata.get("original_mean")
-
-            if g_array is None or s_array is None or harmonics is None:
-                raise ValueError("Missing phasor data")
-
-        except (KeyError, AttributeError, ValueError):
+        if not self.frequency_input.text():
             if self.donor_source_selector.currentIndex() == 1:
                 self.donor_label.setText("Donor lifetime (ns):")
+            return
+
+        try:
+            frequency = float(self.frequency_input.text().strip())
+        except ValueError:
             return
 
         current_harmonic = self.parent_widget.harmonic
+        lifetime_type = self.lifetime_type_combobox.currentText()
 
-        try:
-            # Ensure harmonics is at least 1D for np.where
-            harmonics = np.atleast_1d(harmonics)
-            harmonic_idx = np.where(harmonics == current_harmonic)[0]
+        if (
+            not hasattr(self, '_updating_settings')
+            or not self._updating_settings
+        ):
+            self._update_fret_setting_in_metadata(
+                'donor_lifetime_type', lifetime_type
+            )
 
-            if len(harmonic_idx) == 0:
-                if self.donor_source_selector.currentIndex() == 1:
-                    self.donor_label.setText("Donor lifetime (ns):")
-                return
+        lifetimes = []
+        for donor_layer_name in selected_layer_names:
+            try:
+                donor_layer = self.viewer.layers[donor_layer_name]
+                g_array = donor_layer.metadata.get("G")
+                s_array = donor_layer.metadata.get("S")
+                harmonics = donor_layer.metadata.get("harmonics")
+                mean = donor_layer.metadata.get("original_mean")
 
-            harmonic_idx = harmonic_idx[0]
+                if g_array is None or s_array is None or harmonics is None:
+                    continue
 
-            if g_array.ndim == 3:
-                real = g_array[harmonic_idx]
-                imag = s_array[harmonic_idx]
-            else:
-                real = g_array
-                imag = s_array
+                harmonics = np.atleast_1d(harmonics)
+                harmonic_idx = np.where(harmonics == current_harmonic)[0]
 
-        except IndexError:
+                if len(harmonic_idx) == 0:
+                    continue
+
+                harmonic_idx = harmonic_idx[0]
+
+                if g_array.ndim == 3:
+                    real = g_array[harmonic_idx]
+                    imag = s_array[harmonic_idx]
+                else:
+                    real = g_array
+                    imag = s_array
+
+                _, center_real, center_imag = phasor_center(mean, real, imag)
+
+                if lifetime_type in (
+                    "Apparent Phase Lifetime",
+                    "Apparent Modulation Lifetime",
+                ):
+                    phase_lifetime, mod_lifetime = phasor_to_apparent_lifetime(
+                        center_real, center_imag, frequency=frequency
+                    )
+                    lifetime = {
+                        "Apparent Phase Lifetime": phase_lifetime,
+                        "Apparent Modulation Lifetime": mod_lifetime,
+                    }[lifetime_type]
+                elif lifetime_type == "Normal Lifetime":
+                    lifetime = phasor_to_normal_lifetime(
+                        center_real, center_imag, frequency=frequency
+                    )
+                else:
+                    continue
+
+                lifetimes.append(float(lifetime))
+
+            except Exception:
+                continue
+
+        if not lifetimes:
             if self.donor_source_selector.currentIndex() == 1:
                 self.donor_label.setText("Donor lifetime (ns):")
             return
 
-        try:
-            _, center_real, center_imag = phasor_center(mean, real, imag)
+        avg_lifetime = float(np.mean(lifetimes))
+        self.donor_line_edit.setText(f"{avg_lifetime:.2f}")
+        self.donor_lifetime = avg_lifetime
 
-            if not self.frequency_input.text():
-                if self.donor_source_selector.currentIndex() == 1:
-                    self.donor_label.setText("Donor lifetime (ns):")
-                return
+        if (
+            not hasattr(self, '_updating_settings')
+            or not self._updating_settings
+        ):
+            self._update_fret_setting_in_metadata(
+                'donor_lifetime', avg_lifetime
+            )
 
-            frequency = float(self.frequency_input.text().strip())
+        if self.donor_source_selector.currentIndex() == 1:
+            self.donor_label.setText(
+                f"Donor lifetime (from layer(s)): {avg_lifetime:.2f} ns"
+            )
 
-            lifetime_type = self.lifetime_type_combobox.currentText()
-
-            if (
-                not hasattr(self, '_updating_settings')
-                or not self._updating_settings
-            ):
-                self._update_fret_setting_in_metadata(
-                    'donor_lifetime_type', lifetime_type
-                )
-
-            if lifetime_type in (
-                "Apparent Phase Lifetime",
-                "Apparent Modulation Lifetime",
-            ):
-                phase_lifetime, mod_lifetime = phasor_to_apparent_lifetime(
-                    center_real, center_imag, frequency=frequency
-                )
-                lifetime = {
-                    "Apparent Phase Lifetime": phase_lifetime,
-                    "Apparent Modulation Lifetime": mod_lifetime,
-                }[lifetime_type]
-            elif lifetime_type == "Normal Lifetime":
-                lifetime = phasor_to_normal_lifetime(
-                    center_real, center_imag, frequency=frequency
-                )
-            else:
-                if self.donor_source_selector.currentIndex() == 1:
-                    self.donor_label.setText("Donor lifetime (ns):")
-                return
-
-            self.donor_line_edit.setText(f"{lifetime:.2f}")
-            self.donor_lifetime = lifetime
-
-            if (
-                not hasattr(self, '_updating_settings')
-                or not self._updating_settings
-            ):
-                self._update_fret_setting_in_metadata(
-                    'donor_lifetime', lifetime
-                )
-
-            if self.donor_source_selector.currentIndex() == 1:
-                self.donor_label.setText(
-                    f"Donor lifetime (from layer): {lifetime:.2f} ns"
-                )
-
-            self.plot_donor_trajectory()
-
-        except Exception as e:
-            show_error(f"Error calculating donor lifetime: {str(e)}")
-            if self.donor_source_selector.currentIndex() == 1:
-                self.donor_label.setText("Donor lifetime (ns): Error")
+        self.plot_donor_trajectory()
 
     def plot_donor_trajectory(self):
         """Plot the donor trajectory with current parameters."""
@@ -1207,10 +1203,10 @@ class FretWidget(QWidget):
                 'colormap_changed': False,
             },
             'donor_source': 'Manual',
-            'donor_layer_name': None,
+            'donor_layer_names': [],
             'donor_lifetime_type': 'Apparent Phase Lifetime',
             'background_source': 'Manual',
-            'background_layer_name': None,
+            'background_layer_names': [],
         }
 
     def _update_fret_setting_in_metadata(self, key_path, value):
@@ -1307,23 +1303,24 @@ class FretWidget(QWidget):
                 self.colormap_checkbox.setChecked(self.use_colormap)
 
             donor_source = settings.get('donor_source', 'Manual')
-            donor_layer_name = settings.get('donor_layer_name', None)
+            # Support both old single-name format and new list format
+            donor_layer_names_raw = settings.get('donor_layer_names', None)
+            if donor_layer_names_raw is None:
+                old_name = settings.get('donor_layer_name', None)
+                donor_layer_names_raw = [old_name] if old_name else []
+            donor_layer_names = [
+                n for n in donor_layer_names_raw if n in self.viewer.layers
+            ]
             donor_lifetime_type = settings.get(
                 'donor_lifetime_type', 'Apparent Phase Lifetime'
             )
 
-            donor_layer_exists = (
-                donor_layer_name is not None
-                and donor_layer_name in self.viewer.layers
-                and donor_layer_name != "Select layer..."
-            )
-
-            if donor_source == 'From layer' and donor_layer_exists:
+            if (
+                donor_source in ('From layer', 'From layer(s)')
+                and donor_layer_names
+            ):
                 self.donor_source_selector.setCurrentIndex(1)
-                index = self.donor_lifetime_combobox.findText(donor_layer_name)
-                if index >= 0:
-                    self.donor_lifetime_combobox.setCurrentIndex(index)
-
+                self.donor_lifetime_combobox.setCheckedItems(donor_layer_names)
                 type_index = self.lifetime_type_combobox.findText(
                     donor_lifetime_type
                 )
@@ -1337,21 +1334,27 @@ class FretWidget(QWidget):
                     )
 
             background_source = settings.get('background_source', 'Manual')
-            background_layer_name = settings.get('background_layer_name', None)
-
-            background_layer_exists = (
-                background_layer_name is not None
-                and background_layer_name in self.viewer.layers
-                and background_layer_name != "Select layer..."
+            # Support both old single-name format and new list format
+            background_layer_names_raw = settings.get(
+                'background_layer_names', None
             )
+            if background_layer_names_raw is None:
+                old_name = settings.get('background_layer_name', None)
+                background_layer_names_raw = [old_name] if old_name else []
+            background_layer_names = [
+                n
+                for n in background_layer_names_raw
+                if n in self.viewer.layers
+            ]
 
-            if background_source == 'From layer' and background_layer_exists:
+            if (
+                background_source in ('From layer', 'From layer(s)')
+                and background_layer_names
+            ):
                 self.bg_source_selector.setCurrentIndex(1)
-                index = self.background_image_combobox.findText(
-                    background_layer_name
+                self.background_image_combobox.setCheckedItems(
+                    background_layer_names
                 )
-                if index >= 0:
-                    self.background_image_combobox.setCurrentIndex(index)
             else:
                 self.bg_source_selector.setCurrentIndex(0)
 


### PR DESCRIPTION
This PR proposes changes to the FRET tab, particularly the comboboxes to select donor and background layers now were replaced with the Checkable Combobox class from the _utils module to be able to select more than one layer. When more than one layer is selected, te average values for all selected layers are used to populate the edit fields used for the FRET analysis. 

**Test logic and assertions updated for CheckableComboBox:**

* All tests now use `setCheckedItems()` and `checkedItems()` instead of `setCurrentText()` and `currentText()` for selecting layers in `donor_lifetime_combobox` and `background_image_combobox`. Tests no longer expect placeholder items like "Select layer..." and instead check for empty states or checked items as appropriate. [[1]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL42-R43) [[2]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL892-R891) [[3]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1187-R1210) [[4]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1391-R1392)

* Tests for behavior when no valid layers are present or no items are checked have been updated to assert that the comboboxes are empty and that the UI handles these cases gracefully without errors. [[1]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL963-R960) [[2]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1229-R1243) [[3]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1408-R1411)

**UI mode and label updates:**

* Test descriptions and assertions have been updated to refer to "From layer(s)" mode, reflecting the new multi-selection capability, and label assertions have been changed accordingly. [[1]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL178-R185) [[2]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1254-R1257) [[3]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1270-R1269) [[4]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1280-R1283) [[5]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1312-R1323) [[6]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1351-R1355) [[7]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1448-R1449) [[8]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1630-R1642)

**Persistence and error handling improvements:**

* Tests for selection persistence now check that checked items persist across layer changes and that the UI reverts to an empty state when all layers are removed. [[1]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1177-R1173) [[2]](diffhunk://#diff-8f6c6c020d62abea63a4ffe23431ba595c2042ca34d95c3acd38e4bbd0dce3edL1187-R1210)

* Error handling tests ensure that invalid layers (without required metadata) are not added to the comboboxes and that calculations are no-ops when no valid layers are checked.

**Metadata and settings validation:**

* Tests for metadata storage and restoration have been updated to check for new keys and values reflecting multi-selection, such as `donor_layer_names` and `background_layer_names` instead of singular names.