### PR TITLE
Update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,19 +10,19 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.3.1
     hooks:
       - id: black
         args: ["--config", "pyproject.toml"]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         args: ["--settings-path", "pyproject.toml"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.7
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml", "--fix"]


### PR DESCRIPTION
This pull request updates several pre-commit hooks to their latest versions in the `.pre-commit-config.yaml` file. These updates help ensure that the project uses the most recent bug fixes and features for code formatting and linting tools.

Dependency updates:

* Updated `pre-commit-hooks` from `v5.0.0` to `v6.0.0` to bring in the latest checks and improvements.
* Updated `black` from `24.10.0` to `26.3.1` for the latest Python code formatting features and fixes.
* Updated `isort` from `5.13.2` to `8.0.1` for improved import sorting and compatibility.
* Updated `ruff-pre-commit` from `v0.15.4` to `v0.15.7` for enhanced linting capabilities.