### PR TITLE
feat: add CSV export functionality to HistogramWidget

### DIFF
--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -1,3 +1,5 @@
+import csv
+
 import numpy as np
 
 from napari_phasors._utils import (
@@ -26,6 +28,7 @@ def test_histogram_widget_update_data_and_clear(qtbot):
     assert np.all(np.isfinite(widget._raw_valid_data))
     assert widget._settings_button.isEnabled()
     assert widget.save_png_button.isEnabled()
+    assert widget.save_csv_button.isEnabled()
 
     widget.clear()
 
@@ -36,6 +39,64 @@ def test_histogram_widget_update_data_and_clear(qtbot):
     assert widget._raw_valid_data is None
     assert not widget._settings_button.isEnabled()
     assert not widget.save_png_button.isEnabled()
+    assert not widget.save_csv_button.isEnabled()
+
+
+def test_histogram_widget_save_csv(qtbot, tmp_path, monkeypatch):
+    """HistogramWidget should export CSV accurately in all modes."""
+    from qtpy.QtWidgets import QFileDialog
+
+    widget = HistogramWidget(bins=2)
+    qtbot.addWidget(widget)
+
+    # Put some data
+    data1 = np.array([1.0, 1.0, 2.0])
+    data2 = np.array([1.0, 2.0, 2.0])
+
+    csv_file = tmp_path / "test.csv"
+    monkeypatch.setattr(
+        QFileDialog,
+        "getSaveFileName",
+        lambda *args, **kwargs: (str(csv_file), ""),
+    )
+
+    # 1. Test Merged (default) mode with multiple datasets
+    widget.update_multi_data({"Layer 1": data1, "Layer 2": data2})
+    widget._display_mode = "Merged"
+    widget._save_histogram_csv()
+
+    assert csv_file.exists()
+
+    with open(csv_file, newline='') as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    assert rows[0] == ['Bin Center', 'Mean Counts', 'Std Counts']
+    assert len(rows) == 3  # Header + 2 bins
+
+    # 2. Test Grouped mode
+    widget._display_mode = "Grouped"
+    widget._group_assignments = {"Layer 1": 1, "Layer 2": 1}
+    widget._group_names = {1: "MyGroup"}
+    widget._save_histogram_csv()
+
+    with open(csv_file, newline='') as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    assert rows[0] == ['Bin Center', 'MyGroup Mean', 'MyGroup Std']
+    assert len(rows) == 3
+
+    # 3. Test Individual mode
+    widget._display_mode = "Individual layers"
+    widget._save_histogram_csv()
+
+    with open(csv_file, newline='') as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    assert rows[0] == ['Bin Center', 'Layer 1', 'Layer 2']
+    assert len(rows) == 3
 
 
 def test_histogram_widget_default_filter_keeps_zero(qtbot):

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -1558,11 +1558,17 @@ class HistogramWidget(QWidget):
         self.save_png_button.clicked.connect(self._save_histogram_png)
         controls_layout.addWidget(self.save_png_button)
 
+        self.save_csv_button = QPushButton("Save Histogram as CSV")
+        self.save_csv_button.setMinimumWidth(180)
+        self.save_csv_button.clicked.connect(self._save_histogram_csv)
+        controls_layout.addWidget(self.save_csv_button)
+
         layout.addLayout(controls_layout)
 
         # Buttons are disabled until data is loaded
         self._settings_button.setEnabled(False)
         self.save_png_button.setEnabled(False)
+        self.save_csv_button.setEnabled(False)
 
     def _filter_valid_values(self, data: np.ndarray) -> np.ndarray:
         """Return finite values, optionally excluding non-positive entries."""
@@ -1738,6 +1744,116 @@ class HistogramWidget(QWidget):
         self._style_axes(export_mode=False)
         self.fig.canvas.draw_idle()
 
+    def _save_histogram_csv(self):
+        """Save the histogram data as a CSV file."""
+        if self.counts is None or self.bin_centers is None:
+            return
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Histogram as CSV",
+            "",
+            "CSV Files (*.csv)",
+        )
+
+        if not file_path:
+            return
+
+        if not file_path.endswith('.csv'):
+            file_path += '.csv'
+
+        import csv
+
+        try:
+            with open(file_path, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                n_datasets = len(self._counts_per_dataset)
+
+                if self._display_mode == "Individual layers":
+                    # Export individual counts per dataset aligned on the same bins
+                    header = ['Bin Center'] + list(
+                        self._counts_per_dataset.keys()
+                    )
+                    writer.writerow(header)
+                    for i in range(len(self.bin_centers)):
+                        row = [self.bin_centers[i]]
+                        for label in self._counts_per_dataset:
+                            row.append(self._counts_per_dataset[label][i])
+                        writer.writerow(row)
+
+                elif self._display_mode == "Grouped":
+                    # Export grouped means and stdevs
+                    groups = {}
+                    for label, counts in self._counts_per_dataset.items():
+                        g = self._group_assignments.get(label, 1)
+                        groups.setdefault(g, []).append((label, counts))
+
+                    header = ['Bin Center']
+                    group_stats = {}
+
+                    for group_id, members in sorted(groups.items()):
+                        group_label = self._group_names.get(
+                            group_id, f"Group {group_id}"
+                        )
+                        header.append(f"{group_label} Mean")
+                        if len(members) > 1:
+                            header.append(f"{group_label} Std")
+
+                        all_counts = np.array(
+                            [c for _, c in members], dtype=float
+                        )
+                        mean_c = np.mean(all_counts, axis=0)
+                        std_c = (
+                            np.std(all_counts, axis=0, ddof=1)
+                            if len(members) > 1
+                            else None
+                        )
+                        group_stats[group_id] = (mean_c, std_c)
+
+                    writer.writerow(header)
+
+                    for i in range(len(self.bin_centers)):
+                        row = [self.bin_centers[i]]
+                        for _group_id, (mean_c, std_c) in sorted(
+                            group_stats.items()
+                        ):
+                            row.append(mean_c[i])
+                            if std_c is not None:
+                                row.append(std_c[i])
+                        writer.writerow(row)
+
+                else:
+                    # Merged mode
+                    if n_datasets > 1:
+                        all_counts = np.array(
+                            list(self._counts_per_dataset.values()),
+                            dtype=float,
+                        )
+                        mean_counts = np.mean(all_counts, axis=0)
+                        std_counts = np.std(all_counts, axis=0, ddof=1)
+
+                        writer.writerow(
+                            ['Bin Center', 'Mean Counts', 'Std Counts']
+                        )
+                        for i in range(len(self.bin_centers)):
+                            writer.writerow(
+                                [
+                                    self.bin_centers[i],
+                                    mean_counts[i],
+                                    std_counts[i],
+                                ]
+                            )
+                    else:
+                        writer.writerow(['Bin Center', 'Counts'])
+                        for i in range(len(self.bin_centers)):
+                            writer.writerow(
+                                [self.bin_centers[i], self.counts[i]]
+                            )
+        except (OSError, csv.Error) as e:
+            from napari.utils.notifications import show_error
+
+            show_error(f"Error saving CSV: {str(e)}")
+
     def _open_settings_dialog(self):
         """Open the histogram settings dialog."""
         layer_labels = list(self._datasets.keys()) if self._datasets else None
@@ -1801,6 +1917,7 @@ class HistogramWidget(QWidget):
             self.fig.canvas.draw_idle()
             self._settings_button.setEnabled(False)
             self.save_png_button.setEnabled(False)
+            self.save_csv_button.setEnabled(False)
             self.show()
             self.dataChanged.emit()
             return
@@ -1817,6 +1934,7 @@ class HistogramWidget(QWidget):
         self._render()
         self._settings_button.setEnabled(True)
         self.save_png_button.setEnabled(True)
+        self.save_csv_button.setEnabled(True)
         self.show()
         self.dataChanged.emit()
 
@@ -1852,6 +1970,7 @@ class HistogramWidget(QWidget):
             self.fig.canvas.draw_idle()
             self._settings_button.setEnabled(False)
             self.save_png_button.setEnabled(False)
+            self.save_csv_button.setEnabled(False)
             self.show()
             self.dataChanged.emit()
             return
@@ -1874,6 +1993,7 @@ class HistogramWidget(QWidget):
         self._render()
         self._settings_button.setEnabled(True)
         self.save_png_button.setEnabled(True)
+        self.save_csv_button.setEnabled(True)
         self.show()
         self.dataChanged.emit()
 
@@ -1910,6 +2030,7 @@ class HistogramWidget(QWidget):
         self.fig.canvas.draw_idle()
         self._settings_button.setEnabled(False)
         self.save_png_button.setEnabled(False)
+        self.save_csv_button.setEnabled(False)
         self.dataChanged.emit()
 
     @property


### PR DESCRIPTION
This pull request adds the ability to export histogram data as a CSV file from the `HistogramWidget`, and ensures that the "Save as CSV" button is enabled or disabled appropriately based on widget state. It also introduces comprehensive tests for the new CSV export functionality, covering all display modes.

Closes #227 

**New feature: CSV export for histograms**
- Added a `save_csv_button` to the `HistogramWidget` UI, which allows users to export histogram data to a CSV file. The button is enabled only when valid data is present and is disabled when data is cleared or invalid. [[1]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R1561-R1571) [[2]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R1920) [[3]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R1937) [[4]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R1973) [[5]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R1996) [[6]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R2033)
- Implemented the `_save_histogram_csv` method in `HistogramWidget` to handle exporting data in all display modes: "Merged", "Grouped", and "Individual layers", with appropriate CSV formatting and error handling.

**Testing improvements**
- Added tests to verify that the "Save as CSV" button is enabled/disabled in sync with data state, and to ensure the CSV export produces correct output for all histogram display modes. [[1]](diffhunk://#diff-59fee090652bc67654dca105f1fb1b8de710c477038a85d8300c2efe158a4cf4R31) [[2]](diffhunk://#diff-59fee090652bc67654dca105f1fb1b8de710c477038a85d8300c2efe158a4cf4R42-R99)
- Imported the `csv` module in the test file to support new tests.