### PR TITLE
fix: resolve all ruff lint warnings and enable ruff in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,8 @@ repos:
       - id: isort
         args: ["--settings-path", "pyproject.toml"]
 
-  # NOTE: ruff is configured in pyproject.toml but intentionally NOT included
-  # as a pre-commit hook yet. The existing codebase has ~280 pre-existing
-  # warnings that would block commits on unrelated files. Once those are
-  # cleaned up, uncomment the block below to enforce ruff on every commit.
-  #
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: v0.8.6
-  #   hooks:
-  #     - id: ruff
-  #       args: ["--config", "pyproject.toml", "--fix"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
+    hooks:
+      - id: ruff
+        args: ["--config", "pyproject.toml", "--fix"]

--- a/README.md
+++ b/README.md
@@ -219,34 +219,20 @@ the coverage at least stays the same before you submit a pull request.
 
 ### Pre-commit Hooks
 
-This project uses [pre-commit](https://pre-commit.com/) to run **black**
-and **isort** automatically on every commit. To set it up:
+This project uses [pre-commit](https://pre-commit.com/) to run **black**,
+**isort**, and **ruff** automatically on every commit. To set it up:
 
 ```bash
 pip install pre-commit
 pre-commit install
 ```
 
-From now on, every `git commit` will auto-format your code before the
-commit goes through. You can also run the hooks manually on all files:
+From now on, every `git commit` will auto-format and lint your code before
+the commit goes through. You can also run the hooks manually on all files:
 
 ```bash
 pre-commit run --all-files
 ```
-
-#### Ruff
-
-The project also has a [ruff](https://docs.astral.sh/ruff/) configuration in
-`pyproject.toml`. Ruff is **not** enforced in pre-commit yet because the
-existing codebase has ~280 pre-existing warnings that would block commits on
-unrelated files. You can run it manually to check your changes:
-
-```bash
-ruff check src/napari_phasors/ --config pyproject.toml
-```
-
-Once the legacy warnings are cleaned up, ruff will be added to the
-pre-commit hooks. Incremental lint fixes in PRs are welcome.
 
 ## License
 

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -9,14 +9,13 @@ import inspect
 import itertools
 import json
 import os
-from typing import Any, Callable, Optional, Sequence, Union
+from collections.abc import Callable, Sequence
+from typing import Any, Union
 
 import numpy as np
-import pandas as pd
 import phasorpy.io as io
 import tifffile
 import xarray as xr
-from napari.layers import Labels
 from napari.utils.colormaps.colormap_utils import CYMRGB, MAGENTA_GREEN
 from napari.utils.notifications import show_error
 from phasorpy.phasor import phasor_from_signal
@@ -92,9 +91,9 @@ when calculating phasor coordinates in the file.
 
 def napari_get_reader(
     path: str,
-    reader_options: Optional[dict] = None,
+    reader_options: dict | None = None,
     harmonics: Union[int, Sequence[int], None] = None,
-) -> Optional[Callable]:
+) -> Callable | None:
     """Initial reader function to map file extension to
     specific reader functions.
 
@@ -134,7 +133,7 @@ def napari_get_reader(
 
 def raw_file_reader(
     path: str,
-    reader_options: Optional[dict] = None,
+    reader_options: dict | None = None,
     harmonics: Union[int, Sequence[int], None] = None,
 ) -> list[tuple]:
     """Read raw data files from supported file formats and apply the phasor
@@ -193,7 +192,7 @@ def raw_file_reader(
     if (
         file_extension != '.fbd'
         and hasattr(raw_data, "attrs")
-        and 'frequency' in raw_data.attrs.keys()
+        and 'frequency' in raw_data.attrs
     ):
         settings['frequency'] = raw_data.attrs['frequency']
 
@@ -302,7 +301,7 @@ def raw_file_reader(
     # Set colormaps if multichannel image
     if len(layers) == 2:
         # add colormaps MAGENTA_GREEN
-        for layer, cmap in zip(layers, MAGENTA_GREEN):
+        for layer, cmap in zip(layers, MAGENTA_GREEN, strict=False):
             layer[1]["colormap"] = cmap
             layer[1]['blending'] = 'additive'
     elif len(layers) > 2:
@@ -316,7 +315,7 @@ def raw_file_reader(
 
 def processed_file_reader(
     path: str,
-    reader_options: Optional[dict[str, str]] = None,
+    reader_options: dict[str, str] | None = None,
     harmonics: Union[int, Sequence[int], None] = None,
 ) -> list[tuple]:
     """Reader function for files that contain processed images, as phasor
@@ -352,7 +351,7 @@ def processed_file_reader(
     mean_intensity_image, real, imag, attrs = extension_mapping["processed"][
         file_extension
     ](path, reader_options)
-    if "description" in attrs.keys():
+    if "description" in attrs:
         # HTML-unescape the description to handle tifffile HTML encoding
         description_str = html.unescape(attrs["description"])
         description = json.loads(description_str)
@@ -360,11 +359,11 @@ def processed_file_reader(
             raise ValueError("Description dictionary is too large.")
         if "napari_phasors_settings" in description:
             settings = json.loads(description["napari_phasors_settings"])
-            if "calibrated" in settings.keys():
+            if "calibrated" in settings:
                 settings["calibrated"] = bool(settings["calibrated"])
     else:
         settings = {}
-    if "frequency" in attrs.keys():
+    if "frequency" in attrs:
         settings["frequency"] = attrs["frequency"]
     harmonics_read = attrs.get("harmonic", None)
 
@@ -377,7 +376,7 @@ def processed_file_reader(
     threshold_value = 0
     threshold_upper_value = None
 
-    if "filter" in settings.keys():
+    if "filter" in settings:
         filter_settings = settings["filter"]
         if filter_settings.get("repeat", 0) > 0:
             should_apply_processing = True
@@ -389,12 +388,12 @@ def processed_file_reader(
                 "levels": filter_settings.get("levels", 3),
             }
 
-    if "threshold" in settings.keys() and settings["threshold"] is not None:
+    if "threshold" in settings and settings["threshold"] is not None:
         should_apply_processing = True
         threshold_value = settings["threshold"]
 
     if (
-        "threshold_upper" in settings.keys()
+        "threshold_upper" in settings
         and settings["threshold_upper"] is not None
     ):
         should_apply_processing = True
@@ -451,7 +450,7 @@ def _parse_and_call_io_function(
     path: str,
     func: Callable,
     args_defaults: dict[str, Any],
-    reader_options: Optional[dict[str, Any]] = None,
+    reader_options: dict[str, Any] | None = None,
 ) -> Any:
     """Private helper function to parse arguments and call a `io` function.
 
@@ -517,8 +516,5 @@ def _get_filename_extension(path: str) -> tuple[str, str]:
     """
     filename = os.path.basename(path)
     parts = filename.split(".", 1)
-    if len(parts) > 1:
-        file_extension = "." + parts[1]
-    else:
-        file_extension = ""
+    file_extension = "." + parts[1] if len(parts) > 1 else ""
     return parts[0], file_extension.lower()

--- a/src/napari_phasors/_synthetic_generator.py
+++ b/src/napari_phasors/_synthetic_generator.py
@@ -6,7 +6,7 @@ from phasorpy.phasor import phasor_from_signal
 def make_raw_flim_data(
     n_time_bins=1000,
     shape=(2, 5),
-    time_constants=[0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50],
+    time_constants=None,
     laser_frequency=40.0,
 ):
     """Generate a synthetic FLIM data with exponential decay for each pixel.
@@ -27,6 +27,8 @@ def make_raw_flim_data(
     raw_flim_data : np.ndarray
         A synthetic FLIM data with exponential decay for each pixel. The shape of the array is (n_time_bins, shape[0], shape[1]).
     """
+    if time_constants is None:
+        time_constants = [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50]
     n_pixels = np.prod(shape)
     # Ensure time_constants length matches the number of samples by repeating the whole list
     time_constants = np.tile(

--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest

--- a/src/napari_phasors/_tests/test_filter_tab.py
+++ b/src/napari_phasors/_tests/test_filter_tab.py
@@ -134,7 +134,7 @@ def test_filter_widget_initialization_values(make_napari_viewer):
     scroll_areas = filter_widget.findChildren(QScrollArea)
     assert len(scroll_areas) == 1
     scroll_area = scroll_areas[0]
-    assert scroll_area.widgetResizable() == True
+    assert scroll_area.widgetResizable()
 
     # Test initial visibility of filter widgets
     assert filter_widget.median_filter_widget.isHidden()
@@ -259,19 +259,6 @@ def create_image_layer_with_incompatible_harmonics():
     """Create an image layer with incompatible harmonics for wavelet filtering."""
     layer = create_image_layer_with_phasors()
 
-    phasor_features = layer.metadata['phasor_features_labels_layer']
-
-    num_pixels = len(phasor_features.features['harmonic'])
-    incompatible_harmonics = np.random.choice([1, 3, 5], size=num_pixels)
-    phasor_features.features['harmonic'] = incompatible_harmonics
-
-    return layer
-
-
-def create_image_layer_with_incompatible_harmonics():
-    """Create an image layer with incompatible harmonics for wavelet filtering."""
-    layer = create_image_layer_with_phasors()
-
     # Update harmonics in the new array-based metadata structure
     # Incompatible harmonics are non-consecutive (e.g., [1, 3, 5] instead of [1, 2])
     layer.metadata['harmonics'] = [1, 3, 5]
@@ -375,7 +362,7 @@ def test_apply_button_with_median_filter(make_napari_viewer):
         patch(
             'napari_phasors.filter_tab.apply_filter_and_threshold'
         ) as mock_apply,
-        patch.object(parent, 'plot') as mock_plot,
+        patch.object(parent, 'plot'),
     ):
         filter_widget.apply_button_clicked()
 

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -335,7 +335,7 @@ def test_calculate_fret_efficiency_with_layer(make_napari_viewer):
     widget.calculate_fret_efficiency_button.click()
 
     # Check that a FRET layer was added
-    fret_layer_name = f"FRET efficiency: test_layer"
+    fret_layer_name = "FRET efficiency: test_layer"
     assert fret_layer_name in [layer.name for layer in viewer.layers]
     assert widget.fret_layer is not None
 
@@ -433,7 +433,7 @@ def test_colormap_events(make_napari_viewer):
     # Calculate FRET efficiency to create the FRET layer
     widget.calculate_fret_efficiency_button.click()
 
-    fret_layer_name = f"FRET efficiency: test_layer"
+    fret_layer_name = "FRET efficiency: test_layer"
     assert fret_layer_name in [layer.name for layer in viewer.layers]
 
     # Get the created FRET layer
@@ -531,7 +531,7 @@ def test_fret_widget_layer_replacement(make_napari_viewer):
     # Calculate FRET efficiency first time
     widget.calculate_fret_efficiency_button.click()
 
-    fret_layer_name = f"FRET efficiency: test_layer"
+    fret_layer_name = "FRET efficiency: test_layer"
     assert fret_layer_name in [layer.name for layer in viewer.layers]
 
     # Count layers before second calculation
@@ -737,7 +737,7 @@ def test_fret_efficiency_calculation_with_harmonics(make_napari_viewer):
     widget._on_harmonic_changed()
     widget.calculate_fret_efficiency_button.click()
 
-    fret_layer_name_h1 = f"FRET efficiency: test_layer"
+    fret_layer_name_h1 = "FRET efficiency: test_layer"
     assert fret_layer_name_h1 in [layer.name for layer in viewer.layers]
     fret_data_h1 = viewer.layers[fret_layer_name_h1].data.copy()
 
@@ -874,7 +874,7 @@ def test_calculate_fret_efficiency_invalid_inputs(
 
     assert len(viewer.layers) == initial_layer_count
 
-    fret_layer_name = f"FRET efficiency: test_layer"
+    fret_layer_name = "FRET efficiency: test_layer"
     assert fret_layer_name not in [layer.name for layer in viewer.layers]
 
     assert widget.fret_layer is None

--- a/src/napari_phasors/_tests/test_import_export_settings.py
+++ b/src/napari_phasors/_tests/test_import_export_settings.py
@@ -279,7 +279,7 @@ def test_import_with_calibration(make_napari_viewer):
     plotter._copy_metadata_from_layer("layer2", ['calibration_tab'])
 
     # Verify calibration settings were imported
-    assert layer1.metadata['settings'].get('calibrated') == True
+    assert layer1.metadata['settings'].get('calibrated')
     assert layer1.metadata['settings'].get('calibration_phase') == 0.5
     assert layer1.metadata['settings'].get('calibration_modulation') == 0.9
 
@@ -504,7 +504,7 @@ def test_show_import_dialog_all_options(make_napari_viewer):
         mock_dialog_class.return_value = mock_dialog_instance
 
         # Mock the layout to avoid type errors
-        with patch('napari_phasors.plotter.QVBoxLayout') as mock_layout:
+        with patch('napari_phasors.plotter.QVBoxLayout'):
             result = plotter._show_import_dialog()
 
             # Should return empty list when dialog is rejected
@@ -521,10 +521,10 @@ def test_show_import_dialog_default_all_checked(make_napari_viewer):
 
     with (
         patch('napari_phasors.plotter.QDialog') as mock_dialog,
-        patch('napari_phasors.plotter.QVBoxLayout') as mock_layout,
-        patch('napari_phasors.plotter.QLabel') as mock_label,
+        patch('napari_phasors.plotter.QVBoxLayout'),
+        patch('napari_phasors.plotter.QLabel'),
         patch('napari_phasors.plotter.QCheckBox') as mock_checkbox,
-        patch('napari_phasors.plotter.QDialogButtonBox') as mock_buttonbox,
+        patch('napari_phasors.plotter.QDialogButtonBox'),
     ):
 
         mock_dialog_instance = Mock()
@@ -572,7 +572,7 @@ def test_initialize_plot_settings_in_metadata(make_napari_viewer):
     layer = create_image_layer_with_phasors()
     viewer.add_layer(layer)
 
-    plotter = PlotterWidget(viewer)
+    PlotterWidget(viewer)
 
     # Settings should be initialized
     assert 'settings' in layer.metadata
@@ -593,8 +593,8 @@ def test_restore_plot_settings_from_metadata(make_napari_viewer):
     assert plotter.harmonic == 2
     assert plotter.plot_type == 'SCATTER'
     assert plotter.histogram_colormap == 'viridis'
-    assert plotter.toggle_semi_circle == False
-    assert plotter.white_background == False
+    assert not plotter.toggle_semi_circle
+    assert not plotter.white_background
 
 
 def test_update_setting_in_metadata(make_napari_viewer):

--- a/src/napari_phasors/_tests/test_lifetime_tab.py
+++ b/src/napari_phasors/_tests/test_lifetime_tab.py
@@ -103,10 +103,10 @@ def test_lifetime_widget_initialization_values(make_napari_viewer):
     scroll_areas = lifetime_widget.findChildren(QScrollArea)
     assert len(scroll_areas) == 1
     scroll_area = scroll_areas[0]
-    assert scroll_area.widgetResizable() == True
+    assert scroll_area.widgetResizable()
 
     # Test histogram widget initially hidden
-    assert lifetime_widget.histogram_widget.isHidden() == True
+    assert lifetime_widget.histogram_widget.isHidden()
 
 
 def test_lifetime_widget_histogram_styling(make_napari_viewer):
@@ -208,7 +208,7 @@ def test_lifetime_widget_plot_histogram_no_data(make_napari_viewer):
 
     # Should hide histogram widget and return early
     lifetime_widget.plot_lifetime_histogram()
-    assert lifetime_widget.histogram_widget.isHidden() == True
+    assert lifetime_widget.histogram_widget.isHidden()
 
 
 def test_lifetime_widget_ui_layout(make_napari_viewer):
@@ -661,9 +661,7 @@ def test_lifetime_widget_no_recursive_updates_when_restoring_settings(
     )
 
     # Mock the update method to check it's not called during restoration
-    with patch.object(
-        lifetime_widget, '_update_lifetime_setting_in_metadata'
-    ) as mock_update:
+    with patch.object(lifetime_widget, '_update_lifetime_setting_in_metadata'):
         # Switch to another layer and back (triggers restoration)
         layer_2 = create_image_layer_with_phasors()
         viewer.add_layer(layer_2)
@@ -793,7 +791,7 @@ def test_lifetime_widget_image_layer_changed_no_layer(make_napari_viewer):
     lifetime_widget._on_image_layer_changed()
 
     # Should hide histogram
-    assert lifetime_widget.histogram_widget.isHidden() == True
+    assert lifetime_widget.histogram_widget.isHidden()
 
 
 def test_lifetime_widget_colormap_changed_callback(make_napari_viewer):
@@ -962,7 +960,7 @@ def test_lifetime_widget_full_workflow_with_real_calculations(
     parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
 
     # Set frequency
-    lifetime_widget.frequency_input.setText(str("80"))
+    lifetime_widget.frequency_input.setText("80")
 
     # Select lifetime type
     lifetime_widget.lifetime_type_combobox.setCurrentText(
@@ -987,10 +985,7 @@ def test_lifetime_widget_full_workflow_with_real_calculations(
     harmonics = np.atleast_1d(harmonics)
     if len(harmonics) > 1 and G_image.ndim > 2:
         harmonic_idx = np.where(harmonics == harmonic)[0]
-        if len(harmonic_idx) == 0:
-            harmonic_idx = 0
-        else:
-            harmonic_idx = harmonic_idx[0]
+        harmonic_idx = 0 if len(harmonic_idx) == 0 else harmonic_idx[0]
         real = G_image[harmonic_idx]
         imag = S_image[harmonic_idx]
     else:

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1,3 +1,4 @@
+import contextlib
 from unittest.mock import patch
 
 import numpy as np
@@ -24,8 +25,10 @@ from napari_phasors.plotter import PlotterWidget
 from napari_phasors.selection_tab import SelectionWidget
 
 
-def create_image_layer_with_phasors(harmonic=[1, 2, 3]):
+def create_image_layer_with_phasors(harmonic=None):
     """Create an intensity image layer with phasors for testing."""
+    if harmonic is None:
+        harmonic = [1, 2, 3]
     time_constants = [0.1, 1, 2, 3, 4, 5, 10]
     raw_flim_data = make_raw_flim_data(time_constants=time_constants)
     harmonic = harmonic
@@ -116,12 +119,8 @@ def test_phasor_plotter_initialization_values(make_napari_viewer):
     assert plotter.harmonic == 1
     assert plotter.plot_type == 'HISTOGRAM2D'
     assert plotter.histogram_colormap == 'turbo'
-    assert (
-        plotter.toggle_semi_circle == True
-    )  # Should default to semi-circle mode
-    assert (
-        plotter.white_background == True
-    )  # Should default to white background
+    assert plotter.toggle_semi_circle  # Should default to semi-circle mode
+    assert plotter.white_background  # Should default to white background
 
     # Test plot type combobox items
     plot_types = []
@@ -294,15 +293,13 @@ def test_adding_removing_layers_updates_plot(make_napari_viewer):
         # Check values were not reset to defaults when new layer was added
         assert plotter.plot_type == 'SCATTER'
         assert plotter.histogram_colormap == 'viridis'
-        assert plotter.toggle_semi_circle == False
-        assert plotter.white_background == False
+        assert not plotter.toggle_semi_circle
+        assert not plotter.white_background
         assert (
-            plotter.plotter_inputs_widget.semi_circle_checkbox.isChecked()
-            == False
+            not plotter.plotter_inputs_widget.semi_circle_checkbox.isChecked()
         )
         assert (
-            plotter.plotter_inputs_widget.white_background_checkbox.isChecked()
-            == False
+            not plotter.plotter_inputs_widget.white_background_checkbox.isChecked()
         )
 
         # Check that the combobox has both layers with phasor features
@@ -343,8 +340,8 @@ def test_layer_settings_persistence_across_layer_switches(make_napari_viewer):
     )
     assert plotter.plot_type == 'SCATTER'
     assert plotter.histogram_colormap == 'viridis'
-    assert plotter.toggle_semi_circle == False
-    assert plotter.white_background == False
+    assert not plotter.toggle_semi_circle
+    assert not plotter.white_background
 
     # Switch back to layer_1 (should restore settings)
     plotter.image_layer_with_phasor_features_combobox.setCurrentText(
@@ -352,8 +349,8 @@ def test_layer_settings_persistence_across_layer_switches(make_napari_viewer):
     )
     assert plotter.plot_type == 'SCATTER'
     assert plotter.histogram_colormap == 'viridis'
-    assert plotter.toggle_semi_circle == False
-    assert plotter.white_background == False
+    assert not plotter.toggle_semi_circle
+    assert not plotter.white_background
 
     plotter.deleteLater()
 
@@ -377,12 +374,12 @@ def test_layer_settings_initialization_in_metadata(make_napari_viewer):
 
     # Check default values
     assert layer.metadata['settings']['harmonic'] == 1
-    assert layer.metadata['settings']['semi_circle'] == True
-    assert layer.metadata['settings']['white_background'] == True
+    assert layer.metadata['settings']['semi_circle']
+    assert layer.metadata['settings']['white_background']
     assert layer.metadata['settings']['plot_type'] == 'HISTOGRAM2D'
     assert layer.metadata['settings']['colormap'] == 'turbo'
     assert layer.metadata['settings']['number_of_bins'] == 150
-    assert layer.metadata['settings']['log_scale'] == False
+    assert not layer.metadata['settings']['log_scale']
 
     plotter.deleteLater()
 
@@ -405,8 +402,8 @@ def test_layer_settings_update_in_metadata(make_napari_viewer):
     assert layer.metadata['settings']['harmonic'] == 2
     assert layer.metadata['settings']['plot_type'] == 'SCATTER'
     assert layer.metadata['settings']['colormap'] == 'viridis'
-    assert layer.metadata['settings']['semi_circle'] == False
-    assert layer.metadata['settings']['white_background'] == False
+    assert not layer.metadata['settings']['semi_circle']
+    assert not layer.metadata['settings']['white_background']
 
     plotter.deleteLater()
 
@@ -428,8 +425,8 @@ def test_adding_layer_without_settings_initializes_defaults(
     # Verify settings were initialized with defaults
     assert 'settings' in layer.metadata
     assert layer.metadata['settings']['harmonic'] == 1
-    assert layer.metadata['settings']['semi_circle'] == True
-    assert layer.metadata['settings']['white_background'] == True
+    assert layer.metadata['settings']['semi_circle']
+    assert layer.metadata['settings']['white_background']
     assert layer.metadata['settings']['plot_type'] == 'HISTOGRAM2D'
 
     plotter.deleteLater()
@@ -460,15 +457,15 @@ def test_modifying_settings_updates_metadata_correctly(make_napari_viewer):
 
     # Test log scale update
     plotter.plotter_inputs_widget.log_scale_checkbox.setChecked(True)
-    assert layer.metadata['settings']['log_scale'] == True
+    assert layer.metadata['settings']['log_scale']
 
     # Test semi circle update
     plotter.plotter_inputs_widget.semi_circle_checkbox.setChecked(False)
-    assert layer.metadata['settings']['semi_circle'] == False
+    assert not layer.metadata['settings']['semi_circle']
 
     # Test white background update
     plotter.plotter_inputs_widget.white_background_checkbox.setChecked(False)
-    assert layer.metadata['settings']['white_background'] == False
+    assert not layer.metadata['settings']['white_background']
 
     plotter.deleteLater()
 
@@ -529,18 +526,13 @@ def test_phasor_plotter_property_setters(make_napari_viewer):
 
     # Test white_background setter
     plotter.white_background = True
-    assert plotter.white_background == True
-    assert (
-        plotter.plotter_inputs_widget.white_background_checkbox.isChecked()
-        == True
-    )
+    assert plotter.white_background
+    assert plotter.plotter_inputs_widget.white_background_checkbox.isChecked()
 
     # Test toggle_semi_circle setter
     plotter.toggle_semi_circle = False
-    assert plotter.toggle_semi_circle == False
-    assert (
-        plotter.plotter_inputs_widget.semi_circle_checkbox.isChecked() == False
-    )
+    assert not plotter.toggle_semi_circle
+    assert not plotter.plotter_inputs_widget.semi_circle_checkbox.isChecked()
 
 
 def test_phasor_plotter_layer_management(make_napari_viewer):
@@ -584,10 +576,8 @@ def test_phasor_plotter_semicircle_checkbox(make_napari_viewer):
     plotter = PlotterWidget(viewer)
 
     # Initially semicircle should be enabled (default)
-    assert plotter.toggle_semi_circle == True
-    assert (
-        plotter.plotter_inputs_widget.semi_circle_checkbox.isChecked() == True
-    )
+    assert plotter.toggle_semi_circle
+    assert plotter.plotter_inputs_widget.semi_circle_checkbox.isChecked()
 
     # Get initial axes limits (semicircle mode)
     initial_ylim = plotter.canvas_widget.axes.get_ylim()
@@ -789,7 +779,7 @@ def test_on_image_layer_changed_prevents_recursion(
         plotter.deleteLater()
 
     # Verify guard flag is still True (not reset by early return)
-    assert plotter._in_on_image_layer_changed == True
+    assert plotter._in_on_image_layer_changed
 
 
 def test_on_image_layer_changed_with_empty_layer_name(
@@ -901,16 +891,14 @@ def test_on_image_layer_changed_guard_flag_cleanup(
     with patch.object(
         plotter, 'plot', side_effect=Exception("Test exception")
     ):
-        try:
+        with contextlib.suppress(Exception):
             plotter.on_image_layer_changed()
-        except Exception:
-            pass  # We expect the exception
         plotter.deleteLater()
 
     # Verify guard flag is cleaned up even after exception
     assert (
         not hasattr(plotter, '_in_on_image_layer_changed')
-        or plotter._in_on_image_layer_changed == False
+        or not plotter._in_on_image_layer_changed
     )
 
 
@@ -937,7 +925,6 @@ def test_on_image_layer_changed_multiple_calls(
 
 def test_phasor_plotter_tab_changed_functionality(make_napari_viewer):
     """Test tab change functionality and artist visibility management."""
-    from unittest.mock import Mock, patch
 
     viewer = make_napari_viewer()
     intensity_image_layer = create_image_layer_with_phasors()
@@ -1082,185 +1069,6 @@ def test_phasor_plotter_tab_changed_with_different_tabs(make_napari_viewer):
     ):
 
         # Test each tab index
-        tab_names = [
-            "Plot Settings",
-            "Calibration",
-            "Filter",
-            "Selection",
-            "Components",
-            "Lifetime",
-            "FRET",
-        ]
-
-        for i in range(plotter.tab_widget.count()):
-            mock_hide_all.reset_mock()
-            mock_show_tab.reset_mock()
-
-            plotter._on_tab_changed(i)
-
-            # Should always hide all artists first
-            mock_hide_all.assert_called_once()
-
-            # Should show artists for the current tab
-            expected_tab = plotter.tab_widget.widget(i)
-            mock_show_tab.assert_called_once_with(expected_tab)
-
-
-def test_phasor_plotter_tab_changed_functionality(make_napari_viewer):
-    """Test tab change functionality and artist visibility management."""
-
-    viewer = make_napari_viewer()
-    intensity_image_layer = create_image_layer_with_phasors()
-    viewer.add_layer(intensity_image_layer)
-    plotter = PlotterWidget(viewer)
-
-    # Mock the tab-specific visibility methods
-    with (
-        patch.object(plotter, '_hide_all_tab_artists') as mock_hide_all,
-        patch.object(plotter, '_show_tab_artists') as mock_show_tab,
-        patch.object(
-            plotter.canvas_widget.figure.canvas, 'draw_idle'
-        ) as mock_draw,
-    ):
-
-        # Test tab change to components tab (index 4)
-        components_tab_index = 4
-        plotter._on_tab_changed(components_tab_index)
-
-        # Verify methods were called
-        mock_hide_all.assert_called_once()
-        mock_show_tab.assert_called_once_with(plotter.components_tab)
-        mock_draw.assert_called_once()
-
-        # Reset mocks
-        mock_hide_all.reset_mock()
-        mock_show_tab.reset_mock()
-        mock_draw.reset_mock()
-
-        # Test tab change to FRET tab (index 6)
-        fret_tab_index = 6
-        plotter._on_tab_changed(fret_tab_index)
-
-        mock_hide_all.assert_called_once()
-        mock_show_tab.assert_called_once_with(plotter.fret_tab)
-        mock_draw.assert_called_once()
-
-
-def test_phasor_plotter_hide_and_show_tab_artists(make_napari_viewer):
-    """Test hiding and showing tab-specific artists."""
-    viewer = make_napari_viewer()
-    intensity_image_layer = create_image_layer_with_phasors()
-    viewer.add_layer(intensity_image_layer)
-    plotter = PlotterWidget(viewer)
-
-    # Mock the tab-specific visibility methods
-    with (
-        patch.object(
-            plotter, '_set_components_visibility'
-        ) as mock_components_vis,
-        patch.object(plotter, '_set_fret_visibility') as mock_fret_vis,
-    ):
-
-        # Test _hide_all_tab_artists
-        plotter._hide_all_tab_artists()
-
-        # Should call visibility methods with False
-        mock_components_vis.assert_called_with(False)
-        mock_fret_vis.assert_called_with(False)
-
-        # Reset mocks
-        mock_components_vis.reset_mock()
-        mock_fret_vis.reset_mock()
-
-        # Test _show_tab_artists with components tab
-        plotter._show_tab_artists(plotter.components_tab)
-        mock_components_vis.assert_called_once_with(True)
-        mock_fret_vis.assert_not_called()
-
-        # Reset mocks
-        mock_components_vis.reset_mock()
-        mock_fret_vis.reset_mock()
-
-        # Test _show_tab_artists with FRET tab
-        plotter._show_tab_artists(plotter.fret_tab)
-        mock_fret_vis.assert_called_once_with(True)
-        mock_components_vis.assert_not_called()
-
-        # Test _show_tab_artists with non-specific tab (should not call any visibility methods)
-        mock_components_vis.reset_mock()
-        mock_fret_vis.reset_mock()
-
-        plotter._show_tab_artists(plotter.settings_tab)
-        mock_components_vis.assert_not_called()
-        mock_fret_vis.assert_not_called()
-
-
-def test_phasor_plotter_tab_specific_visibility_methods(make_napari_viewer):
-    """Test the tab-specific visibility methods."""
-    viewer = make_napari_viewer()
-    intensity_image_layer = create_image_layer_with_phasors()
-    viewer.add_layer(intensity_image_layer)
-    plotter = PlotterWidget(viewer)
-
-    # Test _set_components_visibility
-    with patch.object(
-        plotter.components_tab, 'set_artists_visible'
-    ) as mock_components_artists:
-        plotter._set_components_visibility(True)
-        mock_components_artists.assert_called_once_with(True)
-
-        mock_components_artists.reset_mock()
-        plotter._set_components_visibility(False)
-        mock_components_artists.assert_called_once_with(False)
-
-    # Test _set_fret_visibility
-    with patch.object(
-        plotter.fret_tab, 'set_artists_visible'
-    ) as mock_fret_artists:
-        plotter._set_fret_visibility(True)
-        mock_fret_artists.assert_called_once_with(True)
-
-        mock_fret_artists.reset_mock()
-        plotter._set_fret_visibility(False)
-        mock_fret_artists.assert_called_once_with(False)
-
-
-def test_phasor_plotter_tab_widget_signal_connection(make_napari_viewer):
-    """Test that tab widget currentChanged signal is properly connected."""
-    viewer = make_napari_viewer()
-
-    with patch.object(PlotterWidget, '_on_tab_changed') as mock_tab_changed:
-        plotter = PlotterWidget(viewer)
-
-        # Simulate tab change by emitting the signal directly
-        plotter.tab_widget.setCurrentIndex(2)  # Change to filter tab
-
-        # The signal should trigger the method
-        mock_tab_changed.assert_called_with(2)
-
-
-def test_phasor_plotter_tab_changed_with_different_tabs(make_napari_viewer):
-    """Test tab changes with different tab indices."""
-    viewer = make_napari_viewer()
-    intensity_image_layer = create_image_layer_with_phasors()
-    viewer.add_layer(intensity_image_layer)
-    plotter = PlotterWidget(viewer)
-
-    with (
-        patch.object(plotter, '_hide_all_tab_artists') as mock_hide_all,
-        patch.object(plotter, '_show_tab_artists') as mock_show_tab,
-    ):
-
-        # Test each tab index
-        tab_names = [
-            "Plot Settings",
-            "Calibration",
-            "Filter",
-            "Selection",
-            "Components",
-            "Lifetime",
-            "FRET",
-        ]
 
         for i in range(plotter.tab_widget.count()):
             mock_hide_all.reset_mock()
@@ -1335,10 +1143,10 @@ def test_phasor_plotter_set_visibility_methods_without_tabs(
     try:
         plotter._set_components_visibility(True)
         plotter._set_components_visibility(False)
-    except AttributeError:
-        assert (
-            False
-        ), "_set_components_visibility should handle missing components_tab gracefully"
+    except AttributeError as err:
+        raise AssertionError(
+            "_set_components_visibility should handle missing components_tab gracefully"
+        ) from err
 
     # Restore components_tab
     plotter.components_tab = original_components_tab
@@ -1351,10 +1159,10 @@ def test_phasor_plotter_set_visibility_methods_without_tabs(
     try:
         plotter._set_fret_visibility(True)
         plotter._set_fret_visibility(False)
-    except AttributeError:
-        assert (
-            False
-        ), "_set_fret_visibility should handle missing fret_tab gracefully"
+    except AttributeError as err:
+        raise AssertionError(
+            "_set_fret_visibility should handle missing fret_tab gracefully"
+        ) from err
 
     # Restore fret_tab
     plotter.fret_tab = original_fret_tab
@@ -1379,7 +1187,7 @@ def test_phasor_plotter_visibility_methods_error_handling(make_napari_viewer):
         # Should not crash if set_artists_visible raises an exception
         try:
             plotter._set_components_visibility(True)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             # If the method doesn't handle the exception, the test will catch it
             # In a real implementation, you might want to handle this gracefully
             assert "Mock error in set_artists_visible" in str(e)
@@ -1392,7 +1200,7 @@ def test_phasor_plotter_visibility_methods_error_handling(make_napari_viewer):
         # Should not crash if set_artists_visible raises an exception
         try:
             plotter._set_fret_visibility(False)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             # If the method doesn't handle the exception, the test will catch it
             # In a real implementation, you might want to handle this gracefully
             assert "Mock error in set_artists_visible" in str(e)
@@ -1421,9 +1229,9 @@ def test_phasor_plotter_visibility_methods_called_by_hide_show_artists(
 
         # Verify all calls were with False
         for call in mock_comp_vis.call_args_list:
-            assert call[0][0] == False
+            assert not call[0][0]
         for call in mock_fret_vis.call_args_list:
-            assert call[0][0] == False
+            assert not call[0][0]
 
     # Test that _show_tab_artists calls the correct visibility method for components tab
     with (
@@ -1445,39 +1253,6 @@ def test_phasor_plotter_visibility_methods_called_by_hide_show_artists(
         plotter._show_tab_artists(plotter.fret_tab)
 
         mock_comp_vis.assert_not_called()
-        mock_fret_vis.assert_called_once_with(True)
-
-
-def test_phasor_plotter_visibility_methods_integration_with_tab_changes(
-    make_napari_viewer,
-):
-    """Test visibility methods integration with tab changes."""
-    viewer = make_napari_viewer()
-    plotter = PlotterWidget(viewer)
-
-    # Add an image layer with phasors
-    intensity_image_layer = create_image_layer_with_phasors()
-    viewer.add_layer(intensity_image_layer)
-
-    # Test switching to components tab
-    components_idx = plotter.tab_widget.indexOf(plotter.components_tab)
-    plotter.tab_widget.setCurrentIndex(components_idx)
-
-    # Components should be visible
-    with patch.object(
-        plotter.components_tab, 'set_artists_visible'
-    ) as mock_comp_vis:
-        plotter._show_tab_artists(plotter.components_tab)
-        mock_comp_vis.assert_called_once_with(True)
-
-    # Test switching to FRET tab
-    fret_idx = plotter.tab_widget.indexOf(plotter.fret_tab)
-    plotter.tab_widget.setCurrentIndex(fret_idx)
-
-    with patch.object(
-        plotter.fret_tab, 'set_artists_visible'
-    ) as mock_fret_vis:
-        plotter._show_tab_artists(plotter.fret_tab)
         mock_fret_vis.assert_called_once_with(True)
 
 
@@ -1796,7 +1571,7 @@ def test_toolbar_visibility_on_mode_change_within_selection_tab(
         # Should call _set_selection_visibility(True) to show toolbar
         assert mock_vis.call_count >= 1
         # Last call should be True
-        assert mock_vis.call_args_list[-1][0][0] == True
+        assert mock_vis.call_args_list[-1][0][0]
 
     # Reset mock
     with patch.object(plotter, '_set_selection_visibility') as mock_vis:
@@ -1806,7 +1581,7 @@ def test_toolbar_visibility_on_mode_change_within_selection_tab(
         # Should call _set_selection_visibility(False) to hide toolbar
         assert mock_vis.call_count >= 1
         # Last call should be False
-        assert mock_vis.call_args_list[-1][0][0] == False
+        assert not mock_vis.call_args_list[-1][0][0]
 
 
 def test_circular_cursor_and_manual_selection_visibility_coordination(
@@ -1882,10 +1657,10 @@ def test_phasor_plotter_visibility_methods_integration_with_tab_changes(
         calls_fret = mock_fret_vis.call_args_list
 
         # The last component call should be True (show components)
-        assert calls_comp[-1][0][0] == True
+        assert calls_comp[-1][0][0]
         # All fret calls should be False (hide fret)
         for call in calls_fret:
-            assert call[0][0] == False
+            assert not call[0][0]
 
         # Reset mocks
         mock_comp_vis.reset_mock()
@@ -1904,9 +1679,9 @@ def test_phasor_plotter_visibility_methods_integration_with_tab_changes(
 
         # All component calls should be False (hide components)
         for call in calls_comp:
-            assert call[0][0] == False
+            assert not call[0][0]
         # The last FRET call should be True (show FRET)
-        assert calls_fret[-1][0][0] == True
+        assert calls_fret[-1][0][0]
 
 
 def test_canvas_cleared_when_no_layer_selected(make_napari_viewer):
@@ -1925,8 +1700,8 @@ def test_canvas_cleared_when_no_layer_selected(make_napari_viewer):
     assert plotter.colorbar is not None  # Should have colorbar for histogram
 
     # Store reference to semicircle/polar plot artists before clearing
-    initial_semicircle_artists = len(plotter.semi_circle_plot_artist_list)
-    initial_polar_artists = len(plotter.polar_plot_artist_list)
+    len(plotter.semi_circle_plot_artist_list)
+    len(plotter.polar_plot_artist_list)
 
     # Deselect all layers (simulate no layer selected)
     plotter.image_layers_checkable_combobox.setCheckedItems([])
@@ -1973,7 +1748,7 @@ def test_canvas_cleared_when_no_layer_selected(make_napari_viewer):
     with (
         patch.object(plotter, '_set_components_visibility') as mock_comp_vis,
         patch.object(plotter, '_set_fret_visibility') as mock_fret_vis,
-        patch.object(plotter, '_set_selection_visibility') as mock_sel_vis,
+        patch.object(plotter, '_set_selection_visibility'),
     ):
         # This was already called during on_image_layer_changed, but verify the method works
         plotter._hide_all_tab_artists()

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -1,5 +1,4 @@
 import json
-import sys
 
 import numpy as np
 from phasorpy.io import (
@@ -315,7 +314,7 @@ def test_reader_ometif_metadata():
     # Test that summed_signal is present and is a list
     _, _, _, attrs = phasor_from_ometiff(ometif_file, harmonic='all')
     signal_data = None
-    if "description" in attrs.keys():
+    if "description" in attrs:
         description = json.loads(attrs["description"])
         if len(json.dumps(description)) > 512 * 512:  # Threshold: 256 KB
             raise ValueError("Description dictionary is too large.")

--- a/src/napari_phasors/_tests/test_selection_tab.py
+++ b/src/napari_phasors/_tests/test_selection_tab.py
@@ -21,7 +21,7 @@ def test_selection_widget_initialization_values(make_napari_viewer):
 
     # Test initial attribute values
     assert widget._current_selection_id == "None"
-    assert widget.selection_id == None
+    assert widget.selection_id is None
     assert widget._phasors_selected_layer is None
 
     # Test mode combobox initialization
@@ -70,7 +70,7 @@ def test_selection_widget_with_layer_data(make_napari_viewer):
 
     # Test initial attribute values
     assert widget._current_selection_id == "None"
-    assert widget.selection_id == None
+    assert widget.selection_id is None
     assert widget._phasors_selected_layer is None
 
     # Switch to manual selection mode to test manual selection functionality
@@ -107,7 +107,7 @@ def test_selection_id_property_getter(make_napari_viewer):
     widget = parent.selection_tab
 
     # Test with "None" selected
-    assert widget.selection_id == None
+    assert widget.selection_id is None
 
     # Test with empty combobox
     widget.selection_input_widget.phasor_selection_id_combobox.clear()
@@ -352,13 +352,13 @@ def test_circular_cursor_widget_initialization(make_napari_viewer):
     assert widget.clear_all_button.text() == 'Clear All'
     assert widget.calculate_button.text() == 'Calculate'
     assert widget.autoupdate_check.text() == 'Autoupdate'
-    assert widget.autoupdate_check.isChecked() == False  # Default is off
+    assert not widget.autoupdate_check.isChecked()  # Default is off
 
     # Test internal state
     assert widget._cursors == []
     assert widget._dragging_cursor is None
     assert widget._drag_offset == (0, 0)  # Initialized to (0, 0) not None
-    assert widget._autoupdate_enabled == False  # Default is off
+    assert not widget._autoupdate_enabled  # Default is off
 
 
 def test_circular_cursor_add_cursor(make_napari_viewer):
@@ -584,9 +584,9 @@ def test_circular_cursor_autoupdate_checkbox(make_napari_viewer):
     widget = parent.selection_tab.circular_cursor_widget
 
     # Initially autoupdate should be disabled
-    assert widget.autoupdate_check.isChecked() == False
-    assert widget._autoupdate_enabled == False
-    assert widget.calculate_button.isEnabled() == True
+    assert not widget.autoupdate_check.isChecked()
+    assert not widget._autoupdate_enabled
+    assert widget.calculate_button.isEnabled()
 
     # Add a cursor (should not create labels layer without autoupdate)
     widget._add_cursor()
@@ -595,18 +595,16 @@ def test_circular_cursor_autoupdate_checkbox(make_napari_viewer):
 
     # Enable autoupdate
     widget.autoupdate_check.setChecked(True)
-    assert widget._autoupdate_enabled == True
-    assert widget.calculate_button.isEnabled() == False  # Should be disabled
+    assert widget._autoupdate_enabled
+    assert not widget.calculate_button.isEnabled()  # Should be disabled
 
     # Labels layer should be created immediately when autoupdate is enabled
     assert expected_layer_name in [layer.name for layer in viewer.layers]
 
     # Disable autoupdate
     widget.autoupdate_check.setChecked(False)
-    assert widget._autoupdate_enabled == False
-    assert (
-        widget.calculate_button.isEnabled() == True
-    )  # Should be enabled again
+    assert not widget._autoupdate_enabled
+    assert widget.calculate_button.isEnabled()  # Should be enabled again
 
 
 def test_circular_cursor_calculate_button(make_napari_viewer):
@@ -671,7 +669,7 @@ def test_circular_cursor_count_and_percentage_columns(make_napari_viewer):
     assert "." in percentage_text or percentage_text.isdigit()
 
     # Explicitly update statistics and verify values remain valid
-    initial_count = int(count_text)
+    int(count_text)
     widget._update_cursor_statistics()
 
     new_count_text = count_label.text()
@@ -688,13 +686,12 @@ def test_circular_cursor_statistics_update_on_change(make_napari_viewer):
     widget = parent.selection_tab.circular_cursor_widget
 
     # Ensure autoupdate is off
-    assert widget._autoupdate_enabled == False
+    assert not widget._autoupdate_enabled
 
     # Add a cursor
     widget._add_cursor(g=0.5, s=0.5, radius=0.1)
 
     # Get initial statistics
-    from qtpy.QtWidgets import QLabel
 
     count_label = widget.cursor_table.cellWidget(0, 4)
     initial_count = count_label.text()
@@ -1111,11 +1108,13 @@ def test_circular_cursor_empty_metadata_handling(make_napari_viewer):
     intensity_image_layer = create_image_layer_with_phasors()
 
     # Ensure no circular cursors in metadata
-    if "settings" in intensity_image_layer.metadata:
-        if "selections" in intensity_image_layer.metadata["settings"]:
-            intensity_image_layer.metadata["settings"]["selections"].pop(
-                "circular_cursors", None
-            )
+    if (
+        "settings" in intensity_image_layer.metadata
+        and "selections" in intensity_image_layer.metadata["settings"]
+    ):
+        intensity_image_layer.metadata["settings"]["selections"].pop(
+            "circular_cursors", None
+        )
 
     viewer.add_layer(intensity_image_layer)
     parent = PlotterWidget(viewer)
@@ -1168,7 +1167,7 @@ def test_automatic_clustering_widget_initialization(make_napari_viewer):
     assert hasattr(widget, 'clear_button')
     assert widget.apply_button.text() == "Apply Clustering"
     assert widget.clear_button.text() == "Clear Clusters"
-    assert widget.clear_button.isEnabled() == False  # Initially disabled
+    assert not widget.clear_button.isEnabled()  # Initially disabled
 
     # Test internal state
     assert widget._clusters == []
@@ -1238,7 +1237,7 @@ def test_automatic_clustering_apply_gmm(make_napari_viewer):
     assert widget.cluster_table.rowCount() == 3
 
     # Clear button should be enabled
-    assert widget.clear_button.isEnabled() == True
+    assert widget.clear_button.isEnabled()
 
     # Check that labels layer was created
     layer_name = f"Cluster Selection: {intensity_image_layer.name}"
@@ -1308,7 +1307,7 @@ def test_automatic_clustering_clear_clusters(make_napari_viewer):
     # Should have no clusters
     assert len(widget._clusters) == 0
     assert len(widget._ellipse_patches) == 0
-    assert widget.clear_button.isEnabled() == False
+    assert not widget.clear_button.isEnabled()
     assert widget.cluster_table.rowCount() == 0  # Table should be empty
 
 
@@ -1695,7 +1694,7 @@ def test_automatic_clustering_remove_cluster(make_napari_viewer):
     assert len(widget._clusters) == 0
     assert widget.cluster_table.rowCount() == 0
     assert len(widget._ellipse_patches) == 0
-    assert widget.clear_button.isEnabled() == False
+    assert not widget.clear_button.isEnabled()
 
 
 def test_automatic_clustering_count_and_percentage(make_napari_viewer):
@@ -1743,7 +1742,7 @@ def test_circular_cursor_drag_no_autoupdate(make_napari_viewer):
     widget = parent.selection_tab.circular_cursor_widget
 
     # Ensure autoupdate is off
-    assert widget._autoupdate_enabled == False
+    assert not widget._autoupdate_enabled
 
     # Add a cursor and create labels
     widget._add_cursor()
@@ -1752,7 +1751,7 @@ def test_circular_cursor_drag_no_autoupdate(make_napari_viewer):
     # Get initial labels layer
     layer_name = f"Cursor Selection: {intensity_image_layer.name}"
     labels_layer = viewer.layers[layer_name]
-    initial_data = labels_layer.data.copy()
+    labels_layer.data.copy()
 
     # Simulate dragging
     widget._dragging_cursor = 0
@@ -1784,7 +1783,7 @@ def test_circular_cursor_drag_with_autoupdate(make_napari_viewer):
 
     # Enable autoupdate
     widget.autoupdate_check.setChecked(True)
-    assert widget._autoupdate_enabled == True
+    assert widget._autoupdate_enabled
 
     # Add a cursor (labels should be created immediately with autoupdate)
     widget._add_cursor(g=0.5, s=0.3, radius=0.2)
@@ -1792,7 +1791,7 @@ def test_circular_cursor_drag_with_autoupdate(make_napari_viewer):
     # Get labels layer
     layer_name = f"Cursor Selection: {intensity_image_layer.name}"
     labels_layer = viewer.layers[layer_name]
-    initial_nonzero = np.count_nonzero(labels_layer.data)
+    np.count_nonzero(labels_layer.data)
 
     # Simulate dragging to a different position
     widget._dragging_cursor = 0

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -28,50 +28,48 @@ def test_validate_harmonics_for_wavelet():
     """Test validate_harmonics_for_wavelet function."""
     # Test compatible harmonics (each has double or half)
     compatible_harmonics_1 = [1, 2]  # 2 = 1*2
-    assert validate_harmonics_for_wavelet(compatible_harmonics_1) == True
+    assert validate_harmonics_for_wavelet(compatible_harmonics_1)
 
     compatible_harmonics_2 = [2, 4]  # 4 = 2*2
-    assert validate_harmonics_for_wavelet(compatible_harmonics_2) == True
+    assert validate_harmonics_for_wavelet(compatible_harmonics_2)
 
     compatible_harmonics_3 = [1, 2, 4]  # 2 = 1*2, 4 = 2*2
-    assert validate_harmonics_for_wavelet(compatible_harmonics_3) == True
+    assert validate_harmonics_for_wavelet(compatible_harmonics_3)
 
     compatible_harmonics_4 = [2, 1, 4]  # Same as above, different order
-    assert validate_harmonics_for_wavelet(compatible_harmonics_4) == True
+    assert validate_harmonics_for_wavelet(compatible_harmonics_4)
 
     compatible_harmonics_5 = [0.5, 1, 2]  # 1 = 0.5*2, 2 = 1*2
-    assert validate_harmonics_for_wavelet(compatible_harmonics_5) == True
+    assert validate_harmonics_for_wavelet(compatible_harmonics_5)
 
     # Test incompatible harmonics (some don't have double or half)
     incompatible_harmonics_1 = [
         1,
         3,
     ]  # 3 has no double/half relationship with 1
-    assert validate_harmonics_for_wavelet(incompatible_harmonics_1) == False
+    assert not validate_harmonics_for_wavelet(incompatible_harmonics_1)
 
     incompatible_harmonics_2 = [1, 3, 5]  # None have double/half relationships
-    assert validate_harmonics_for_wavelet(incompatible_harmonics_2) == False
+    assert not validate_harmonics_for_wavelet(incompatible_harmonics_2)
 
     incompatible_harmonics_3 = [1, 2, 5]  # 1,2 are compatible but 5 is not
-    assert validate_harmonics_for_wavelet(incompatible_harmonics_3) == False
+    assert not validate_harmonics_for_wavelet(incompatible_harmonics_3)
 
     # Test single harmonic (incompatible by definition)
     single_harmonic = [1]
-    assert validate_harmonics_for_wavelet(single_harmonic) == False
+    assert not validate_harmonics_for_wavelet(single_harmonic)
 
     # Test empty array
     empty_harmonics = []
-    assert (
-        validate_harmonics_for_wavelet(empty_harmonics) == True
-    )  # Vacuously true
+    assert validate_harmonics_for_wavelet(empty_harmonics)  # Vacuously true
 
     # Test numpy array input
     numpy_harmonics = np.array([1, 2, 4])
-    assert validate_harmonics_for_wavelet(numpy_harmonics) == True
+    assert validate_harmonics_for_wavelet(numpy_harmonics)
 
     # Test with duplicates
     harmonics_with_duplicates = [1, 1, 2, 2]
-    assert validate_harmonics_for_wavelet(harmonics_with_duplicates) == True
+    assert validate_harmonics_for_wavelet(harmonics_with_duplicates)
 
 
 def test_apply_filter_and_threshold_median(make_napari_viewer):

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -512,7 +512,7 @@ def test_signal_plot_ometif_widget(make_napari_viewer):
     # Get harmonics from attrs
     if "harmonic" in attrs:
         harmonics = attrs["harmonic"]
-    if "description" in attrs.keys():
+    if "description" in attrs:
         description = json.loads(attrs["description"])
         if sys.getsizeof(description) > 512 * 512:  # Threshold: 256 KB
             raise ValueError("Description dictionary is too large.")
@@ -571,7 +571,7 @@ def test_signal_plot_error_handling(make_napari_viewer):
         widget._update_signal_plot()
 
         # Plot should be cleared or show error state
-        lines = widget.ax.get_lines()
+        widget.ax.get_lines()
         # Should either be empty or show error message
 
 
@@ -856,7 +856,6 @@ def test_writer_widget_image_exports(make_napari_viewer, tmp_path):
 
 def test_writer_widget_colormap_applied(make_napari_viewer, tmp_path):
     """Test that the napari layer's colormap is correctly applied to exported images."""
-    import matplotlib.pyplot as plt
     from PIL import Image
 
     viewer = make_napari_viewer()
@@ -965,7 +964,7 @@ def test_writer_widget_csv_export_2d_no_phasor(make_napari_viewer, tmp_path):
 
     # Create a simple 2D image layer without phasor metadata
     data = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    layer = viewer.add_image(data, name="test_2d_image")
+    viewer.add_image(data, name="test_2d_image")
 
     # Export as CSV
     csv_path = tmp_path / "test_2d.csv"
@@ -1002,7 +1001,7 @@ def test_writer_widget_csv_export_4d_no_phasor(make_napari_viewer, tmp_path):
 
     # Create a 4D image layer
     data = np.arange(48).reshape(2, 2, 3, 4)
-    layer = viewer.add_image(data, name="test_4d_image")
+    viewer.add_image(data, name="test_4d_image")
 
     # Export as CSV
     csv_path = tmp_path / "test_4d.csv"
@@ -1038,7 +1037,7 @@ def test_writer_widget_csv_coordinates_consistency_2d(
 
     # Create 2D image with known pattern
     data = np.array([[10, 20], [30, 40]])
-    layer = viewer.add_image(data, name="test_pattern")
+    viewer.add_image(data, name="test_pattern")
 
     # Export as CSV
     csv_path = tmp_path / "test_pattern.csv"

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -255,11 +255,13 @@ def test_write_ometif_without_circular_cursors(tmp_path):
     )
 
     # Explicitly ensure no circular cursors in metadata
-    if "settings" in intensity_image_layer.metadata:
-        if "selections" in intensity_image_layer.metadata["settings"]:
-            intensity_image_layer.metadata["settings"]["selections"].pop(
-                "circular_cursors", None
-            )
+    if (
+        "settings" in intensity_image_layer.metadata
+        and "selections" in intensity_image_layer.metadata["settings"]
+    ):
+        intensity_image_layer.metadata["settings"]["selections"].pop(
+            "circular_cursors", None
+        )
 
     # Write the file
     filepath = os.path.join(tmp_path, "test_no_cursors.ome.tif")

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -505,7 +505,7 @@ def update_frequency_in_metadata(
     frequency: float,
 ):
     """Update the frequency in the layer metadata."""
-    if "settings" not in image_layer.metadata.keys():
+    if "settings" not in image_layer.metadata:
         image_layer.metadata["settings"] = {}
     image_layer.metadata["settings"]["frequency"] = frequency
 

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
 )
@@ -245,7 +244,7 @@ class AdvancedOptionsWidget(QWidget):
             self.figure.tight_layout()
             self.canvas.draw()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error updating signal plot: {str(e)}")
 
     def _get_signal_data(self):
@@ -562,7 +561,7 @@ class FbdWidget(AdvancedOptionsWidget):
         try:
             signal = signal_from_fbd(self.path, **options)
             return signal
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error reading FBD signal: {str(e)}")
             return None
 
@@ -645,7 +644,7 @@ class PtuWidget(AdvancedOptionsWidget):
         try:
             signal = signal_from_ptu(self.path, **options)
             return signal
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error reading PTU signal: {str(e)}")
             return None
 
@@ -682,7 +681,7 @@ class LsmWidget(AdvancedOptionsWidget):
 
             with tifffile.TiffFile(path) as tif:
                 return tif.is_lsm
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     def initUI(self):
@@ -718,7 +717,7 @@ class LsmWidget(AdvancedOptionsWidget):
 
                 signal = tifffile.imread(self.path)
                 return signal
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(
                 f"Error reading {'LSM' if self._is_lsm else 'TIFF'} signal: {str(e)}"
             )
@@ -768,7 +767,7 @@ class LsmWidget(AdvancedOptionsWidget):
             self.figure.tight_layout()
             self.canvas.draw()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error updating signal plot: {str(e)}")
 
 
@@ -822,7 +821,7 @@ class SdtWidget(AdvancedOptionsWidget):
         try:
             signal = signal_from_sdt(self.path, **options)
             return signal
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error reading SDT signal: {str(e)}")
             return None
 
@@ -859,7 +858,7 @@ class OmeTifWidget(AdvancedOptionsWidget):
                 else:
                     self.max_harmonic = int(harmonics)
 
-            if "description" in attrs.keys():
+            if "description" in attrs:
                 description = json.loads(attrs["description"])
                 if (
                     len(json.dumps(description)) > 512 * 512
@@ -885,7 +884,7 @@ class OmeTifWidget(AdvancedOptionsWidget):
                         elif 'frequency' in attrs:
                             self.frequency = attrs['frequency']
 
-        except Exception as e:
+        except Exception:  # noqa: BLE001
             pass
 
     def initUI(self):
@@ -1022,7 +1021,7 @@ class OmeTifWidget(AdvancedOptionsWidget):
             self.figure.tight_layout()
             self.canvas.draw()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error updating signal plot: {str(e)}")
 
     def _on_click(self, path, reader_options, harmonics):
@@ -1036,7 +1035,7 @@ class OmeTifWidget(AdvancedOptionsWidget):
                         name=layer[1]["name"],
                         metadata=layer[1]["metadata"],
                     )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error during phasor transformation: {str(e)}")
 
 
@@ -1280,7 +1279,7 @@ class WriterWidget(QWidget):
                         current_step=self.viewer.dims.current_step,
                     )
                 show_info(f"Exported {export_layer.name} to {final_path}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 show_error(f"Error exporting {layer_name}: {str(e)}")
         else:
             # Multiple layers export
@@ -1315,7 +1314,7 @@ class WriterWidget(QWidget):
                         )
 
                     exported_count += 1
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     show_error(f"Error exporting {layer_name}: {str(e)}")
 
             if exported_count > 0:

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import importlib.metadata
 import json
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -19,7 +20,7 @@ from phasorpy.io import phasor_to_ometiff
 
 if TYPE_CHECKING:
     DataType = Union[Any, Sequence[Any]]
-    FullLayerData = Tuple[DataType, dict, str]
+    FullLayerData = tuple[DataType, dict, str]
 
 
 def _convert_numpy_types(obj):
@@ -58,7 +59,7 @@ def _convert_numpy_types(obj):
     return obj
 
 
-def write_ome_tiff(path: str, image_layer: Any) -> List[str]:
+def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
     """Save image layer with phasor coordinates as 'OME-TIFF'.
 
     For layers with phasor metadata, saves mean intensity and phasor coordinates.
@@ -171,7 +172,7 @@ def export_layer_as_image(
     path: str,
     image_layer: Image,
     include_colorbar: bool = True,
-    current_step: Optional[Sequence[int]] = None,
+    current_step: Sequence[int] | None = None,
 ) -> None:
     """Export an image layer as an image file using its colormap and contrast limits.
 

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -1,3 +1,4 @@
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -104,10 +105,8 @@ class CalibrationWidget(QWidget):
             )
 
             for layer in image_layers:
-                try:
+                with contextlib.suppress(TypeError, ValueError):
                     layer.events.name.disconnect(self._populate_comboboxes)
-                except (TypeError, ValueError):
-                    pass
                 layer.events.name.connect(self._populate_comboboxes)
 
         finally:

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -1,3 +1,4 @@
+import contextlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -7,7 +8,6 @@ import numpy as np
 import vispy.color
 from matplotlib.collections import LineCollection
 from matplotlib.colors import LinearSegmentedColormap, ListedColormap
-from napari.experimental import link_layers
 from napari.layers import Image
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 from napari.utils.notifications import show_error, show_info, show_warning
@@ -409,17 +409,13 @@ class ComponentsWidget(QWidget):
                 self.analysis_type_combo.setCurrentIndex(index)
 
         if self.component_line is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_line.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_line = None
 
         if self.component_polygon is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_polygon.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_polygon = None
 
         self._update_component_visibility()
@@ -478,7 +474,7 @@ class ComponentsWidget(QWidget):
                 return 3
 
             return 2 * num_harmonics + 1
-        except Exception:
+        except Exception:  # noqa: BLE001
             return 3
 
     def _update_button_states(self):
@@ -494,17 +490,13 @@ class ComponentsWidget(QWidget):
         """Clear all component visualizations and input fields."""
         for comp in self.components:
             if comp.dot is not None:
-                try:
+                with contextlib.suppress(ValueError, AttributeError):
                     comp.dot.remove()
-                except (ValueError, AttributeError):
-                    pass
                 comp.dot = None
 
             if comp.text is not None:
-                try:
+                with contextlib.suppress(ValueError, AttributeError):
                     comp.text.remove()
-                except (ValueError, AttributeError):
-                    pass
                 comp.text = None
 
             comp.g_edit.clear()
@@ -514,17 +506,13 @@ class ComponentsWidget(QWidget):
                 comp.lifetime_edit.clear()
 
         if self.component_line is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_line.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_line = None
 
         if self.component_polygon is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_polygon.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_polygon = None
 
         self._update_components_setting_in_metadata('components', {})
@@ -630,9 +618,7 @@ class ComponentsWidget(QWidget):
                 settings['components'], dict
             ):
                 if settings['components']:
-                    max_idx = max(
-                        int(k) for k in settings['components'].keys()
-                    )
+                    max_idx = max(int(k) for k in settings['components'])
                 else:
                     max_idx = -1
 
@@ -735,7 +721,7 @@ class ComponentsWidget(QWidget):
 
             self._update_component_visibility()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(
                 f"Error restoring component settings from metadata: {str(e)}"
             )
@@ -787,9 +773,7 @@ class ComponentsWidget(QWidget):
                 settings['components'], dict
             ):
                 if settings['components']:
-                    max_idx = max(
-                        int(k) for k in settings['components'].keys()
-                    )
+                    max_idx = max(int(k) for k in settings['components'])
                 else:
                     max_idx = -1
 
@@ -907,7 +891,7 @@ class ComponentsWidget(QWidget):
                         harmonics_in_metadata = set()
                         for comp_data in settings['components'].values():
                             gs_harmonics = comp_data.get('gs_harmonics', {})
-                            for harmonic_key in gs_harmonics.keys():
+                            for harmonic_key in gs_harmonics:
                                 harmonics_in_metadata.add(int(harmonic_key))
 
                         if len(harmonics_in_metadata) >= required_harmonics:
@@ -930,7 +914,7 @@ class ComponentsWidget(QWidget):
 
             self._update_component_visibility()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(
                 f"Error restoring component settings from metadata: {str(e)}"
             )
@@ -974,12 +958,10 @@ class ComponentsWidget(QWidget):
             if fraction_layer is None:
                 continue
 
-            try:
+            with contextlib.suppress(Exception):
                 fraction_layer.events.colormap.disconnect(
                     self._on_colormap_changed
                 )
-            except Exception:
-                pass
 
             try:
                 if colormap_colors is not None:
@@ -1008,14 +990,13 @@ class ComponentsWidget(QWidget):
         if (
             len(settings.get('components', {})) == 2
             and self.analysis_type == "Linear Projection"
-        ):
-            if self.comp1_fractions_layer is not None:
-                self.fractions_colormap = (
-                    self.comp1_fractions_layer.colormap.colors
-                )
-                self.colormap_contrast_limits = (
-                    self.comp1_fractions_layer.contrast_limits
-                )
+        ) and self.comp1_fractions_layer is not None:
+            self.fractions_colormap = (
+                self.comp1_fractions_layer.colormap.colors
+            )
+            self.colormap_contrast_limits = (
+                self.comp1_fractions_layer.contrast_limits
+            )
 
         self._update_component_colors()
         self.draw_line_between_components()
