### PR TITLE
Add support for .tiff and .ome.tiff file extensions

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -56,6 +56,12 @@ extension_mapping = {
             {},
             reader_options,
         ),
+        ".tiff": lambda path, reader_options: _parse_and_call_io_function(
+            path,
+            tifffile.imread,
+            {},
+            reader_options,
+        ),
         # ".flif": lambda path: io.read_flif(path),
         # ".bh": lambda path: io.read_bh(path),
         # ".bhz": lambda path: io.read_bhz(path),
@@ -63,6 +69,9 @@ extension_mapping = {
     },
     "processed": {
         ".ome.tif": lambda path, reader_options: _parse_and_call_io_function(
+            path, io.phasor_from_ometiff, {}, reader_options
+        ),
+        ".ome.tiff": lambda path, reader_options: _parse_and_call_io_function(
             path, io.phasor_from_ometiff, {}, reader_options
         ),
         # ".b64": lambda path: io.read_b64(path),
@@ -82,6 +91,7 @@ iter_index_mapping = {
     ".fbd": "C",
     ".lsm": None,
     ".tif": None,
+    ".tiff": None,
     '.sdt': "C",
 }
 """This dictionary contains the mapping for the axis to iterate over
@@ -201,7 +211,7 @@ def raw_file_reader(
 
     if iter_axis is None or iter_axis not in raw_data.dims:
         # Handle files without iteration axis or when keepdims=False squeezed it out
-        if file_extension == ".tif":
+        if file_extension in [".tif", ".tiff"]:
             axis = 0
         elif iter_axis is None:
             # Hyperspectral files - find "C" dimension
@@ -210,7 +220,7 @@ def raw_file_reader(
             # FLIM files without "C" dimension (single channel)
             axis = raw_data.dims.index("H")
 
-        if file_extension in [".lsm", ".tif"]:
+        if file_extension in [".lsm", ".tif", ".tiff"]:
             axes_to_sum = tuple(range(1, len(raw_data.shape)))
         else:
             axes_to_sum = tuple(
@@ -223,7 +233,7 @@ def raw_file_reader(
             summed_signal = summed_signal.values
 
         # Only set channel for files that actually have channels (FLIM files)
-        if file_extension not in [".lsm", ".tif"]:
+        if file_extension not in [".lsm", ".tif", ".tiff"]:
             settings['channel'] = 0
 
         mean_intensity_image, G_image, S_image = phasor_from_signal(

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -296,6 +296,18 @@ def test_reader_ometif():
     assert list(harmonics) == [1, 2]
 
 
+def test_reader_ometiff_extension():
+    """Test .ome.tiff extension maps to processed reader."""
+    reader = napari_get_reader("test_file.ome.tiff")
+    assert callable(reader)
+
+
+def test_reader_tiff_extension():
+    """Test .tiff extension maps to raw reader."""
+    reader = napari_get_reader("test_file.tiff")
+    assert callable(reader)
+
+
 def test_reader_ometif_metadata():
     """Test reading OME-TIFF file and verify metadata settings"""
     ometif_file = get_test_file_path("test_file.ome.tif")

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -73,7 +73,9 @@ class PhasorTransform(QWidget):
             ".ptu": PtuWidget,
             ".lsm": LsmWidget,
             ".tif": LsmWidget,
+            ".tiff": LsmWidget,
             ".ome.tif": OmeTifWidget,
+            ".ome.tiff": OmeTifWidget,
             ".sdt": SdtWidget,
         }
 
@@ -83,7 +85,7 @@ class PhasorTransform(QWidget):
         dialog = QFileDialog(self, "Select Export Location", options=options)
         dialog.setFileMode(QFileDialog.AnyFile)
         dialog.setNameFilter(
-            "All files (*.tif *.ome.tif *.ptu *.fbd *.sdt *.lsm)"
+            "All files (*.tif *.tiff *.ome.tif *.ome.tiff *.ptu *.fbd *.sdt *.lsm)"
         )
         if dialog.exec_():
             selected_file = dialog.selectedFiles()[0]


### PR DESCRIPTION
This pull request adds support for `.tiff` and `.ome.tiff` file extensions throughout the napari-phasors plugin, ensuring that these common variants are handled equivalently to their `.tif` and `.ome.tif` counterparts. The changes update file readers, widget mappings, and dialog filters, and introduce tests to verify the new functionality.

Closes #224 

**File format support improvements:**

* Added `.tiff` and `.ome.tiff` extensions to the file readers in `_reader.py`, mapping them to the same processing functions as `.tif` and `.ome.tif` respectively. This ensures that files with these extensions are correctly recognized and processed. [[1]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R59-R64) [[2]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R74-R76)
* Updated the `AXIS_MAPPING` and logic in `raw_file_reader` to treat `.tiff` files the same as `.tif`, including axis handling and channel assignment. [[1]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R94) [[2]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598L204-R214) [[3]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598L213-R223) [[4]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598L226-R236)

**User interface updates:**

* Extended widget mapping in `_widget.py` to support `.tiff` and `.ome.tiff` extensions, ensuring that the correct widgets are used for these file types.
* Updated the file dialog filter to include `.tiff` and `.ome.tiff`, making it easier for users to select these files in the UI.

**Testing enhancements:**

* Added tests to verify that `.tiff` and `.ome.tiff` extensions are correctly mapped to their respective readers.