### PR TITLE
Update plot types and add `None` artist type

### DIFF
--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -1379,20 +1379,30 @@ def test_phasor_mapping_widget_apply_2d_text_tracks_plot_type(
         == "Apply colormap to 2D Histogram"
     )
 
-    parent.plotter_inputs_widget.plot_type_combobox.setCurrentText('SCATTER')
+    parent.plotter_inputs_widget.plot_type_combobox.setCurrentText(
+        "Dot Plot (Scatter)"
+    )
     assert (
         mapping_widget.apply_2d_colormap_checkbox.text()
         == "Apply colormap to Scatter plot"
     )
 
-    parent.plotter_inputs_widget.plot_type_combobox.setCurrentText('CONTOUR')
+    parent.plotter_inputs_widget.plot_type_combobox.setCurrentText(
+        "Contour Plot"
+    )
     assert (
         mapping_widget.apply_2d_colormap_checkbox.text()
         == "Apply colormap to Contour plot"
     )
 
+    parent.plotter_inputs_widget.plot_type_combobox.setCurrentText("None")
+    assert (
+        mapping_widget.apply_2d_colormap_checkbox.text()
+        == "Apply colormap to Plot"
+    )
+
     parent.plotter_inputs_widget.plot_type_combobox.setCurrentText(
-        'HISTOGRAM2D'
+        "Density Plot (2D Histogram)"
     )
     assert (
         mapping_widget.apply_2d_colormap_checkbox.text()

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -134,7 +134,12 @@ def test_phasor_plotter_initialization_values(make_napari_viewer):
         plot_types.append(
             plotter.plotter_inputs_widget.plot_type_combobox.itemText(i)
         )
-    assert plot_types == ['HISTOGRAM2D', 'SCATTER', 'CONTOUR']
+    assert plot_types == [
+        "Density Plot (2D Histogram)",
+        "Dot Plot (Scatter)",
+        "Contour Plot",
+        "None",
+    ]
 
     # Test colormap combobox has items (should have all available colormaps)
     assert plotter.plotter_inputs_widget.colormap_combobox.count() > 0
@@ -455,7 +460,9 @@ def test_modifying_settings_updates_metadata_correctly(make_napari_viewer):
     assert layer.metadata['settings']['harmonic'] == 3
 
     # Test plot type update
-    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText('SCATTER')
+    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText(
+        "Dot Plot (Scatter)"
+    )
     assert layer.metadata['settings']['plot_type'] == 'SCATTER'
 
     # Test colormap update
@@ -510,7 +517,9 @@ def test_plot_type_ui_toggles(make_napari_viewer):
     assert plotter.plotter_inputs_widget.marker_color_button.isHidden()
 
     # Change to SCATTER
-    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText('SCATTER')
+    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText(
+        "Dot Plot (Scatter)"
+    )
 
     assert plotter._colormap_row_widget.isHidden()
     assert plotter.plotter_inputs_widget.number_of_bins_spinbox.isHidden()
@@ -521,7 +530,9 @@ def test_plot_type_ui_toggles(make_napari_viewer):
     assert not plotter.plotter_inputs_widget.marker_color_button.isHidden()
 
     # Change to CONTOUR
-    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText('CONTOUR')
+    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText(
+        "Contour Plot"
+    )
 
     assert not plotter._colormap_row_widget.isHidden()
     assert not plotter.plotter_inputs_widget.number_of_bins_spinbox.isHidden()
@@ -535,6 +546,20 @@ def test_plot_type_ui_toggles(make_napari_viewer):
     assert (
         not plotter.plotter_inputs_widget.contour_linewidth_spinbox.isHidden()
     )
+
+    # Change to None
+    plotter.plotter_inputs_widget.plot_type_combobox.setCurrentText("None")
+
+    assert plotter._colormap_row_widget.isHidden()
+    assert plotter.plotter_inputs_widget.number_of_bins_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.log_scale_checkbox.isHidden()
+
+    assert plotter.plotter_inputs_widget.marker_size_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.marker_alpha_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.marker_color_button.isHidden()
+
+    assert plotter.plotter_inputs_widget.contour_levels_spinbox.isHidden()
+    assert plotter.plotter_inputs_widget.contour_linewidth_spinbox.isHidden()
 
     plotter.deleteLater()
 

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -254,6 +254,8 @@ class PhasorMappingWidget(QWidget):
             suffix = "Scatter plot"
         elif plot_type == 'CONTOUR':
             suffix = "Contour plot"
+        elif plot_type == 'NONE':
+            suffix = "Plot"
         else:
             suffix = "2D Histogram"
         self.apply_2d_colormap_checkbox.setText(f"Apply colormap to {suffix}")
@@ -1270,7 +1272,7 @@ class PhasorMappingWidget(QWidget):
         if output_type not in {"Phase", "Modulation"}:
             return
         pw = self.parent_widget
-        if pw is None:
+        if pw is None or getattr(pw, 'plot_type', 'HISTOGRAM2D') == 'NONE':
             return
 
         features = pw.get_merged_features()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1145,6 +1145,14 @@ class PlotterWidget(QWidget):
 
     """
 
+    PLOT_TYPE_DISPLAY_NAMES = {
+        'HISTOGRAM2D': "Density Plot (2D Histogram)",
+        'SCATTER': "Dot Plot (Scatter)",
+        'CONTOUR': "Contour Plot",
+        'NONE': "None",
+    }
+    PLOT_TYPE_KEYS = {v: k for k, v in PLOT_TYPE_DISPLAY_NAMES.items()}
+
     def __init__(self, napari_viewer):
         """Initialize the PlotterWidget."""
         super().__init__()
@@ -1718,9 +1726,9 @@ class PlotterWidget(QWidget):
             self._import_settings_from_file
         )
 
-        # Populate plot type combobox
+        # Populate plot type combobox with display names
         self.plotter_inputs_widget.plot_type_combobox.addItems(
-            ['HISTOGRAM2D', 'SCATTER', 'CONTOUR']
+            list(self.PLOT_TYPE_DISPLAY_NAMES.values())
         )
 
         # Populate colormap combobox with swatches.
@@ -2215,8 +2223,13 @@ class PlotterWidget(QWidget):
                 'plot_type' in settings
                 and not self._preserve_plot_type_on_restore
             ):
+                plot_type_key = settings['plot_type']
+                # Map old metadata keys to display names if needed
+                display_name = self.PLOT_TYPE_DISPLAY_NAMES.get(
+                    plot_type_key, plot_type_key
+                )
                 self.plotter_inputs_widget.plot_type_combobox.setCurrentText(
-                    settings['plot_type']
+                    display_name
                 )
 
             # Only restore if explicitly set in metadata
@@ -3136,22 +3149,32 @@ class PlotterWidget(QWidget):
 
     def _on_plot_type_changed(self):
         """Callback for plot type change."""
-        new_plot_type = (
+        new_plot_type_display = (
             self.plotter_inputs_widget.plot_type_combobox.currentText()
+        )
+        new_plot_type = self.PLOT_TYPE_KEYS.get(
+            new_plot_type_display, 'HISTOGRAM2D'
         )
         self._update_setting_in_metadata('plot_type', new_plot_type)
 
         is_scatter = new_plot_type == 'SCATTER'
         is_contour = new_plot_type == 'CONTOUR'
+        is_none = new_plot_type == 'NONE'
 
-        # Histogram/Contour shared elements
-        self.plotter_inputs_widget.label_3.setVisible(not is_scatter)
-        self._colormap_row_widget.setVisible(not is_scatter)
-        self.plotter_inputs_widget.label_4.setVisible(not is_scatter)
-        self.plotter_inputs_widget.number_of_bins_spinbox.setVisible(
-            not is_scatter
+        # Histogram/Contour/None shared elements
+        self.plotter_inputs_widget.label_3.setVisible(
+            not is_scatter and not is_none
         )
-        show_log_controls = (not is_scatter) and (not is_contour)
+        self._colormap_row_widget.setVisible(not is_scatter and not is_none)
+        self.plotter_inputs_widget.label_4.setVisible(
+            not is_scatter and not is_none
+        )
+        self.plotter_inputs_widget.number_of_bins_spinbox.setVisible(
+            not is_scatter and not is_none
+        )
+        show_log_controls = (
+            (not is_scatter) and (not is_contour) and (not is_none)
+        )
         self.plotter_inputs_widget.label_7.setVisible(show_log_controls)
         self.plotter_inputs_widget.log_scale_checkbox.setVisible(
             show_log_controls
@@ -3773,17 +3796,17 @@ class PlotterWidget(QWidget):
     def _update_contour_controls_visibility(self):
         if self._is_closing or not self._has_plot_type_controls():
             return
-        is_scatter = (
-            self.plotter_inputs_widget.plot_type_combobox.currentText()
-            == 'SCATTER'
-        )
-        is_contour = (
-            self.plotter_inputs_widget.plot_type_combobox.currentText()
-            == 'CONTOUR'
-        )
+        plot_type = self.plot_type
+        is_scatter = plot_type == 'SCATTER'
+        is_contour = plot_type == 'CONTOUR'
+        is_none = plot_type == 'NONE'
         has_multiple = self._has_multiple_selected_layers()
 
-        show_colormap = (not is_scatter) and not (is_contour and has_multiple)
+        show_colormap = (
+            (not is_scatter)
+            and (not is_none)
+            and not (is_contour and has_multiple)
+        )
         self.plotter_inputs_widget.label_3.setVisible(show_colormap)
         self._colormap_row_widget.setVisible(show_colormap)
 
@@ -4622,7 +4645,10 @@ class PlotterWidget(QWidget):
         """Sets the plot type from the plot type combobox."""
         if self._is_closing or not self._has_plot_type_controls():
             return
-        self.plotter_inputs_widget.plot_type_combobox.setCurrentText(value)
+        display_name = self.PLOT_TYPE_DISPLAY_NAMES.get(value, value)
+        self.plotter_inputs_widget.plot_type_combobox.setCurrentText(
+            display_name
+        )
 
     def _has_plot_type_controls(self):
         """Return True if the plot-type controls are valid Qt objects."""
@@ -4636,7 +4662,8 @@ class PlotterWidget(QWidget):
     def _get_plot_type_safe(self, default='HISTOGRAM2D'):
         """Safely read plot type while controls may be tearing down."""
         try:
-            return self.plotter_inputs_widget.plot_type_combobox.currentText()
+            text = self.plotter_inputs_widget.plot_type_combobox.currentText()
+            return self.PLOT_TYPE_KEYS.get(text, text)
         except (AttributeError, RuntimeError):
             return getattr(self, '_current_plot_type', default)
 
@@ -6655,16 +6682,19 @@ class PlotterWidget(QWidget):
             return
         if plot_type != self.plot_type:
             self.plotter_inputs_widget.plot_type_combobox.blockSignals(True)
+            display_name = self.PLOT_TYPE_DISPLAY_NAMES.get(
+                plot_type, plot_type
+            )
             self.plotter_inputs_widget.plot_type_combobox.setCurrentText(
-                plot_type
+                display_name
             )
             self.plotter_inputs_widget.plot_type_combobox.blockSignals(False)
             self._connect_active_artist_signals()
 
-        # Make sure biaplotter artists are hidden if switching to CONTOUR
+        # Make sure biaplotter artists are hidden if switching to CONTOUR or NONE
         current_active = getattr(self.canvas_widget, 'active_artist', None)
 
-        if plot_type == 'CONTOUR':
+        if plot_type in ('CONTOUR', 'NONE'):
             for _name, artist in getattr(
                 self.canvas_widget, 'artists', {}
             ).items():
@@ -6674,8 +6704,8 @@ class PlotterWidget(QWidget):
                 # Fallback for biaplotter < 0.4.2 which doesn't support None
                 self.canvas_widget.active_artist = None
 
-        else:
-            # Hide contour items when switching away
+        if plot_type != 'CONTOUR':
+            # Hide contour items when switching away (including to NONE)
             self._clear_contour_plot()
             self.canvas_widget.figure.canvas.draw_idle()
 
@@ -6686,11 +6716,16 @@ class PlotterWidget(QWidget):
             self._update_scatter_plot(x_data, y_data, selection_id_data)
         elif plot_type == 'CONTOUR':
             self._update_contour_plot(x_data, y_data, selection_id_data)
+        elif plot_type == 'NONE':
+            self._remove_colorbar()
 
-        if current_active != plot_type and plot_type in getattr(
-            self.canvas_widget, 'artists', {}
-        ):
-            self.canvas_widget.active_artist = plot_type
+        if plot_type in getattr(self.canvas_widget, 'artists', {}):
+            if current_active != plot_type:
+                self.canvas_widget.active_artist = plot_type
+        else:
+            # For CONTOUR or NONE, we might want to unset active_artist in biaplotter
+            with contextlib.suppress(AttributeError, TypeError):
+                self.canvas_widget.active_artist = None
 
         if (
             plot_type not in getattr(self.canvas_widget, 'artists', {})


### PR DESCRIPTION
This pull request updates the plot type handling in the napari phasors plugin to use more descriptive display names and introduces a new "None" plot type option. The changes ensure that the UI, internal logic, and metadata handling are consistent with the new display names and support the "None" state. Several tests are updated to reflect these changes, and the logic for toggling UI elements and handling plot type transitions is improved.

**Plot type display names and logic updates:**

- Added a mapping (`PLOT_TYPE_DISPLAY_NAMES` and `PLOT_TYPE_KEYS`) to translate between internal plot type keys and user-facing display names, and updated all relevant logic to use these mappings for setting and retrieving the plot type. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R1148-R1155) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L1721-R1731) [[3]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L3139-L3154) [[4]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L4625-R4651) [[5]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L4639-R4666)

- Introduced a "None" plot type option, updated the UI to include it, and ensured proper handling in plot logic (e.g., hiding all plot-specific controls and removing colorbars when "None" is selected). [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R1148-R1155) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L1721-R1731) [[3]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L3139-L3154) [[4]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R6685-R6697) [[5]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L6677-R6708) [[6]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R6719-R6728)

**UI and metadata consistency:**

- Updated the logic for restoring and setting plot types from metadata to handle both old and new formats, ensuring backward compatibility and consistency in the UI. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R2226-R2232) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L4625-R4651)

- Improved the logic for toggling the visibility of plot-specific UI controls based on the selected plot type, including the new "None" option. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L3139-L3154) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L3776-R3809)

**Test updates:**

- Updated tests to use the new display names for plot types and added assertions for the "None" option, ensuring that UI and logic changes are properly tested. [[1]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aL137-R142) [[2]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aL458-R465) [[3]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aL513-R522) [[4]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aL524-R535) [[5]](diffhunk://#diff-5c3794250798769f871c59dca79b67157a507b5824f4e2f007c1a9149c893c4aR550-R563) [[6]](diffhunk://#diff-cde263035f355315f484281fdc350d6f58faa814e37d10e7939ff11f5aa33e63L1382-R1405)

**Phasor mapping and coloring logic:**

- Updated the phasor mapping tab logic to handle the "None" plot type, ensuring the UI text and coloring logic behave correctly when no plot is selected. [[1]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79R257-R258) [[2]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1273-R1275)

These changes improve the clarity and flexibility of plot type selection in the UI and ensure that the application logic remains robust and consistent as new plot types are added.