@@ -1212,17 +1193,13 @@ class ComponentsWidget(QWidget):
             hasattr(self, 'component_polygon')
             and self.component_polygon is not None
         ):
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_polygon.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_polygon = None
 
         if self.component_line is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_line.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_line = None
 
         if self.parent_widget is not None:
@@ -1461,7 +1438,7 @@ class ComponentsWidget(QWidget):
 
                 self.draw_line_between_components()
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"Error applying saved colormap settings: {e}")
                 try:
                     self.comp1_fractions_layer.events.colormap.connect(
@@ -1470,7 +1447,7 @@ class ComponentsWidget(QWidget):
                     self.comp1_fractions_layer.events.contrast_limits.connect(
                         self._on_contrast_limits_changed
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
     def get_all_artists(self):
@@ -1533,9 +1510,7 @@ class ComponentsWidget(QWidget):
             len(active_components) == 2
             and self.show_colormap_line
             and self.fractions_colormap is not None
-        ):
-            self._update_component_colors()
-        elif len(active_components) > 2:
+        ) or len(active_components) > 2:
             self._update_component_colors()
         else:
             for comp in self.components:
@@ -1575,10 +1550,8 @@ class ComponentsWidget(QWidget):
         )
 
         if isinstance(self.component_line, LineCollection):
