### PR TITLE
fix: apply calibration and filters to all selected layers, not just the primary one.

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -2097,3 +2097,167 @@ def test_artist_data_cleared_when_no_layer_selected(make_napari_viewer):
         # Verify _remove_artists was called on both artists
         mock_hist_remove.assert_called_once()
         mock_scatter_remove.assert_called_once()
+
+
+def test_import_settings_filter_applies_to_all_selected_layers(
+    make_napari_viewer,
+):
+    """Test that the import settings filter button applies to all selected layers."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    # Create three identical layers and add them to the viewer
+    layer_a = create_image_layer_with_phasors()
+    layer_b = create_image_layer_with_phasors()
+    layer_c = create_image_layer_with_phasors()
+    viewer.add_layer(layer_a)
+    viewer.add_layer(layer_b)
+    viewer.add_layer(layer_c)
+
+    # Select all three layers
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer_a.name, layer_b.name, layer_c.name]
+    )
+
+    # Build a minimal settings dict that represents an active filter
+    imported_settings = {
+        "filter": {"method": "median", "size": 3, "repeat": 1},
+        "threshold": 1.0,
+        "threshold_upper": None,
+        "threshold_method": "Manual",
+    }
+
+    # Apply imported settings (the buggy code only touched the primary layer)
+    plotter._apply_imported_settings(
+        imported_settings, selected_tabs=["filter_tab"]
+    )
+
+    # All three layers must have the filter settings in their metadata
+    for layer in (layer_a, layer_b, layer_c):
+        settings = layer.metadata.get("settings", {})
+        assert (
+            "filter" in settings
+        ), f"{layer.name}: 'filter' key missing from settings after import"
+        assert (
+            settings["filter"].get("method") == "median"
+        ), f"{layer.name}: filter method not saved after import"
+        assert (
+            settings.get("threshold") == 1.0
+        ), f"{layer.name}: threshold not saved after import"
+
+    plotter.deleteLater()
+
+
+def test_apply_calibration_if_needed_applies_to_all_selected_layers(
+    make_napari_viewer,
+):
+    """Test that the apply calibration if needed button applies to all selected layers."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    layer_a = create_image_layer_with_phasors()
+    layer_b = create_image_layer_with_phasors()
+    viewer.add_layer(layer_a)
+    viewer.add_layer(layer_b)
+
+    # Select both layers
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer_a.name, layer_b.name]
+    )
+
+    # Inject fake calibration parameters into both layers so the helper
+    # believes they need calibration applied.
+    for layer in (layer_a, layer_b):
+        layer.metadata.setdefault("settings", {}).update(
+            {
+                "calibrated": True,
+                "calibration_phase": [0.0],
+                "calibration_modulation": [1.0],
+            }
+        )
+        # calibration_applied is intentionally absent / False
+        layer.metadata.pop("calibration_applied", None)
+
+    # Patch the actual phasor transformation so the test stays fast & pure
+    transformed_layers = []
+
+    def _fake_transform(layer_name, phi_zero, mod_zero):
+        transformed_layers.append(layer_name)
+        # Mark as applied so the guard inside the loop works correctly
+        viewer.layers[layer_name].metadata["calibration_applied"] = True
+
+    with patch.object(
+        plotter.calibration_tab,
+        "_apply_phasor_transformation",
+        side_effect=_fake_transform,
+    ):
+        plotter._apply_calibration_if_needed()
+
+    # Both layers must have been transformed — not just the primary one
+    assert layer_a.name in transformed_layers, (
+        "layer_a was not calibrated "
+        "(only primary layer was affected — bug regression)"
+    )
+    assert layer_b.name in transformed_layers, (
+        "layer_b was not calibrated "
+        "(only primary layer was affected — bug regression)"
+    )
+
+    plotter.deleteLater()
+
+
+def test_copy_metadata_from_layer_applies_to_all_selected_layers(
+    make_napari_viewer,
+):
+    """Test that the copy metadata from layer button applies to all selected layers."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    # Source layer whose settings we want to copy
+    source_layer = create_image_layer_with_phasors()
+    # Target layers — all are selected in the combobox
+    layer_b = create_image_layer_with_phasors()
+    layer_c = create_image_layer_with_phasors()
+
+    for lyr in (source_layer, layer_b, layer_c):
+        viewer.add_layer(lyr)
+
+    # Pre-configure the source layer with specific settings we can assert on
+    source_layer.metadata.setdefault("settings", {}).update(
+        {
+            "filter": {"method": "median", "size": 5, "repeat": 2},
+            "threshold": 10.0,
+            "threshold_upper": None,
+            "threshold_method": "Manual",
+        }
+    )
+
+    # Select only the target layers (source is NOT selected)
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer_b.name, layer_c.name]
+    )
+
+    # Import filter settings from the source layer
+    plotter._copy_metadata_from_layer(
+        source_layer.name, selected_tabs=["filter_tab"]
+    )
+
+    # Both target layers must now carry the filter settings
+    for layer in (layer_b, layer_c):
+        settings = layer.metadata.get("settings", {})
+        assert "filter" in settings, (
+            f"{layer.name}: 'filter' key missing — "
+            "settings were not copied to this layer"
+        )
+        assert settings["filter"].get("size") == 5, (
+            f"{layer.name}: filter size not copied "
+            "(only primary layer was affected — bug regression)"
+        )
+        assert (
+            settings.get("threshold") == 10.0
+        ), f"{layer.name}: threshold not copied from source layer"
+
+    # Source layer's own settings must remain unchanged
+    assert source_layer.metadata["settings"]["filter"]["size"] == 5
+
+    plotter.deleteLater()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1142,26 +1142,24 @@ class PlotterWidget(QWidget):
         self._on_tab_changed(current_tab_index)
 
     def _apply_calibration_if_needed(self):
-        """Apply calibration transformation if needed."""
-        layer_name = (
-            self.image_layer_with_phasor_features_combobox.currentText()
-        )
-        if not layer_name or layer_name not in self.viewer.layers:
+        """Apply calibration transformation if needed to all selected layers."""
+        selected_layers = self.get_selected_layers()
+        if not selected_layers:
             return
-        layer = self.viewer.layers[layer_name]
-        settings = layer.metadata.get("settings", {})
-        if (
-            settings.get("calibrated", False)
-            and "calibration_phase" in settings
-            and "calibration_modulation" in settings
-            and not layer.metadata.get("calibration_applied", False)
-        ):
-            phi_zero = settings["calibration_phase"]
-            mod_zero = settings["calibration_modulation"]
-            self.calibration_tab._apply_phasor_transformation(
-                layer_name, phi_zero, mod_zero
-            )
-            layer.metadata["calibration_applied"] = True
+        for layer in selected_layers:
+            settings = layer.metadata.get("settings", {})
+            if (
+                settings.get("calibrated", False)
+                and "calibration_phase" in settings
+                and "calibration_modulation" in settings
+                and not layer.metadata.get("calibration_applied", False)
+            ):
+                phi_zero = settings["calibration_phase"]
+                mod_zero = settings["calibration_modulation"]
+                self.calibration_tab._apply_phasor_transformation(
+                    layer.name, phi_zero, mod_zero
+                )
+                layer.metadata["calibration_applied"] = True
 
     def _get_import_settings_groups(self):
         """Return the settings keys controlled by each importable tab."""
@@ -1251,13 +1249,26 @@ class PlotterWidget(QWidget):
             harmonics=harmonics,
         )
 
-    def _apply_imported_analyses(self, layer, selected_tabs):
-        """Apply imported analysis settings that affect layer data."""
+    def _apply_imported_analyses(self, layers, selected_tabs):
+        """Apply imported analysis settings that affect layer data.
+
+        Parameters
+        ----------
+        layers : list of napari.layers.Image or napari.layers.Image
+            The target layer(s) to apply analyses to.
+        selected_tabs : list of str
+            The tabs whose analyses should be applied.
+        """
+        # Support both single layer and list of layers for backward compat
+        if not isinstance(layers, list):
+            layers = [layers]
+
         if "calibration_tab" in selected_tabs:
             self._apply_calibration_if_needed()
 
         if "filter_tab" in selected_tabs:
-            self._apply_imported_filter_if_needed(layer)
+            for layer in layers:
+                self._apply_imported_filter_if_needed(layer)
             self.refresh_phasor_data()
 
     def _import_settings_from_layer(self):
@@ -1268,9 +1279,7 @@ class PlotterWidget(QWidget):
         layout.addWidget(QLabel("Select layer to import settings from:"))
 
         layer_combo = QComboBox()
-        current_layer = (
-            self.image_layer_with_phasor_features_combobox.currentText()
-        )
+        selected_layer_names = set(self.get_selected_layer_names())
         available_layers = [
             layer.name
             for layer in self.viewer.layers
@@ -1279,7 +1288,7 @@ class PlotterWidget(QWidget):
                 key in layer.metadata
                 for key in ["G", "S", "G_original", "S_original"]
             )
-            and layer.name != current_layer
+            and layer.name not in selected_layer_names
         ]
         layer_combo.addItems(available_layers)
         layout.addWidget(layer_combo)
@@ -1359,51 +1368,61 @@ class PlotterWidget(QWidget):
             )
 
     def _copy_metadata_from_layer(self, source_layer_name, selected_tabs):
-        """Copy metadata from source layer to current layer and apply selected analyses."""
+        """Copy metadata from source layer to all selected layers and apply selected analyses."""
         try:
             source_layer = self.viewer.layers[source_layer_name]
-            current_layer_name = (
-                self.image_layer_with_phasor_features_combobox.currentText()
-            )
-            if not current_layer_name:
+            selected_layers = self.get_selected_layers()
+            if not selected_layers:
                 notifications.WarningNotification("No layer selected")
                 return
-            current_layer = self.viewer.layers[current_layer_name]
+
             source_settings = copy.deepcopy(
                 source_layer.metadata.get('settings', {})
-            )
-            current_settings = copy.deepcopy(
-                current_layer.metadata.get('settings', {})
             )
 
             selected_analysis_tabs = [
                 tab for tab in selected_tabs if tab != "frequency"
             ]
 
-            self._prepare_layer_for_import(
-                current_layer, selected_analysis_tabs
-            )
+            for target_layer in selected_layers:
+                current_settings = copy.deepcopy(
+                    target_layer.metadata.get('settings', {})
+                )
 
-            current_layer.metadata['settings'] = self._merge_imported_settings(
-                current_settings,
-                source_settings,
-                selected_analysis_tabs,
-            )
+                self._prepare_layer_for_import(
+                    target_layer, selected_analysis_tabs
+                )
+
+                target_layer.metadata['settings'] = (
+                    self._merge_imported_settings(
+                        current_settings,
+                        source_settings,
+                        selected_analysis_tabs,
+                    )
+                )
+
+                if (
+                    "frequency" in selected_tabs
+                    and 'frequency' in source_settings
+                ):
+                    freq_val = source_settings['frequency']
+                    update_frequency_in_metadata(target_layer, freq_val)
 
             if "frequency" in selected_tabs and 'frequency' in source_settings:
-                freq_val = source_settings['frequency']
-                update_frequency_in_metadata(current_layer, freq_val)
-                self._broadcast_frequency_value_across_tabs(str(freq_val))
+                self._broadcast_frequency_value_across_tabs(
+                    str(source_settings['frequency'])
+                )
 
             self._apply_imported_analyses(
-                current_layer, selected_analysis_tabs
+                selected_layers, selected_analysis_tabs
             )
 
             self._restore_plot_settings_from_metadata()
             self._restore_all_tab_analyses(selected_tabs)
             self.plot()
+            layer_names = ", ".join([layer.name for layer in selected_layers])
             notifications.show_info(
-                f"Settings and analyses imported from {source_layer_name}"
+                f"Settings and analyses imported from {source_layer_name} to {layer_names}"
             )
         except Exception as e:  # noqa: BLE001
             notifications.WarningNotification(
@@ -1411,35 +1430,41 @@ class PlotterWidget(QWidget):
             )
 
     def _apply_imported_settings(self, settings, selected_tabs):
-        current_layer_name = (
-            self.image_layer_with_phasor_features_combobox.currentText()
-        )
-        if not current_layer_name:
+        selected_layers = self.get_selected_layers()
+        if not selected_layers:
             notifications.WarningNotification("No layer selected")
             return
-        current_layer = self.viewer.layers[current_layer_name]
-        current_settings = copy.deepcopy(
-            current_layer.metadata.get('settings', {})
-        )
+
         selected_analysis_tabs = [
             tab for tab in selected_tabs if tab != "frequency"
         ]
 
-        self._prepare_layer_for_import(current_layer, selected_analysis_tabs)
+        for target_layer in selected_layers:
+            current_settings = copy.deepcopy(
+                target_layer.metadata.get('settings', {})
+            )
 
-        current_layer.metadata['settings'] = self._merge_imported_settings(
-            current_settings,
-            settings,
-            selected_analysis_tabs,
-        )
+            self._prepare_layer_for_import(
+                target_layer, selected_analysis_tabs
+            )
+
+            target_layer.metadata['settings'] = self._merge_imported_settings(
+                current_settings,
+                settings,
+                selected_analysis_tabs,
+            )
+
+            if 'frequency' in selected_tabs and 'frequency' in settings:
+                update_frequency_in_metadata(
+                    target_layer, settings['frequency']
+                )
 
         if 'frequency' in selected_tabs and 'frequency' in settings:
-            update_frequency_in_metadata(current_layer, settings['frequency'])
             self._broadcast_frequency_value_across_tabs(
                 str(settings['frequency'])
             )
 
-        self._apply_imported_analyses(current_layer, selected_analysis_tabs)
+        self._apply_imported_analyses(selected_layers, selected_analysis_tabs)
 
         self._restore_plot_settings_from_metadata()
         self._restore_all_tab_analyses(selected_tabs)


### PR DESCRIPTION
This pull request expands support for applying analysis settings and metadata operations to multiple selected layers at once in the napari-phasors plugin. Previously, several actions (such as importing settings, applying filters or calibration, and copying metadata) only affected a single "primary" layer. With these changes, all relevant operations now consistently apply to all selected layers, improving usability and fixing bugs where only one layer was updated.

Fixes #218.

Key changes include:

**Expanded Multi-Layer Operations:**

* Refactored `_apply_calibration_if_needed` to apply calibration to all selected layers, not just the primary one. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L1145-R1149) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L1162-R1160)
* Updated `_apply_imported_analyses` and related methods to accept and process lists of layers, ensuring imported analyses and filters are applied to all selected layers.
* Modified `_copy_metadata_from_layer` and `_apply_imported_settings` to copy metadata and settings to all selected layers, not just the current layer, and improved notifications to reflect this.

**User Interface Improvements:**

* Adjusted the layer selection logic in `_import_settings_from_layer` to exclude all currently selected layers from the source options, preventing users from copying settings from a target to itself. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L1271-R1282) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L1282-R1291)

**Test Coverage:**

* Added new tests to verify that importing settings, applying calibration, and copying metadata all correctly update every selected layer, preventing regressions where only one layer is affected.