### PR TITLE
Fix mask renaming layer bug

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1495,6 +1495,48 @@ def test_phasor_plotter_restore_original_phasor_data(make_napari_viewer):
     )
 
 
+def test_mask_layer_rename_updates_combobox_and_assignments(
+    make_napari_viewer,
+):
+    """Regression test for mask-layer rename synchronization in the plotter."""
+    viewer = make_napari_viewer()
+
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+
+    # Build a mask compatible with phasor spatial dimensions.
+    g_data = layer1.metadata["G"]
+    mask_shape = g_data.shape[1:] if g_data.ndim == 3 else g_data.shape
+    mask = np.ones(mask_shape, dtype=int)
+    labels_layer = viewer.add_labels(mask, name="mask_before_rename")
+
+    plotter = PlotterWidget(viewer)
+
+    # Single-layer mode: selecting a mask updates the combobox and assignments.
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer1.name])
+    plotter.mask_layer_combobox.setCurrentText("mask_before_rename")
+    assert plotter.mask_layer_combobox.currentText() == "mask_before_rename"
+    assert plotter._mask_assignments.get(layer1.name) == "mask_before_rename"
+
+    # Renaming the mask layer should propagate to UI and assignments.
+    labels_layer.name = "mask_after_rename"
+
+    combo_items = [
+        plotter.mask_layer_combobox.itemText(i)
+        for i in range(plotter.mask_layer_combobox.count())
+    ]
+    assert "mask_after_rename" in combo_items
+    assert "mask_before_rename" not in combo_items
+    assert plotter.mask_layer_combobox.currentText() == "mask_after_rename"
+    assert plotter._mask_assignments.get(layer1.name) == "mask_after_rename"
+
+    # Re-running UI sync must not reset selection to None.
+    plotter._update_mask_ui_mode()
+    assert plotter.mask_layer_combobox.currentText() == "mask_after_rename"
+
+
 def test_mask_ui_switches_to_button_when_multiple_layers_selected(
     make_napari_viewer,
 ):

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -4822,6 +4822,32 @@ class PlotterWidget(QWidget):
                 for layer in self.viewer.layers
                 if isinstance(layer, (Labels, Shapes))
             ]
+            mask_layers_by_id = {
+                id(layer): layer.name
+                for layer in self.viewer.layers
+                if isinstance(layer, (Labels, Shapes))
+            }
+
+            # If mask layers were renamed, keep combobox and assignments synced
+            # by matching layer object identity across updates.
+            old_mask_layers_by_id = getattr(self, '_mask_layers_by_id', {})
+            renamed_masks = {
+                old_mask_layers_by_id[layer_id]: new_name
+                for layer_id, new_name in mask_layers_by_id.items()
+                if layer_id in old_mask_layers_by_id
+                and old_mask_layers_by_id[layer_id] != new_name
+            }
+
+            if mask_layer_combobox_current_text in renamed_masks:
+                mask_layer_combobox_current_text = renamed_masks[
+                    mask_layer_combobox_current_text
+                ]
+
+            if renamed_masks:
+                self._mask_assignments = {
+                    image_layer_name: renamed_masks.get(mask_name, mask_name)
+                    for image_layer_name, mask_name in self._mask_assignments.items()
+                }
 
             # Add items to the checkable combobox
             for name in layer_names:
@@ -4885,10 +4911,11 @@ class PlotterWidget(QWidget):
             # Connect layer name change events (disconnect first to avoid duplicates)
             for layer_name in layer_names + mask_layer_names:
                 layer = self.viewer.layers[layer_name]
-                if (
-                    isinstance(layer, Image)
-                    and "phasor_features_labels_layer" in layer.metadata
-                ):
+                if isinstance(layer, Image):
+                    with contextlib.suppress(TypeError, ValueError):
+                        layer.events.name.disconnect(self.reset_layer_choices)
+                    layer.events.name.connect(self.reset_layer_choices)
+                if isinstance(layer, (Shapes, Labels)):
                     with contextlib.suppress(TypeError, ValueError):
                         layer.events.name.disconnect(self.reset_layer_choices)
                     layer.events.name.connect(self.reset_layer_choices)
@@ -4910,6 +4937,8 @@ class PlotterWidget(QWidget):
                         pass  # Not connected, ignore
                     layer.events.paint.connect(self._on_mask_data_changed)
                     layer.events.set_data.connect(self._on_mask_data_changed)
+
+            self._mask_layers_by_id = mask_layers_by_id
 
             new_selected = self.get_selected_layer_names()
             if new_selected != previously_selected or (
@@ -5386,7 +5415,19 @@ class PlotterWidget(QWidget):
             self.mask_assign_button.setVisible(False)
             # Sync the combobox with current assignment for the single selected layer
             if selected:
-                current_mask = self._mask_assignments.get(selected[0], "None")
+                assigned_mask = self._mask_assignments.get(selected[0])
+                available_masks = {
+                    self.mask_layer_combobox.itemText(i)
+                    for i in range(self.mask_layer_combobox.count())
+                }
+                if assigned_mask in available_masks:
+                    current_mask = assigned_mask
+                elif self.mask_layer_combobox.currentText() in available_masks:
+                    # Preserve the current valid selection when there is no
+                    # explicit assignment for this layer.
+                    current_mask = self.mask_layer_combobox.currentText()
+                else:
+                    current_mask = "None"
                 self.mask_layer_combobox.blockSignals(True)
                 self.mask_layer_combobox.setCurrentText(current_mask)
                 self.mask_layer_combobox.blockSignals(False)


### PR DESCRIPTION
This pull request improves the synchronization between mask layer renaming and the plotter UI in napari-phasors, ensuring that mask layer name changes are reflected in the combobox and mask assignments without breaking user selection. It also adds a regression test to prevent future issues and refines event handling for layer name changes.

Fixes #241 

**Mask layer rename synchronization:**

* The `reset_layer_choices` method now tracks mask layers by object identity, allowing mask layer renames to propagate to the combobox and mask assignments, keeping them in sync with the actual layer names. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R4825-R4850) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R4941-R4942)
* The `_update_mask_ui_mode` method was updated to ensure the mask selection remains valid and consistent after a rename, preserving user selection where possible.

**Event handling improvements:**

* Event connections for layer name changes are now established for all `Image`, `Labels`, and `Shapes` layers, and are properly disconnected first to avoid duplicate event handlers.

**Testing:**

* Added a regression test (`test_mask_layer_rename_updates_combobox_and_assignments`) to verify that mask layer renaming is correctly reflected in the UI and assignments, and that UI state is preserved after a rename.