-            try:
+            with contextlib.suppress(Exception):
                 self.component_line.set_linewidths([self.line_width])
-            except Exception:
-                pass
 
             if self.parent_widget is not None:
                 self.parent_widget.canvas_widget.canvas.draw_idle()
@@ -1597,9 +1570,10 @@ class ComponentsWidget(QWidget):
         if hasattr(self, 'line_alpha_value_label'):
             self.line_alpha_value_label.setText(f"{self.line_alpha:.2f}")
 
-        if self.component_line is not None:
-            if hasattr(self.component_line, 'set_alpha'):
-                self.component_line.set_alpha(self.line_alpha)
+        if self.component_line is not None and hasattr(
+            self.component_line, 'set_alpha'
+        ):
+            self.component_line.set_alpha(self.line_alpha)
 
         for comp in self.components:
             if comp.dot is not None:
@@ -1656,33 +1630,32 @@ class ComponentsWidget(QWidget):
         except (AttributeError, TypeError):
             has_freq = False
 
-        for i, comp in enumerate(self.components):
-            if comp is not None:
-                if (
-                    hasattr(comp, 'ui_elements')
-                    and 'lifetime_label' in comp.ui_elements
-                ):
-                    comp.ui_elements['lifetime_label'].setVisible(has_freq)
+        for _i, comp in enumerate(self.components):
+            if comp is not None and (
+                hasattr(comp, 'ui_elements')
+                and 'lifetime_label' in comp.ui_elements
+            ):
+                comp.ui_elements['lifetime_label'].setVisible(has_freq)
 
