### PR TITLE
Enhance Scatter plot artists and dynamic UI on plot settings tab

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -114,6 +114,9 @@ def test_phasor_plotter_initialization_values(make_napari_viewer):
     assert hasattr(plotter.plotter_inputs_widget, 'semi_circle_checkbox')
     assert hasattr(plotter.plotter_inputs_widget, 'white_background_checkbox')
     assert hasattr(plotter.plotter_inputs_widget, 'log_scale_checkbox')
+    assert hasattr(plotter.plotter_inputs_widget, 'marker_size_spinbox')
+    assert hasattr(plotter.plotter_inputs_widget, 'marker_alpha_spinbox')
+    assert hasattr(plotter.plotter_inputs_widget, 'marker_color_button')
 
     # Test default property values
     assert plotter.harmonic == 1
@@ -371,6 +374,9 @@ def test_layer_settings_initialization_in_metadata(make_napari_viewer):
     assert 'colormap' in layer.metadata['settings']
     assert 'number_of_bins' in layer.metadata['settings']
     assert 'log_scale' in layer.metadata['settings']
+    assert 'marker_size' in layer.metadata['settings']
+    assert 'marker_alpha' in layer.metadata['settings']
+    assert 'marker_color' in layer.metadata['settings']
 
     # Check default values
     assert layer.metadata['settings']['harmonic'] == 1
@@ -378,8 +384,12 @@ def test_layer_settings_initialization_in_metadata(make_napari_viewer):
     assert layer.metadata['settings']['white_background']
     assert layer.metadata['settings']['plot_type'] == 'HISTOGRAM2D'
     assert layer.metadata['settings']['colormap'] == 'turbo'
+    assert plotter.plotter_inputs_widget.marker_size_spinbox.value() == 50
     assert layer.metadata['settings']['number_of_bins'] == 150
     assert not layer.metadata['settings']['log_scale']
+    assert layer.metadata['settings']['marker_size'] == 50
+    assert layer.metadata['settings']['marker_alpha'] == 0.5
+    assert layer.metadata['settings']['marker_color'] == '#1f77b4'
 
     plotter.deleteLater()
 
@@ -466,6 +476,48 @@ def test_modifying_settings_updates_metadata_correctly(make_napari_viewer):
     # Test white background update
     plotter.plotter_inputs_widget.white_background_checkbox.setChecked(False)
     assert not layer.metadata['settings']['white_background']
