### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-14, macos-15]
-        python-version: ['3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "napari-phasors"
 dynamic = ["version"]
 description = "A simple plugin to use phasor analysis"
 readme = "README.md"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 authors = [
     { name = "Bruno Pannunzio", email = "bpannunzio@pasteur.edu.uy" },
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Image Processing",
     "Topic :: Scientific/Engineering :: Visualization"
 ]
@@ -94,7 +95,7 @@ fallback_version = "0.0.0"
 
 [tool.black]
 line-length = 79
-target-version = ["py312", "py313"]
+target-version = ["py312", "py313", "py314"]
 skip-string-normalization = true
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{312, 313}-{linux,macos,windows}
+envlist = py{312, 313, 314}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
This pull request updates the project to add support for Python 3.14 across the codebase, including configuration files and CI workflows. The changes ensure that the project can be built, tested, and distributed using Python 3.14 in addition to the previously supported versions.

This was made possible by the latest [0.7.0 version of napari](https://github.com/napari/napari/releases/tag/v0.7.0) released today.

**Python 3.14 support:**

* Added Python 3.14 to the test matrix in the GitHub Actions workflow to ensure CI tests run on Python 3.14 (`.github/workflows/run-tests.yml`). [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L25-R25) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L73-R73)
* Updated `pyproject.toml` to remove the upper Python version bound, allowing Python 3.14 and above, and added Python 3.14 to the `Programming Language` classifiers. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L6-R6) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R26)
* Added Python 3.14 as a target version for the Black code formatter in `pyproject.toml`.
* Updated `tox.ini` to include Python 3.14 environments for testing and added mapping for Python 3.14 in the GitHub Actions section.