-                    if comp.lifetime_edit is not None:
-                        comp.lifetime_edit.setVisible(has_freq)
+                if comp.lifetime_edit is not None:
+                    comp.lifetime_edit.setVisible(has_freq)
 
-                        from qtpy.QtWidgets import QSizePolicy
+                    from qtpy.QtWidgets import QSizePolicy
 
-                        if has_freq:
-                            comp.lifetime_edit.setSizePolicy(
-                                QSizePolicy.Expanding, QSizePolicy.Fixed
-                            )
-                            comp.ui_elements['lifetime_label'].setSizePolicy(
-                                QSizePolicy.Fixed, QSizePolicy.Fixed
-                            )
-                        else:
-                            comp.lifetime_edit.setSizePolicy(
-                                QSizePolicy.Ignored, QSizePolicy.Ignored
-                            )
-                            comp.ui_elements['lifetime_label'].setSizePolicy(
-                                QSizePolicy.Ignored, QSizePolicy.Ignored
-                            )
+                    if has_freq:
+                        comp.lifetime_edit.setSizePolicy(
+                            QSizePolicy.Expanding, QSizePolicy.Fixed
+                        )
+                        comp.ui_elements['lifetime_label'].setSizePolicy(
+                            QSizePolicy.Fixed, QSizePolicy.Fixed
+                        )
+                    else:
+                        comp.lifetime_edit.setSizePolicy(
+                            QSizePolicy.Ignored, QSizePolicy.Ignored
+                        )
+                        comp.ui_elements['lifetime_label'].setSizePolicy(
+                            QSizePolicy.Ignored, QSizePolicy.Ignored
+                        )
 
         if has_freq:
             for i, comp in enumerate(self.components):