+
+    # Test marker size update
+    plotter.plotter_inputs_widget.marker_size_spinbox.setValue(30)
+    assert layer.metadata['settings']['marker_size'] == 30
+
+    # Test marker alpha update
+    plotter.plotter_inputs_widget.marker_alpha_spinbox.setValue(0.8)
+    assert layer.metadata['settings']['marker_alpha'] == 0.8
+
+    # Test marker color update
+    plotter._marker_color = '#ff0000'
+    plotter._update_setting_in_metadata('marker_color', '#ff0000')
+    assert layer.metadata['settings']['marker_color'] == '#ff0000'
+
+    plotter.deleteLater()
+
+
+def test_plot_type_ui_toggles(make_napari_viewer):
+    """Test that switching plot types hides and shows correct inputs."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    # Initial is HISTOGRAM2D
+    assert plotter.plot_type == 'HISTOGRAM2D'
+    assert not plotter.plotter_inputs_widget.colormap_combobox.isHidden()
+    assert not plotter.plotter_inputs_widget.number_of_bins_spinbox.isHidden()
+    assert not plotter.plotter_inputs_widget.log_scale_checkbox.isHidden()
+
+    assert plotter.plotter_inputs_widget.marker_size_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.marker_alpha_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.marker_color_button.isHidden()
+
+    # Change to SCATTER
+    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText('SCATTER')
+
+    assert plotter.plotter_inputs_widget.colormap_combobox.isHidden()
+    assert plotter.plotter_inputs_widget.number_of_bins_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.log_scale_checkbox.isHidden()
+
+    assert not plotter.plotter_inputs_widget.marker_size_spinbox.isHidden()
+    assert not plotter.plotter_inputs_widget.marker_alpha_spinbox.isHidden()
+    assert not plotter.plotter_inputs_widget.marker_color_button.isHidden()
 
     plotter.deleteLater()
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -632,6 +632,17 @@ class PlotterWidget(QWidget):
         self.plotter_inputs_widget.white_background_checkbox.stateChanged.connect(
             self._on_white_background_changed
         )
+
+        self.plotter_inputs_widget.marker_size_spinbox.valueChanged.connect(
+            self._on_marker_size_changed
+        )
+        self.plotter_inputs_widget.marker_color_button.clicked.connect(
+            self._on_marker_color_clicked
+        )
+        self.plotter_inputs_widget.marker_alpha_spinbox.valueChanged.connect(
+            self._on_marker_alpha_changed
+        )
+
         self.import_from_layer_button.clicked.connect(
             self._import_settings_from_layer
         )
@@ -665,6 +676,10 @@ class PlotterWidget(QWidget):
         # Start with the histogram2d plot type
         self.plot_type = 'HISTOGRAM2D'
         self._current_plot_type = 'HISTOGRAM2D'
+
+        # Initialize the dynamic UI elements
+        self._on_plot_type_changed()
+        self._update_scatter_colormap()
 
         # Connect only the initial active artist
         self._connect_active_artist_signals()
@@ -839,6 +854,9 @@ class PlotterWidget(QWidget):
             'colormap': self.histogram_colormap,
             'number_of_bins': self.histogram_bins,
             'log_scale': self.histogram_log_scale,
+            'marker_size': 50,
+            'marker_alpha': 0.5,
+            'marker_color': '#1f77b4',
         }
 
     def _initialize_plot_settings_in_metadata(self, layer):
@@ -953,6 +971,24 @@ class PlotterWidget(QWidget):
                 self.plotter_inputs_widget.log_scale_checkbox.setChecked(
                     settings['log_scale']
                 )
+
+            if 'marker_size' in settings:
+                self.plotter_inputs_widget.marker_size_spinbox.setValue(
+                    settings['marker_size']
+                )
+
+            if 'marker_alpha' in settings:
+                self.plotter_inputs_widget.marker_alpha_spinbox.setValue(
+                    settings['marker_alpha']
+                )
+
+            if 'marker_color' in settings:
+                color = settings['marker_color']
+                self._marker_color = color
+                self.plotter_inputs_widget.marker_color_button.setStyleSheet(
+                    f"background-color: {color};"
+                )
+                self._update_scatter_colormap()
 
         finally:
             self._updating_settings = False
@@ -1138,6 +1174,9 @@ class PlotterWidget(QWidget):
                 "colormap",
                 "number_of_bins",
                 "log_scale",
+                "marker_size",
+                "marker_alpha",
+                "marker_color",
             ],
             "calibration_tab": [
                 "calibrated",
@@ -1628,12 +1667,70 @@ class PlotterWidget(QWidget):
         )
         self._update_setting_in_metadata('plot_type', new_plot_type)
 
+        is_scatter = new_plot_type == 'SCATTER'
+        self.plotter_inputs_widget.label_3.setVisible(not is_scatter)
+        self.plotter_inputs_widget.colormap_combobox.setVisible(not is_scatter)
+        self.plotter_inputs_widget.label_4.setVisible(not is_scatter)
+        self.plotter_inputs_widget.number_of_bins_spinbox.setVisible(
+            not is_scatter
+        )
+        self.plotter_inputs_widget.label_7.setVisible(not is_scatter)
+        self.plotter_inputs_widget.log_scale_checkbox.setVisible(
+            not is_scatter
+        )
+
+        self.plotter_inputs_widget.label_marker_size.setVisible(is_scatter)
+        self.plotter_inputs_widget.marker_size_spinbox.setVisible(is_scatter)
+        self.plotter_inputs_widget.label_marker_color.setVisible(is_scatter)
+        self.plotter_inputs_widget.marker_color_button.setVisible(is_scatter)
+        self.plotter_inputs_widget.label_marker_alpha.setVisible(is_scatter)
+        self.plotter_inputs_widget.marker_alpha_spinbox.setVisible(is_scatter)
+
         if not self._updating_settings:
             old_plot_type = getattr(self, '_current_plot_type', None)
             if new_plot_type != old_plot_type:
                 self._current_plot_type = new_plot_type
                 self._connect_active_artist_signals()
                 self.switch_plot_type(new_plot_type)
+
+    def _on_marker_size_changed(self, value):
+        self._update_setting_in_metadata('marker_size', value)
+        if not self._updating_settings and self.plot_type == 'SCATTER':
+            self.canvas_widget.artists['SCATTER'].size = value
+            self.canvas_widget.figure.canvas.draw_idle()
+
+    def _on_marker_alpha_changed(self, value):
+        self._update_setting_in_metadata('marker_alpha', value)
+        if not self._updating_settings and self.plot_type == 'SCATTER':
+            self.canvas_widget.artists['SCATTER'].alpha = value
+            self.canvas_widget.figure.canvas.draw_idle()
+
+    def _on_marker_color_clicked(self):
+        from qtpy.QtWidgets import QColorDialog
+
+        color = QColorDialog.getColor(parent=self)
+        if color.isValid():
+            hex_color = color.name()
+            self.plotter_inputs_widget.marker_color_button.setStyleSheet(
+                f"background-color: {hex_color};"
+            )
+            self._marker_color = hex_color
+            self._update_setting_in_metadata('marker_color', hex_color)
+            if not self._updating_settings:
+                self._update_scatter_colormap()
+
+    def _update_scatter_colormap(self):
+        from matplotlib.colors import ListedColormap
+
+        current_color = getattr(self, '_marker_color', '#1f77b4')
+
+        new_cmap = ListedColormap([current_color])
+
+        self.canvas_widget.artists['SCATTER'].overlay_colormap = new_cmap
+        self.canvas_widget.artists['SCATTER']._colorize(
+            self.canvas_widget.artists['SCATTER'].color_indices
+        )
+        self.canvas_widget.figure.canvas.draw_idle()
 
     def _on_colormap_changed(self):
         """Callback for colormap change."""
@@ -3567,10 +3664,23 @@ class PlotterWidget(QWidget):
         plot_data = np.column_stack((x_data, y_data))
         self.canvas_widget.artists['SCATTER'].data = plot_data
 
+        # Setting data causes biaplotter to reset size and alpha to default values
+        # Re-apply the user's chosen size and alpha
+        self.canvas_widget.artists['SCATTER'].size = (
+            self.plotter_inputs_widget.marker_size_spinbox.value()
+        )
+        self.canvas_widget.artists['SCATTER'].alpha = (
+            self.plotter_inputs_widget.marker_alpha_spinbox.value()
+        )
+
         # Only update color_indices if changed
         target_color_indices = (
             selection_id_data if selection_id_data is not None else 0
         )
+        if isinstance(target_color_indices, np.ndarray):
+            target_color_indices = target_color_indices.astype(int)
+        else:
+            target_color_indices = int(target_color_indices)
 
         # For arrays, use array_equal; for scalars, use direct comparison
         indices_changed = False

--- a/src/napari_phasors/ui/plotter_inputs_widget.ui
+++ b/src/napari_phasors/ui/plotter_inputs_widget.ui
@@ -35,91 +35,120 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="1" column="1">
-        <widget class="QComboBox" name="plot_type_combobox"/>
-       </item>
-       <item row="3" column="1">
-        <widget class="QSpinBox" name="number_of_bins_spinbox">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>150</number>
-         </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text"><string>Universal Semi-Circle / Full Polar Plot:</string></property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Number of bins:</string>
-         </property>
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="semi_circle_checkbox"/>
+       </item>
+
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text"><string>White Background:</string></property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="white_background_checkbox">
+         <property name="checked"><bool>true</bool></property>
+        </widget>
+       </item>
+
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text"><string>Plot Type:</string></property>
         </widget>
        </item>
        <item row="2" column="1">
+        <widget class="QComboBox" name="plot_type_combobox"/>
+       </item>
+
+       <!-- Histogram Elements -->
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text"><string>Colormap:</string></property>
+        </widget>
+       </item>
+       <item row="3" column="1">
         <widget class="QComboBox" name="colormap_combobox"/>
        </item>
-       <item row="0" column="1">
-        <widget class="QCheckBox" name="semi_circle_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
+
        <item row="4" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Colors in Log Scale:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Colormap:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Plot Type:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Universal Semi-Circle / Full Polar Plot:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>White Background:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QCheckBox" name="white_background_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
+        <widget class="QLabel" name="label_4">
+         <property name="text"><string>Number of bins:</string></property>
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="QCheckBox" name="log_scale_checkbox">
-         <property name="text">
-          <string/>
+        <widget class="QSpinBox" name="number_of_bins_spinbox">
+         <property name="minimum"><number>1</number></property>
+         <property name="maximum"><number>10000</number></property>
+         <property name="value"><number>150</number></property>
+        </widget>
+       </item>
+
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text"><string>Colors in Log Scale:</string></property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="log_scale_checkbox"/>
+       </item>
+
+       <!-- Scatter Plot Elements -->
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_marker_size">
+         <property name="text"><string>Marker Size:</string></property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QSpinBox" name="marker_size_spinbox">
+         <property name="value"><number>50</number></property>
+         <property name="minimum"><number>1</number></property>
+         <property name="maximum"><number>1000</number></property>
+         <property name="keyboardTracking"><bool>false</bool></property>
+        </widget>
+       </item>
+
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_marker_color">
+         <property name="text"><string>Marker Color:</string></property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QPushButton" name="marker_color_button">
+         <property name="text"><string/></property>
+         <property name="minimumSize">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
          </property>
         </widget>
        </item>
+
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_marker_alpha">
+         <property name="text"><string>Alpha:</string></property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QDoubleSpinBox" name="marker_alpha_spinbox">
+         <property name="minimum"><double>0.01</double></property>
+         <property name="maximum"><double>1.0</double></property>
+         <property name="singleStep"><double>0.1</double></property>
+         <property name="value"><double>0.5</double></property>
+         <property name="keyboardTracking"><bool>false</bool></property>
+        </widget>
+       </item>
+
       </layout>
      </widget>
     </widget>


### PR DESCRIPTION
This pull request adds new customization options for scatter plots in the phasor plotter, specifically allowing users to adjust marker size, color, and alpha (transparency) through the UI. These settings are now integrated into the plotter’s metadata, persist across sessions, and dynamically update the plot when changed. The UI has been updated to show or hide relevant controls based on the selected plot type, and tests have been added and updated to ensure correct behavior.

**Scatter Plot Customization Enhancements:**

* Added new UI elements in `plotter_inputs_widget.ui` for scatter plot marker size (`marker_size_spinbox`), color (`marker_color_button`), and alpha (`marker_alpha_spinbox`), with appropriate labels and layout. These controls are only visible when the plot type is set to "SCATTER".
* Introduced logic in `plotter.py` to connect these new UI elements to handler methods that update the plot and the metadata whenever a user changes marker size, color, or alpha. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R635-R645) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R1670-R1734)
* Implemented `_on_plot_type_changed` to toggle visibility of histogram vs. scatter controls based on the selected plot type, ensuring a clean and intuitive UI.

**Metadata and State Management:**

* Updated plot settings defaults and metadata handling to include `marker_size`, `marker_alpha`, and `marker_color` so that these values are saved, restored, and imported/exported with layers. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R857-R859) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R975-R992) [[3]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R1177-R1179)
* Ensured that when scatter plot data is updated, the chosen marker size and alpha are re-applied to prevent them from resetting to defaults.

**Testing Improvements:**

* Expanded tests in `test_plotter.py` to verify presence of the new UI elements, correct initialization of new metadata fields, correct updating of settings and metadata when the user interacts with the UI, and proper toggling of UI controls when switching plot types. [[1]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aR117-R119) [[2]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aR377-R392) [[3]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aR480-R521)

These changes provide users with greater flexibility and control over scatter plot appearance, while ensuring that settings are consistently managed and tested throughout the application.