@@ -1961,7 +1934,7 @@ class ComponentsWidget(QWidget):
             else:
                 color = self.component_colors[idx % len(self.component_colors)]
 
-        except Exception:
+        except Exception:  # noqa: BLE001
             color = self.component_colors[idx % len(self.component_colors)]
 
         ax = self.parent_widget.canvas_widget.figure.gca()
@@ -2031,7 +2004,7 @@ class ComponentsWidget(QWidget):
             components_data = settings.get('components', {})
             harmonic_key = str(harmonic)
 
-            sorted_indices = sorted([int(k) for k in components_data.keys()])
+            sorted_indices = sorted([int(k) for k in components_data])
 
             for idx in sorted_indices:
                 idx_str = str(idx)
@@ -2175,7 +2148,7 @@ class ComponentsWidget(QWidget):
                 max_color_rgba = cmap(1.0)
                 max_color_hex = mcolors.to_hex(max_color_rgba)
                 colors.append(max_color_hex)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 colors.append(
                     self.component_colors[i % len(self.component_colors)]
                 )
@@ -2251,7 +2224,7 @@ class ComponentsWidget(QWidget):
                                 if 'green' in colormap_name.lower():
                                     colors.append('green')
                                 else:
-                                    if hasattr(cmap, '__call__'):
+                                    if callable(cmap):
                                         max_color = cmap(1.0)
                                     elif (
                                         hasattr(cmap, 'colors')
@@ -2262,7 +2235,7 @@ class ComponentsWidget(QWidget):
                                         mpl_cmap = plt.get_cmap(str(cmap))
                                         max_color = mpl_cmap(1.0)
                                     colors.append(max_color)
-                            except Exception:
+                            except Exception:  # noqa: BLE001
                                 default_colors = (
                                     self._get_default_colormap_max_colors(2)
                                 )
@@ -2305,7 +2278,7 @@ class ComponentsWidget(QWidget):
                         if 'green' in colormap_name.lower():
                             colors.append('green')
                         else:
-                            if hasattr(cmap, '__call__'):
+                            if callable(cmap):
 
                                 max_color = cmap(1.0)
                             elif (
@@ -2317,7 +2290,7 @@ class ComponentsWidget(QWidget):
                                 mpl_cmap = plt.get_cmap(str(cmap))
                                 max_color = mpl_cmap(1.0)
                             colors.append(max_color)
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         default_colors = self._get_default_colormap_max_colors(
                             max_idx
                         )
@@ -2390,17 +2363,13 @@ class ComponentsWidget(QWidget):
             return
 
         if self.component_line is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_line.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_line = None
 
         if self.component_polygon is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_polygon.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_polygon = None
 
         try:
@@ -2449,16 +2418,12 @@ class ComponentsWidget(QWidget):
                 self._draw_colormap_line(ax, ox1, oy1, ox2, oy2)
                 self._update_component_colors()
                 if hasattr(self.component_line, "set_capstyle"):
-                    try:
+                    with contextlib.suppress(Exception):
                         self.component_line.set_capstyle('butt')
-                    except Exception:
-                        pass
 
                 if hasattr(self.component_line, 'set_zorder'):
-                    try:
+                    with contextlib.suppress(Exception):
                         self.component_line.set_zorder(10)
-                    except Exception:
-                        pass
             else:
                 self.component_line = ax.plot(
                     [ox1, ox2],
@@ -2469,10 +2434,8 @@ class ComponentsWidget(QWidget):
                     zorder=10,
                 )[0]
                 if hasattr(self.component_line, "set_solid_capstyle"):
-                    try:
+                    with contextlib.suppress(Exception):
                         self.component_line.set_solid_capstyle('butt')
-                    except Exception:
-                        pass
 
                 self._update_component_colors()
 
@@ -2486,7 +2449,7 @@ class ComponentsWidget(QWidget):
             )
             self.set_artists_visible(components_tab_is_active)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error drawing line/polygon: {str(e)}")
 
     def _draw_colormap_line(self, ax, x1, y1, x2, y2):
@@ -2560,19 +2523,15 @@ class ComponentsWidget(QWidget):
         lc.set_alpha(self.line_alpha)
 
         if hasattr(lc, "set_capstyle"):
-            try:
+            with contextlib.suppress(Exception):
                 lc.set_capstyle('butt')
-            except Exception:
-                pass
         self.component_line = ax.add_collection(lc)
 
     def _update_polygon(self):
         """Update polygon for multi-component visualization."""
         if self.component_polygon is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_polygon.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_polygon = None
 
         active_components = [
@@ -2630,11 +2589,11 @@ class ComponentsWidget(QWidget):
             colormap_colors = None
         else:
             colormap_colors = layer.colormap.colors
-            if colormap_colors is not None:
-                if hasattr(colormap_colors, 'tolist'):
-                    colormap_colors = colormap_colors.tolist()
-                elif isinstance(colormap_colors, np.ndarray):
-                    colormap_colors = colormap_colors.tolist()
+            if colormap_colors is not None and (
+                hasattr(colormap_colors, 'tolist')
+                or isinstance(colormap_colors, np.ndarray)
+            ):
+                colormap_colors = colormap_colors.tolist()
 
         current_harmonic = getattr(self.parent_widget, 'harmonic', 1)
         self._update_component_colormap(
@@ -2670,9 +2629,9 @@ class ComponentsWidget(QWidget):
             return
 
         contrast_limits = layer.contrast_limits
-        if hasattr(contrast_limits, 'tolist'):
-            contrast_limits = contrast_limits.tolist()
-        elif isinstance(contrast_limits, np.ndarray):
+        if hasattr(contrast_limits, 'tolist') or isinstance(
+            contrast_limits, np.ndarray
+        ):
             contrast_limits = contrast_limits.tolist()
         else:
             contrast_limits = list(contrast_limits)
@@ -2728,8 +2687,8 @@ class ComponentsWidget(QWidget):
                 # Check if layer name matches pattern for this component
                 # Pattern: "{component_name} fractions: {source_layer}" or "{component_name} fraction: {source_layer}"
                 if layer_name.startswith(
-                    f"{name} fractions: "
-                ) or layer_name.startswith(f"{name} fraction: "):
+                    (f"{name} fractions: ", f"{name} fraction: ")
+                ):
                     return i
 
         return None
@@ -2795,13 +2754,13 @@ class ComponentsWidget(QWidget):
         try:
             plt.get_cmap(colormap_name)
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
         try:
             vispy.color.get_colormap(colormap_name)
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
         try:
@@ -2809,7 +2768,7 @@ class ComponentsWidget(QWidget):
 
             if colormap_name in AVAILABLE_COLORMAPS:
                 return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
         return False
@@ -2848,19 +2807,15 @@ class ComponentsWidget(QWidget):
                     self.parent_widget.canvas_widget.toolbar.mode
                     == 'zoom rect'
                 ):
-                    try:
+                    with contextlib.suppress(Exception):
                         self.parent_widget.canvas_widget.toolbar.release_zoom(
                             event
                         )
-                    except Exception:
-                        pass
                 if self.parent_widget.canvas_widget.toolbar.mode == 'pan/zoom':
-                    try:
+                    with contextlib.suppress(Exception):
                         self.parent_widget.canvas_widget.toolbar.release_pan(
                             event
                         )
-                    except Exception:
-                        pass
                 self.parent_widget.canvas_widget._on_escape(None)
                 self.dragging_label_idx = comp.idx
                 return
@@ -2870,19 +2825,15 @@ class ComponentsWidget(QWidget):
                     self.parent_widget.canvas_widget.toolbar.mode
                     == 'zoom rect'
                 ):
-                    try:
+                    with contextlib.suppress(Exception):
                         self.parent_widget.canvas_widget.toolbar.release_zoom(
                             event
                         )
-                    except Exception:
-                        pass
                 if self.parent_widget.canvas_widget.toolbar.mode == 'pan/zoom':
-                    try:
+                    with contextlib.suppress(Exception):
                         self.parent_widget.canvas_widget.toolbar.release_pan(
                             event
                         )
-                    except Exception:
-                        pass
                 self.parent_widget.canvas_widget._on_escape(None)
                 self.dragging_component_idx = comp.idx
                 return
@@ -2955,7 +2906,7 @@ class ComponentsWidget(QWidget):
         if self.current_image_layer_name:
             # Check if layer still exists (defensive check for cleanup/teardown)
             if self.current_image_layer_name not in self.viewer.layers:
-                return sorted(list(harmonics))
+                return sorted(harmonics)
 
             layer = self.viewer.layers[self.current_image_layer_name]
             if (
@@ -2968,10 +2919,10 @@ class ComponentsWidget(QWidget):
 
                 for comp_data in components_data.values():
                     gs_harmonics = comp_data.get('gs_harmonics', {})
-                    for harmonic_str in gs_harmonics.keys():
+                    for harmonic_str in gs_harmonics:
                         harmonics.add(int(harmonic_str))
 
-        return sorted(list(harmonics))
+        return sorted(harmonics)
 
     def _get_available_harmonics(self):
         """Get available harmonics from the phasor data."""
@@ -3024,7 +2975,7 @@ class ComponentsWidget(QWidget):
                     mpl_cmap = plt.get_cmap(inverted_name)
                     colors = mpl_cmap(np.linspace(0, 1, 256))
                     return Colormap(colors=colors, name=inverted_name)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     if inverted_name in AVAILABLE_COLORMAPS:
                         return inverted_name
 
@@ -3040,7 +2991,7 @@ class ComponentsWidget(QWidget):
                 return Colormap(
                     colors=inverted_colors, name=f"inverted_{base_name}"
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
         if colormap_colors is not None:
@@ -3100,12 +3051,14 @@ class ComponentsWidget(QWidget):
 
             settings = layer.metadata['settings']['component_analysis']
 
-            if 'components' in settings and len(settings['components']) > 0:
-                if '0' in settings['components']:
-                    comp1_name = (
-                        settings['components']['0'].get('name')
-                        or "Component 1"
-                    )
+            if (
+                'components' in settings
+                and len(settings['components']) > 0
+                and '0' in settings['components']
+            ):
+                comp1_name = (
+                    settings['components']['0'].get('name') or "Component 1"
+                )
 
         comp1_fractions_layer_name = f"{comp1_name} fractions: {layer_name}"
 
@@ -3137,17 +3090,13 @@ class ComponentsWidget(QWidget):
                     comp.text = None
 
         if self.component_line is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_line.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_line = None
 
         if self.component_polygon is not None:
-            try:
+            with contextlib.suppress(ValueError, AttributeError):
                 self.component_polygon.remove()
-            except (ValueError, AttributeError):
-                pass
             self.component_polygon = None
 
         if self.comp1_fractions_layer is not None:
@@ -3158,7 +3107,7 @@ class ComponentsWidget(QWidget):
                 self.comp1_fractions_layer.events.contrast_limits.disconnect(
                     self._on_contrast_limits_changed
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
         self.comp1_fractions_layer = None
@@ -3515,11 +3464,11 @@ class ComponentsWidget(QWidget):
                     colormap_colors = (
                         self.comp1_fractions_layer.colormap.colors
                     )
-                    if colormap_colors is not None:
-                        if hasattr(colormap_colors, 'tolist'):
-                            colormap_colors = colormap_colors.tolist()
-                        elif isinstance(colormap_colors, np.ndarray):
-                            colormap_colors = colormap_colors.tolist()
+                    if colormap_colors is not None and (
+                        hasattr(colormap_colors, 'tolist')
+                        or isinstance(colormap_colors, np.ndarray)
+                    ):
+                        colormap_colors = colormap_colors.tolist()
                     comp_data['gs_harmonics'][harmonic_key][
                         'colormap_name'
                     ] = colormap_name
@@ -3719,7 +3668,7 @@ class ComponentsWidget(QWidget):
             self.fraction_layers.clear()
 
             for i, (fraction, name) in enumerate(
-                zip(fractions, component_names)
+                zip(fractions, component_names, strict=False)
             ):
                 fraction_layer_name = f"{name} fraction: {layer.name}"
 
@@ -3771,12 +3720,10 @@ class ComponentsWidget(QWidget):
                     else:
                         colormap = 'viridis'
 
-                try:
+                with contextlib.suppress(KeyError):
                     self.viewer.layers.remove(
                         self.viewer.layers[fraction_layer_name]
                     )
-                except KeyError:
-                    pass
                 new_layer = self.viewer.add_image(
                     fraction,
                     name=fraction_layer_name,
@@ -3789,52 +3736,54 @@ class ComponentsWidget(QWidget):
                 self.fraction_layers.append(new_layer)
                 new_layer.events.colormap.connect(self._on_colormap_changed)
 
-                if not self._updating_settings:
-                    if idx_str in settings['components']:
-                        comp_data = settings['components'][idx_str]
-                        if harmonic_key not in comp_data['gs_harmonics']:
-                            comp_data['gs_harmonics'][harmonic_key] = {}
+                if (
+                    not self._updating_settings
+                    and idx_str in settings['components']
+                ):
+                    comp_data = settings['components'][idx_str]
+                    if harmonic_key not in comp_data['gs_harmonics']:
+                        comp_data['gs_harmonics'][harmonic_key] = {}
 
-                        colormap_name = getattr(
-                            new_layer.colormap, 'name', 'custom'
-                        )
-                        is_standard_colormap = False
+                    colormap_name = getattr(
+                        new_layer.colormap, 'name', 'custom'
+                    )
+                    is_standard_colormap = False
+                    try:
+                        plt.get_cmap(colormap_name)
+                        is_standard_colormap = True
+                    except Exception:  # noqa: BLE001
                         try:
-                            plt.get_cmap(colormap_name)
+                            vispy.color.get_colormap(colormap_name)
                             is_standard_colormap = True
-                        except Exception:
-                            try:
-                                vispy.color.get_colormap(colormap_name)
-                                is_standard_colormap = True
-                            except Exception:
-                                is_standard_colormap = False
+                        except Exception:  # noqa: BLE001
+                            is_standard_colormap = False
 
-                        if is_standard_colormap:
-                            comp_data['gs_harmonics'][harmonic_key][
-                                'colormap_name'
-                            ] = colormap_name
-                            comp_data['gs_harmonics'][harmonic_key][
-                                'colormap_colors'
-                            ] = None
-                        else:
-                            colormap_colors = new_layer.colormap.colors
-                            if colormap_colors is not None:
-                                if hasattr(colormap_colors, 'tolist'):
-                                    colormap_colors = colormap_colors.tolist()
-                                elif isinstance(colormap_colors, np.ndarray):
-                                    colormap_colors = colormap_colors.tolist()
-                            comp_data['gs_harmonics'][harmonic_key][
-                                'colormap_name'
-                            ] = None
-                            comp_data['gs_harmonics'][harmonic_key][
-                                'colormap_colors'
-                            ] = colormap_colors
-
+                    if is_standard_colormap:
                         comp_data['gs_harmonics'][harmonic_key][
-                            'contrast_limits'
-                        ] = list(new_layer.contrast_limits)
+                            'colormap_name'
+                        ] = colormap_name
+                        comp_data['gs_harmonics'][harmonic_key][
+                            'colormap_colors'
+                        ] = None
+                    else:
+                        colormap_colors = new_layer.colormap.colors
+                        if colormap_colors is not None and (
+                            hasattr(colormap_colors, 'tolist')
+                            or isinstance(colormap_colors, np.ndarray)
+                        ):
+                            colormap_colors = colormap_colors.tolist()
+                        comp_data['gs_harmonics'][harmonic_key][
+                            'colormap_name'
+                        ] = None
+                        comp_data['gs_harmonics'][harmonic_key][
+                            'colormap_colors'
+                        ] = colormap_colors
+
+                    comp_data['gs_harmonics'][harmonic_key][
+                        'contrast_limits'
+                    ] = list(new_layer.contrast_limits)
 
             self._update_component_colors()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Analysis failed: {str(e)}")

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -376,7 +376,7 @@ class FilterWidget(QWidget):
                 return threshold_yen(clean_data)
             else:
                 return 0
-        except Exception:
+        except Exception:  # noqa: BLE001
             # Fallback to 10% of max if automatic method fails
             return np.nanmax(data) * 0.1
 
@@ -447,7 +447,7 @@ class FilterWidget(QWidget):
             mean_data = layer.metadata.get("original_mean")
             if mean_data is None:
                 continue
-            if 'mask' in layer.metadata.keys():
+            if 'mask' in layer.metadata:
                 max_val = np.nanmax(mean_data[layer.metadata['mask'] > 0])
             else:
                 max_val = np.nanmax(mean_data)
@@ -471,17 +471,17 @@ class FilterWidget(QWidget):
 
         self._updating_threshold = True
 
-        if "settings" in layer_metadata.keys():
+        if "settings" in layer_metadata:
             settings = layer_metadata["settings"]
 
-            if "threshold_method" in settings.keys():
+            if "threshold_method" in settings:
                 self.threshold_method_combobox.setCurrentText(
                     settings["threshold_method"]
                 )
             else:
                 self.threshold_method_combobox.setCurrentText("None")
 
-            if "threshold" in settings.keys():
+            if "threshold" in settings:
                 lower_val = int(settings["threshold"] * self.threshold_factor)
                 upper_val = int(
                     settings.get("threshold_upper", max_mean_value)
@@ -505,7 +505,7 @@ class FilterWidget(QWidget):
                     f'{upper_val / self.threshold_factor:.2f}'
                 )
 
-            if "filter" in settings.keys():
+            if "filter" in settings:
                 filter_settings = settings["filter"]
 
                 if "method" in filter_settings:
@@ -632,13 +632,12 @@ class FilterWidget(QWidget):
             self._updating_threshold = False
 
             current_method = self.threshold_method_combobox.currentText()
-            if current_method not in ["Manual"]:
-                if not (
-                    current_method == "None"
-                    and new_slider_value == 0
-                    and upper_val == self.threshold_slider.maximum()
-                ):
-                    self.threshold_method_combobox.setCurrentText("Manual")
+            if current_method not in ["Manual"] and not (
+                current_method == "None"
+                and new_slider_value == 0
+                and upper_val == self.threshold_slider.maximum()
+            ):
+                self.threshold_method_combobox.setCurrentText("Manual")
 
             self.update_threshold_lines()
         except ValueError:
@@ -669,13 +668,12 @@ class FilterWidget(QWidget):
             self._updating_threshold = False
 
             current_method = self.threshold_method_combobox.currentText()
-            if current_method not in ["Manual"]:
-                if not (
-                    current_method == "None"
-                    and lower_val == 0
-                    and new_slider_value == self.threshold_slider.maximum()
-                ):
-                    self.threshold_method_combobox.setCurrentText("Manual")
+            if current_method not in ["Manual"] and not (
+                current_method == "None"
+                and lower_val == 0
+                and new_slider_value == self.threshold_slider.maximum()
+            ):
+                self.threshold_method_combobox.setCurrentText("Manual")
 
             self.update_threshold_lines()
         except ValueError:

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import LineCollection
@@ -399,24 +401,18 @@ class FretWidget(QWidget):
     def clear_artists(self):
         """Clear (remove) all artists created by this widget."""
         if self.current_donor_line is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self.current_donor_line.remove()
-            except ValueError:
-                pass
             self.current_donor_line = None
 
         if self.current_donor_circle is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self.current_donor_circle.remove()
-            except ValueError:
-                pass
             self.current_donor_circle = None
 
         if self.current_background_circle is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self.current_background_circle.remove()
-            except ValueError:
-                pass
             self.current_background_circle = None
 
         if self.parent_widget is not None:
@@ -652,12 +648,10 @@ class FretWidget(QWidget):
 
             for layer in self.viewer.layers:
                 if isinstance(layer, Image):
-                    try:
+                    with contextlib.suppress(TypeError, ValueError):
                         layer.events.name.disconnect(
                             self._update_background_combobox
                         )
-                    except (TypeError, ValueError):
-                        pass
                     layer.events.name.connect(self._update_background_combobox)
 
         finally:
@@ -693,12 +687,10 @@ class FretWidget(QWidget):
 
             for layer in self.viewer.layers:
                 if isinstance(layer, Image):
-                    try:
+                    with contextlib.suppress(TypeError, ValueError):
                         layer.events.name.disconnect(
                             self._update_donor_lifetime_combobox
                         )
-                    except (TypeError, ValueError):
-                        pass
                     layer.events.name.connect(
                         self._update_donor_lifetime_combobox
                     )
@@ -772,7 +764,7 @@ class FretWidget(QWidget):
                     positions_by_harmonic[harmonic].append(
                         (center_real, center_imag)
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     continue
 
         if not positions_by_harmonic:
@@ -913,7 +905,7 @@ class FretWidget(QWidget):
 
                 lifetimes.append(float(lifetime))
 
-            except Exception:
+            except Exception:  # noqa: BLE001
                 continue
 
         if not lifetimes:
@@ -944,24 +936,18 @@ class FretWidget(QWidget):
         """Plot the donor trajectory with current parameters."""
         try:
             if self.current_donor_line is not None:
-                try:
+                with contextlib.suppress(ValueError):
                     self.current_donor_line.remove()
-                except ValueError:
-                    pass
                 self.current_donor_line = None
 
             if self.current_donor_circle is not None:
-                try:
+                with contextlib.suppress(ValueError):
                     self.current_donor_circle.remove()
-                except ValueError:
-                    pass
                 self.current_donor_circle = None
 
             if self.current_background_circle is not None:
-                try:
+                with contextlib.suppress(ValueError):
                     self.current_background_circle.remove()
-                except ValueError:
-                    pass
                 self.current_background_circle = None
 
             if not (
@@ -1054,7 +1040,7 @@ class FretWidget(QWidget):
 
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             show_error(f"Error drawing line: {str(e)}")
 
     def _draw_colormap_trajectory(
@@ -1128,11 +1114,11 @@ class FretWidget(QWidget):
         colormap_name = getattr(new_colormap, 'name', 'custom')
         colormap_colors = getattr(new_colormap, 'colors', None)
 
-        if colormap_colors is not None:
-            if hasattr(colormap_colors, 'tolist'):
-                colormap_colors = colormap_colors.tolist()
-            elif isinstance(colormap_colors, np.ndarray):
-                colormap_colors = colormap_colors.tolist()
+        if colormap_colors is not None and (
+            hasattr(colormap_colors, 'tolist')
+            or isinstance(colormap_colors, np.ndarray)
+        ):
+            colormap_colors = colormap_colors.tolist()
 
         self._update_fret_setting_in_metadata(
             'colormap_settings.colormap_name', colormap_name
@@ -1168,9 +1154,9 @@ class FretWidget(QWidget):
 
         # Prepare for metadata
         contrast_limits = new_contrast_limits
-        if hasattr(contrast_limits, 'tolist'):
-            contrast_limits = contrast_limits.tolist()
-        elif isinstance(contrast_limits, np.ndarray):
+        if hasattr(contrast_limits, 'tolist') or isinstance(
+            contrast_limits, np.ndarray
+        ):
             contrast_limits = contrast_limits.tolist()
 
         self._update_fret_setting_in_metadata(
@@ -1446,7 +1432,7 @@ class FretWidget(QWidget):
 
                 self.plot_donor_trajectory()
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"Error applying saved colormap settings: {e}")
                 try:
                     self.fret_layer.events.colormap.connect(
@@ -1455,7 +1441,7 @@ class FretWidget(QWidget):
                     self.fret_layer.events.contrast_limits.connect(
                         self._on_contrast_limits_changed
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
     def _reconnect_existing_fret_layer(self, layer_name):
@@ -1479,24 +1465,18 @@ class FretWidget(QWidget):
     def _on_image_layer_changed(self):
         """Callback whenever the image layer with phasor features changes."""
         if self.current_donor_line is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self.current_donor_line.remove()
-            except ValueError:
-                pass
             self.current_donor_line = None
 
         if self.current_donor_circle is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self.current_donor_circle.remove()
-            except ValueError:
-                pass
             self.current_donor_circle = None
 
         if self.current_background_circle is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self.current_background_circle.remove()
-            except ValueError:
-                pass
             self.current_background_circle = None
 
         # Disconnect events from all FRET layers
@@ -1507,7 +1487,7 @@ class FretWidget(QWidget):
                     layer.events.contrast_limits.disconnect(
                         self._on_contrast_limits_changed
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
         self.fret_layer = None
@@ -1584,7 +1564,7 @@ class FretWidget(QWidget):
                     layer.events.contrast_limits.disconnect(
                         self._on_contrast_limits_changed
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
         self.fret_layers = []
 
@@ -1747,21 +1727,20 @@ class FretWidget(QWidget):
         if (
             not hasattr(self, '_saved_colormap_name')
             or self._updating_settings
-        ):
-            if self.fret_layer is not None:
-                self._update_fret_setting_in_metadata(
-                    'colormap_settings.colormap_name',
-                    self.fret_layer.colormap.name,
-                )
-                self._update_fret_setting_in_metadata(
-                    'colormap_settings.colormap_colors', None
-                )
-                self._update_fret_setting_in_metadata(
-                    'colormap_settings.contrast_limits',
-                    self.fret_layer.contrast_limits,
-                )
-                self._update_fret_setting_in_metadata(
-                    'colormap_settings.colormap_changed', False
-                )
+        ) and self.fret_layer is not None:
+            self._update_fret_setting_in_metadata(
+                'colormap_settings.colormap_name',
+                self.fret_layer.colormap.name,
+            )
+            self._update_fret_setting_in_metadata(
+                'colormap_settings.colormap_colors', None
+            )
+            self._update_fret_setting_in_metadata(
+                'colormap_settings.contrast_limits',
+                self.fret_layer.contrast_limits,
+            )
+            self._update_fret_setting_in_metadata(
+                'colormap_settings.colormap_changed', False
+            )
 
         self.plot_donor_trajectory()

--- a/src/napari_phasors/lifetime_tab.py
+++ b/src/napari_phasors/lifetime_tab.py
@@ -624,7 +624,7 @@ class LifetimeWidget(QWidget):
                     )
                 except (AttributeError, RuntimeError, TypeError):
                     pass
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001
                     show_warning(
                         f"Failed to disconnect lifetime layer events for "
                         f"'{getattr(layer, 'name', 'unknown layer')}': {exc}"
@@ -712,7 +712,7 @@ class LifetimeWidget(QWidget):
             )
 
         for count, bin_start, bin_end in zip(
-            self.counts, self.bin_edges[:-1], self.bin_edges[1:]
+            self.counts, self.bin_edges[:-1], self.bin_edges[1:], strict=False
         ):
             bin_center = (bin_start + bin_end) / 2
             color = cmap(norm(bin_center))
@@ -774,7 +774,7 @@ class LifetimeWidget(QWidget):
                         layer.events.contrast_limits.disconnect(
                             self._on_colormap_changed
                         )
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         pass
 
             self.lifetime_data = None

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1,3 +1,4 @@
+import contextlib
 import copy
 import html
 import math
@@ -584,7 +585,7 @@ class PlotterWidget(QWidget):
                 valid_mask_layers = [
                     mask_l
                     for mask_l in self.viewer.layers
-                    if isinstance(mask_l, Labels) or isinstance(mask_l, Shapes)
+                    if isinstance(mask_l, (Labels, Shapes))
                 ]
                 for mask_l in valid_mask_layers:
                     if isinstance(mask_l, Shapes):
@@ -710,9 +711,7 @@ class PlotterWidget(QWidget):
         for label, attr, settings_key in tab_mapping:
             # Determine if this tab should be shown
             show_tab = False
-            if source_settings is None:
-                show_tab = True
-            elif settings_key is None:
+            if source_settings is None or settings_key is None:
                 show_tab = True
             elif isinstance(settings_key, list):
                 show_tab = any(key in source_settings for key in settings_key)
@@ -907,7 +906,7 @@ class PlotterWidget(QWidget):
                 notifications.WarningNotification(
                     "No valid napari-phasors settings found in file"
                 )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             notifications.WarningNotification(
                 f"Failed to import from file: {str(e)}"
             )
@@ -948,7 +947,7 @@ class PlotterWidget(QWidget):
             notifications.show_info(
                 f"Settings and analyses imported from {source_layer_name}"
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             notifications.WarningNotification(
                 f"Failed to import settings: {str(e)}"
             )
@@ -1394,10 +1393,10 @@ class PlotterWidget(QWidget):
                 )
                 if s_pos >= 0.18:
                     lifetimes.append(lifetime_val)
-            except:
+            except Exception:  # noqa: BLE001
                 continue
 
-        for i, lifetime in enumerate(lifetimes):
+        for _i, lifetime in enumerate(lifetimes):
             if lifetime == 0:
                 g_pos, s_pos = 1.0, 0.0
             else:
@@ -1435,10 +1434,7 @@ class PlotterWidget(QWidget):
             tick_line.set_clip_path(ax.patch)
             self.semi_circle_plot_artist_list.append(tick_line)
 
-            if lifetime == 0:
-                label_text = "0"
-            else:
-                label_text = f"{lifetime:g}"
+            label_text = "0" if lifetime == 0 else f"{lifetime:g}"
 
             label_offset = 0.08
             label_x = g_pos + label_offset * dx_norm
@@ -1616,10 +1612,7 @@ class PlotterWidget(QWidget):
             checkbox state.
         """
         if color is None:
-            if self.white_background:
-                color = "white"
-            else:
-                color = "none"  # Transparent background
+            color = "white" if self.white_background else "none"
 
         if color == "none":
             self.canvas_widget.axes.set_facecolor('none')
@@ -1642,9 +1635,9 @@ class PlotterWidget(QWidget):
         return self.plotter_inputs_widget.plot_type_combobox.currentText()
 
     @plot_type.setter
-    def plot_type(self, type):
+    def plot_type(self, value):
         """Sets the plot type from the plot type combobox."""
-        self.plotter_inputs_widget.plot_type_combobox.setCurrentText(type)
+        self.plotter_inputs_widget.plot_type_combobox.setCurrentText(value)
 
     @property
     def histogram_colormap(self):
@@ -1660,7 +1653,7 @@ class PlotterWidget(QWidget):
     @histogram_colormap.setter
     def histogram_colormap(self, colormap: str):
         """Sets the histogram colormap from the colormap combobox."""
-        if colormap not in colormaps.ALL_COLORMAPS.keys():
+        if colormap not in colormaps.ALL_COLORMAPS:
             notifications.WarningNotification(
                 f"{colormap} is not a valid colormap. Setting to default colormap."
             )
@@ -1736,23 +1729,19 @@ class PlotterWidget(QWidget):
 
     def _disconnect_all_artist_signals(self):
         """Disconnect all artist signals to prevent conflicts."""
-        try:
+        with contextlib.suppress(TypeError, AttributeError):
             self.canvas_widget.artists[
                 'SCATTER'
             ].color_indices_changed_signal.disconnect(
                 self.selection_tab.manual_selection_changed
             )
-        except (TypeError, AttributeError):
-            pass
 
-        try:
+        with contextlib.suppress(TypeError, AttributeError):
             self.canvas_widget.artists[
                 'HISTOGRAM2D'
             ].color_indices_changed_signal.disconnect(
                 self.selection_tab.manual_selection_changed
             )
-        except (TypeError, AttributeError):
-            pass
 
     def reset_layer_choices(self):
         """Reset the image layer checkable combobox choices."""
@@ -1778,15 +1767,15 @@ class PlotterWidget(QWidget):
                 layer.name
                 for layer in self.viewer.layers
                 if isinstance(layer, Image)
-                and "G" in layer.metadata.keys()
-                and "S" in layer.metadata.keys()
-                and "G_original" in layer.metadata.keys()
-                and "S_original" in layer.metadata.keys()
+                and "G" in layer.metadata
+                and "S" in layer.metadata
+                and "G_original" in layer.metadata
+                and "S_original" in layer.metadata
             ]
             mask_layer_names = [
                 layer.name
                 for layer in self.viewer.layers
-                if isinstance(layer, Labels) or isinstance(layer, Shapes)
+                if isinstance(layer, (Labels, Shapes))
             ]
 
             # Add items to the checkable combobox
@@ -1829,20 +1818,16 @@ class PlotterWidget(QWidget):
                 layer = self.viewer.layers[layer_name]
                 if (
                     isinstance(layer, Image)
-                    and "phasor_features_labels_layer" in layer.metadata.keys()
+                    and "phasor_features_labels_layer" in layer.metadata
                 ):
-                    try:
+                    with contextlib.suppress(TypeError, ValueError):
                         layer.events.name.disconnect(self.reset_layer_choices)
-                    except (TypeError, ValueError):
-                        pass  # Not connected, ignore
                     layer.events.name.connect(self.reset_layer_choices)
                 if isinstance(layer, Shapes):
-                    try:
+                    with contextlib.suppress(TypeError, ValueError):
                         layer.events.data.disconnect(
                             self._on_mask_data_changed
                         )
-                    except (TypeError, ValueError):
-                        pass  # Not connected, ignore
                     layer.events.data.connect(self._on_mask_data_changed)
                 if isinstance(layer, Labels):
                     try:
@@ -2347,7 +2332,7 @@ class PlotterWidget(QWidget):
         harmonics = np.atleast_1d(self._harmonics_array)
         try:
             return int(np.where(harmonics == target)[0][0])
-        except Exception:
+        except Exception:  # noqa: BLE001
             return None
 
     def get_phasor_spatial_shape(self):
@@ -2503,10 +2488,7 @@ class PlotterWidget(QWidget):
             return
 
         ZOOM_FACTOR = 1.15  # zoom step (>1 means 15% range change per notch)
-        if event.step > 0:  # scroll up → zoom in
-            scale = 1.0 / ZOOM_FACTOR
-        else:  # scroll down → zoom out
-            scale = ZOOM_FACTOR
+        scale = 1.0 / ZOOM_FACTOR if event.step > 0 else ZOOM_FACTOR
 
         x_mouse, y_mouse = event.xdata, event.ydata
         x_min, x_max = ax.get_xlim()
@@ -2698,13 +2680,21 @@ class PlotterWidget(QWidget):
             ax.title.set_color(state["title_color"])
             for name, sp in ax.spines.items():
                 sp.set_edgecolor(state["spine_colors"][name])
-            for t, c in zip(ax.get_xticklabels(), state["xticklabel_colors"]):
+            for t, c in zip(
+                ax.get_xticklabels(), state["xticklabel_colors"], strict=False
+            ):
                 t.set_color(c)
-            for t, c in zip(ax.get_yticklabels(), state["yticklabel_colors"]):
+            for t, c in zip(
+                ax.get_yticklabels(), state["yticklabel_colors"], strict=False
+            ):
                 t.set_color(c)
-            for t, c in zip(ax.xaxis.get_ticklines(), state["xtick_colors"]):
+            for t, c in zip(
+                ax.xaxis.get_ticklines(), state["xtick_colors"], strict=False
+            ):
                 t.set_markeredgecolor(c)
-            for t, c in zip(ax.yaxis.get_ticklines(), state["ytick_colors"]):
+            for t, c in zip(
+                ax.yaxis.get_ticklines(), state["ytick_colors"], strict=False
+            ):
                 t.set_markeredgecolor(c)
 
         if saved["colorbar"] is not None and self.colorbar is not None:
@@ -2712,16 +2702,22 @@ class PlotterWidget(QWidget):
             self.colorbar.ax.yaxis.label.set_color(cb["ylabel_color"])
             self.colorbar.outline.set_edgecolor(cb["outline_color"])
             for t, c in zip(
-                self.colorbar.ax.get_yticklabels(), cb["ticklabel_colors"]
+                self.colorbar.ax.get_yticklabels(),
+                cb["ticklabel_colors"],
+                strict=False,
             ):
                 t.set_color(c)
             for t, c in zip(
-                self.colorbar.ax.yaxis.get_ticklines(), cb["tick_colors"]
+                self.colorbar.ax.yaxis.get_ticklines(),
+                cb["tick_colors"],
+                strict=False,
             ):
                 t.set_markeredgecolor(c)
 
         for artist, (attr_type, saved_color) in zip(
-            self.semi_circle_plot_artist_list, saved.get("semi_circle", [])
+            self.semi_circle_plot_artist_list,
+            saved.get("semi_circle", []),
+            strict=False,
         ):
             if attr_type == "edgecolor":
                 artist.set_edgecolor(saved_color)
@@ -2729,7 +2725,7 @@ class PlotterWidget(QWidget):
                 artist.set_color(saved_color)
 
         for artist, (attr_type, saved_color) in zip(
-            self.polar_plot_artist_list, saved.get("polar", [])
+            self.polar_plot_artist_list, saved.get("polar", []), strict=False
         ):
             if attr_type == "edgecolor":
                 artist.set_edgecolor(saved_color)

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -1,3 +1,4 @@
+import contextlib
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -211,9 +212,10 @@ class SelectionWidget(QWidget):
 
                 # Only manage layers belonging to the current image layer
                 if source_layer == layer.name:
-                    if selection_type == 'circular_cursor':
-                        viewer_layer.visible = not show_manual
-                    elif selection_type == 'automatic_clustering':
+                    if (
+                        selection_type == 'circular_cursor'
+                        or selection_type == 'automatic_clustering'
+                    ):
                         viewer_layer.visible = not show_manual
                     elif selection_type == 'manual':
                         viewer_layer.visible = show_manual
@@ -336,12 +338,10 @@ class SelectionWidget(QWidget):
 
     def _connect_show_overlay_signal(self):
         """Ensure show_color_overlay_signal is connected only to the current layer's visibility."""
-        try:
+        with contextlib.suppress(TypeError, RuntimeError):
             self.parent_widget.canvas_widget.show_color_overlay_signal.disconnect(
                 self._on_show_color_overlay
             )
-        except (TypeError, RuntimeError):
-            pass
         self.parent_widget.canvas_widget.show_color_overlay_signal.connect(
             self._on_show_color_overlay
         )
@@ -581,9 +581,7 @@ class SelectionWidget(QWidget):
             if (
                 candidate_name in combobox_selections
                 and candidate_name not in used_selections
-            ):
-                return candidate_name
-            elif candidate_name not in combobox_selections:
+            ) or candidate_name not in combobox_selections:
                 return candidate_name
             counter += 1
 
@@ -675,7 +673,9 @@ class SelectionWidget(QWidget):
             selection_splits = [None] * len(selected_layers)
 
         # Apply selection to all selected layers
-        for layer, layer_selection in zip(selected_layers, selection_splits):
+        for layer, layer_selection in zip(
+            selected_layers, selection_splits, strict=False
+        ):
             if (
                 "settings" in layer.metadata
                 and "selections" in layer.metadata["settings"]
@@ -1133,7 +1133,7 @@ class AutomaticClusteringWidget(QWidget):
                 # Create labels layer
                 self._create_or_update_labels_layer(layer, selection_map)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Error applying clustering: {e}")
             import traceback
 
@@ -1244,10 +1244,8 @@ class AutomaticClusteringWidget(QWidget):
 
         # Remove ellipse patch
         if cluster_idx < len(self._ellipse_patches):
-            try:
+            with contextlib.suppress(ValueError):
                 self._ellipse_patches[cluster_idx].remove()
-            except ValueError:
-                pass
             self._ellipse_patches.pop(cluster_idx)
 
         # Remove cluster data
@@ -1510,10 +1508,8 @@ class AutomaticClusteringWidget(QWidget):
         """Clear all clusters and their visual representations."""
         # Remove ellipse patches from canvas
         for patch in self._ellipse_patches:
-            try:
+            with contextlib.suppress(ValueError):
                 patch.remove()
-            except ValueError:
-                pass
 
         self._ellipse_patches.clear()
 
@@ -1534,7 +1530,7 @@ class AutomaticClusteringWidget(QWidget):
 
     def _clear_all_labels_layers(self):
         """Remove all cluster selection labels layers."""
-        for layer_name, labels_layer in list(self._label_layers.items()):
+        for _layer_name, labels_layer in list(self._label_layers.items()):
             try:
                 if labels_layer in self.viewer.layers:
                     self.viewer.layers.remove(labels_layer)
@@ -1545,10 +1541,8 @@ class AutomaticClusteringWidget(QWidget):
     def clear_all_patches(self):
         """Clear all patches from the canvas (called when switching modes)."""
         for patch in self._ellipse_patches:
-            try:
+            with contextlib.suppress(ValueError):
                 patch.remove()
-            except ValueError:
-                pass
         self._ellipse_patches.clear()
 
         if self.parent_widget is not None:
@@ -1652,7 +1646,7 @@ class AutomaticClusteringWidget(QWidget):
                 1.0,
             )
 
-        for layer_name, labels_layer in self._label_layers.items():
+        for _layer_name, labels_layer in self._label_layers.items():
             if labels_layer in self.viewer.layers:
                 labels_layer.colormap = DirectLabelColormap(
                     color_dict=color_dict, name="cluster_colors"
@@ -1936,10 +1930,8 @@ class CircularCursorWidget(QWidget):
 
         # Remove patch from canvas
         if self._cursors[cursor_idx]['patch'] is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 self._cursors[cursor_idx]['patch'].remove()
-            except ValueError:
-                pass
 
         # Remove from data
         self._cursors.pop(cursor_idx)
@@ -2059,10 +2051,8 @@ class CircularCursorWidget(QWidget):
 
         # Remove old patch if exists
         if cursor['patch'] is not None:
-            try:
+            with contextlib.suppress(ValueError):
                 cursor['patch'].remove()
-            except ValueError:
-                pass
             cursor['patch'] = None
 
         # Only create new patch if harmonics match
@@ -2092,10 +2082,8 @@ class CircularCursorWidget(QWidget):
         """Clear all cursors."""
         for cursor in self._cursors:
             if cursor['patch'] is not None:
-                try:
+                with contextlib.suppress(ValueError):
                     cursor['patch'].remove()
-                except ValueError:
-                    pass
 
         self._cursors.clear()
         self.cursor_table.setRowCount(0)
@@ -2109,10 +2097,8 @@ class CircularCursorWidget(QWidget):
         """Clear all patches from the canvas (called when switching modes)."""
         for cursor in self._cursors:
             if cursor['patch'] is not None:
-                try:
+                with contextlib.suppress(ValueError):
                     cursor['patch'].remove()
-                except ValueError:
-                    pass
                 cursor['patch'] = None
 
         if self.parent_widget is not None:
@@ -2213,10 +2199,8 @@ class CircularCursorWidget(QWidget):
         """Callback when image layer changes - clear and restore circular cursors."""
         for cursor in self._cursors:
             if cursor['patch'] is not None:
-                try:
+                with contextlib.suppress(ValueError):
                     cursor['patch'].remove()
-                except ValueError:
-                    pass
                 cursor['patch'] = None
 
         self._cursors.clear()
@@ -2534,7 +2518,7 @@ class CircularCursorWidget(QWidget):
 
         # Update table with statistics
         table_row = 0
-        for cursor_idx, cursor in current_harmonic_cursors:
+        for cursor_idx, _cursor in current_harmonic_cursors:
             count = cursor_pixel_counts[cursor_idx]
             percentage = (
                 (count / total_valid_pixels * 100)


### PR DESCRIPTION
## Fix all ruff lint warnings and enable ruff in pre-commit

Fixes #194 

### Summary

Resolves all 325 ruff lint warnings across 23 source files, bringing the codebase to zero ruff errors. With a clean baseline, ruff is now enabled in `.pre-commit-config.yaml` (v0.15.4) to enforce lint checks on every commit.

### What changed

**Auto-fixed (safe):** unused imports (F401), unnecessary dict/list/tuple calls (C4), modern type annotations (UP), import sorting (I).

**Auto-fixed (unsafe, verified safe):** true/false comparisons (E712), none comparisons (E711), mutable defaults (B006), unused variables (F841), dict.keys() removal (SIM118), try/except/pass → contextlib.suppress (SIM105), zip without strict (B905).

**Manual fixes:**
- Bare `except:` → `except Exception:` (E722)
- `raise` without `from` → `raise ... from err` (B904)
- `typing.List/Tuple` → `list/tuple` (UP035)
- Builtin shadowing `type` → renamed parameter (A002)
- Duplicate test function names → removed shadowed definitions (F811)
- Collapsible if statements → merged (SIM102)
- If/else → ternary (SIM108)
- Unused loop variables → prefixed with `_` (B007)
- Blind exception catches → `# noqa: BLE001` (intentional defensive catches in Qt GUI code)

**Pre-commit & docs:**
- Enabled ruff hook (v0.15.4) in `.pre-commit-config.yaml`
- Updated README Contributing section to reflect all three tools

### Impact

- **0 ruff errors** (was 325)
- **25 files changed**, net -362 lines
- **363 tests pass**, no behavioral changes
- Every future commit is now auto-checked by black + isort + ruff