### PR TITLE
Enhance CI configuration and documentation for Qt bindings support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,32 +22,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        platform: [ubuntu-latest, windows-latest, macos-14, macos-15]
+        python-version: ["3.12", "3.13", "3.14"]
+        qt-binding: [pyqt6]
         include:
-          # Linux: Run all python versions, alternating backends
-          - platform: ubuntu-latest
-            python-version: "3.12"
-            qt-binding: pyside6
-          - platform: ubuntu-latest
-            python-version: "3.13"
-            qt-binding: pyqt6
           - platform: ubuntu-latest
             python-version: "3.14"
             qt-binding: pyside6
-
-          # Windows: Run latest python with pyqt6
           - platform: windows-latest
             python-version: "3.14"
-            qt-binding: pyqt6
-
-          # MacOS: Run latest python with pyside6
+            qt-binding: pyside6
           - platform: macos-14
             python-version: "3.14"
             qt-binding: pyside6
-
-          # MacOS 15: Run latest python with pyqt6
           - platform: macos-15
             python-version: "3.14"
-            qt-binding: pyqt6
+            qt-binding: pyside6
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,12 +17,13 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    name: ${{ matrix.platform }} py${{ matrix.python-version }} ${{ matrix.qt-binding }}
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-14, macos-15]
         python-version: ['3.12', '3.13', '3.14']
+        qt-binding: [pyqt6, pyside6]
 
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +58,8 @@ jobs:
           run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
+          QT_BINDING: ${{ matrix.qt-binding }}
+          QT_API: ${{ matrix.qt-binding == 'pyqt6' && 'pyqt6' || 'pyside6' }}
 
       - name: Coverage
         uses: codecov/codecov-action@v4.0.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -76,7 +76,7 @@ jobs:
           QT_API: ${{ matrix.qt-binding == 'pyqt6' && 'pyqt6' || 'pyside6' }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: napari-phasors/napari-phasors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,10 +20,34 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }} ${{ matrix.qt-binding }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-14, macos-15]
-        python-version: ['3.12', '3.13', '3.14']
-        qt-binding: [pyqt6, pyside6]
+        include:
+          # Linux: Run all python versions, alternating backends
+          - platform: ubuntu-latest
+            python-version: "3.12"
+            qt-binding: pyside6
+          - platform: ubuntu-latest
+            python-version: "3.13"
+            qt-binding: pyqt6
+          - platform: ubuntu-latest
+            python-version: "3.14"
+            qt-binding: pyside6
+
+          # Windows: Run latest python with pyqt6
+          - platform: windows-latest
+            python-version: "3.14"
+            qt-binding: pyqt6
+
+          # MacOS: Run latest python with pyside6
+          - platform: macos-14
+            python-version: "3.14"
+            qt-binding: pyside6
+
+          # MacOS 15: Run latest python with pyqt6
+          - platform: macos-15
+            python-version: "3.14"
+            qt-binding: pyqt6
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the `mamba` term whenever you see it below with `conda`.**
 
 Create a conda environment with napari by typing :
 
-    mamba create -y -n napari-phasors-env napari pyqt python=3.12 # or 3.13
+    mamba create -y -n napari-phasors-env napari pyqt6 python=3.13 # or pyside6, pyqt5, etc.
 
 Activate the environment :
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Python 3.12 or 3.13
-- A working Qt backend (PyQt5 is installed automatically)
+- A working Qt backend (PyQt6, PySide6, PyQt5, or PySide2)
 
 ## Using conda + pip (recommended)
 
@@ -13,7 +13,7 @@ If you use Anaconda or Miniconda, replace `mamba` with `conda`.
 Create an environment with napari:
 
 ```bash
-mamba create -y -n napari-phasors-env napari pyqt python=3.12 # or 3.13
+mamba create -y -n napari-phasors-env napari pyqt6 python=3.13 # or pyside6, pyqt5, etc.
 mamba activate napari-phasors-env
 ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 jupyter-book<2.0
 matplotlib
 numpy
-PyQt5
 qtpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,11 @@ dependencies = [
     "ptufile",
     "tifffile",
     "pandas",
-    "pyqt5",
     "pawflim",
     "scipy",
     "czifile",
     "lfdfiles"
+    # Qt binding (PyQt6 or PySide6) is provided by the environment / napari.
 ]
 
 [project.optional-dependencies]
@@ -53,7 +53,6 @@ testing = [
     "qtpy",
     "scikit-image",
     "biaplotter>=0.4.2",
-    "PyQt5",
     "pandas",
     "black",
     "isort",
@@ -68,6 +67,7 @@ testing = [
     "scipy",
     "czifile",
     "lfdfiles"
+    # Qt binding installed separately per CI job (PyQt6 or PySide6).
 ]
 
 [project.entry-points."napari.manifest"]

--- a/src/napari_phasors/_tests/test_filter_tab.py
+++ b/src/napari_phasors/_tests/test_filter_tab.py
@@ -809,7 +809,7 @@ def test_filter_widget_ui_layout(make_napari_viewer):
 
 def test_filter_widget_canvas_properties(make_napari_viewer):
     """Test canvas and figure properties."""
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 
     viewer = make_napari_viewer()
     parent = PlotterWidget(viewer)

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import matplotlib.colors as mcolors
 import numpy as np
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from napari.layers import Image
 from phasorpy.lifetime import (

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import numpy as np
 from biaplotter.plotter import CanvasWidget
+from nap_plot_tools.tools import CustomToolbarWidget
 from napari.layers import Image
 from qtpy.QtWidgets import (
     QComboBox,
@@ -164,6 +165,12 @@ def test_phasor_plotter_initialization_values(make_napari_viewer):
     ylim = plotter.canvas_widget.axes.get_ylim()
     assert xlim[0] == -0.1 and xlim[1] == 1.1
     assert ylim[0] == -0.1 and ylim[1] == 0.7
+
+
+def test_nap_plot_tools_toolbar_disconnect_is_patched():
+    assert getattr(
+        CustomToolbarWidget, '_napari_phasors_disconnect_patched', False
+    )
 
 
 def test_phasor_plotter_initialization_plot_not_called(make_napari_viewer):

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -21,7 +21,7 @@ from phasorpy.filter import (
     phasor_filter_pawflim,
     phasor_threshold,
 )
-from qtpy.QtCore import QRect, QSize, Qt, Signal
+from qtpy.QtCore import QEvent, QRect, QSize, Qt, Signal
 from qtpy.QtGui import (
     QColor,
     QDoubleValidator,
@@ -921,7 +921,9 @@ class CheckableComboBox(QComboBox):
         self._primary_layer_name = ""
 
         # Connect model signals
-        self.model().dataChanged.connect(self._on_data_changed)
+        self.model().dataChanged.connect(
+            lambda *args: self._on_data_changed(*args)
+        )
 
         # Track if we're inside the popup
         self._popup_visible = False
@@ -960,14 +962,14 @@ class CheckableComboBox(QComboBox):
     def eventFilter(self, obj, event):
         """Filter events to make line edit clickable and handle item clicks."""
         if obj == self.lineEdit():
-            if event.type() == event.MouseButtonRelease:
+            if event.type() == QEvent.Type.MouseButtonRelease:
                 if not self.view().isVisible():
                     self.showPopup()
                 return True
-            elif event.type() == event.MouseButtonPress:
+            elif event.type() == QEvent.Type.MouseButtonPress:
                 return True
         elif obj == self.view().viewport():
-            if event.type() == event.MouseMove:
+            if event.type() == QEvent.Type.MouseMove:
                 index = self.view().indexAt(event.pos())
                 old_hover = self._delegate._hovered_index
                 self._delegate._hovered_index = (
@@ -976,7 +978,7 @@ class CheckableComboBox(QComboBox):
                 if old_hover != self._delegate._hovered_index:
                     self.view().viewport().update()
                 return False
-            elif event.type() == event.MouseButtonRelease:
+            elif event.type() == QEvent.Type.MouseButtonRelease:
                 index = self.view().indexAt(event.pos())
                 if index.isValid():
                     vis_rect = self.view().visualRect(index)
@@ -1010,7 +1012,7 @@ class CheckableComboBox(QComboBox):
                             )
                             item.setCheckState(new_state)
                         return True
-            elif event.type() == event.Leave:
+            elif event.type() == QEvent.Type.Leave:
                 if self._delegate._hovered_index is not None:
                     self._delegate._hovered_index = None
                     self.view().viewport().update()
@@ -1405,21 +1407,23 @@ class HistogramSettingsDialog(QDialog):
         # Add group button
         add_group_btn = QPushButton("+ Add Group")
         add_group_btn.setMaximumWidth(120)
-        add_group_btn.clicked.connect(self._on_add_group)
+        add_group_btn.clicked.connect(lambda: self._on_add_group())
         group_layout.addWidget(add_group_btn)
 
         layout.addWidget(self._group_section)
 
         # Show / hide sections based on mode
         self._update_ui_for_mode(display_mode)
-        self.mode_combo.currentTextChanged.connect(self._update_ui_for_mode)
+        self.mode_combo.currentTextChanged.connect(
+            lambda: self._update_ui_for_mode()
+        )
 
         # --- OK / Cancel ---
         btn_layout = QHBoxLayout()
         ok_btn = QPushButton("OK")
         cancel_btn = QPushButton("Cancel")
-        ok_btn.clicked.connect(self.accept)
-        cancel_btn.clicked.connect(self.reject)
+        ok_btn.clicked.connect(lambda: self.accept())
+        cancel_btn.clicked.connect(lambda: self.reject())
         btn_layout.addWidget(ok_btn)
         btn_layout.addWidget(cancel_btn)
         layout.addLayout(btn_layout)
@@ -1720,16 +1724,22 @@ class HistogramWidget(QWidget):
             self.range_slider.setValue((0, 100))
             self.range_slider.setBarMovesAllHandles(False)
 
-            self.range_slider.valueChanged.connect(self._on_range_label_update)
-            self.range_slider.sliderPressed.connect(self._on_slider_pressed)
-            self.range_slider.sliderReleased.connect(self._on_slider_released)
+            self.range_slider.valueChanged.connect(
+                lambda *args: self._on_range_label_update(*args)
+            )
+            self.range_slider.sliderPressed.connect(
+                lambda *args: self._on_slider_pressed(*args)
+            )
+            self.range_slider.sliderReleased.connect(
+                lambda *args: self._on_slider_released(*args)
+            )
             layout.addWidget(self.range_slider)
 
             self.range_min_edit.editingFinished.connect(
-                self._on_range_min_edit
+                lambda *args: self._on_range_min_edit(*args)
             )
             self.range_max_edit.editingFinished.connect(
-                self._on_range_max_edit
+                lambda *args: self._on_range_max_edit(*args)
             )
 
         # Matplotlib canvas
@@ -1748,19 +1758,25 @@ class HistogramWidget(QWidget):
 
         self._settings_button = QPushButton("Histogram Settings…")
         self._settings_button.setMaximumWidth(150)
-        self._settings_button.clicked.connect(self._open_settings_dialog)
+        self._settings_button.clicked.connect(
+            lambda: self._open_settings_dialog()
+        )
         controls_layout.addWidget(self._settings_button)
 
         controls_layout.addStretch()
 
         self.save_png_button = QPushButton("Save Histogram as PNG")
         self.save_png_button.setMinimumWidth(180)
-        self.save_png_button.clicked.connect(self._save_histogram_png)
+        self.save_png_button.clicked.connect(
+            lambda: self._save_histogram_png()
+        )
         controls_layout.addWidget(self.save_png_button)
 
         self.save_csv_button = QPushButton("Save Histogram as CSV")
         self.save_csv_button.setMinimumWidth(180)
-        self.save_csv_button.clicked.connect(self._save_histogram_csv)
+        self.save_csv_button.clicked.connect(
+            lambda: self._save_histogram_csv()
+        )
         controls_layout.addWidget(self.save_csv_button)
 
         layout.addLayout(controls_layout)
@@ -2708,7 +2724,7 @@ class CollapsibleSection(QWidget):
         )
         self._toggle_button.setCheckable(True)
         self._toggle_button.setChecked(not initially_collapsed)
-        self._toggle_button.clicked.connect(self._on_toggle)
+        self._toggle_button.clicked.connect(lambda: self._on_toggle())
         layout.addWidget(self._toggle_button)
 
         # Content area
@@ -2776,7 +2792,9 @@ class StatisticsTableWidget(QTableWidget):
             "QTableWidget::item:selected { background: #4a6fa5; color: white; }"
         )
         self.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.customContextMenuRequested.connect(self._show_context_menu)
+        self.customContextMenuRequested.connect(
+            lambda: self._show_context_menu()
+        )
 
     def keyPressEvent(self, event):
         """Handle Ctrl+C / Ctrl+A keyboard shortcuts."""
@@ -3020,12 +3038,14 @@ class StatisticsDockWidget(QWidget):
         self.export_csv_button = QPushButton("Export Table as CSV")
         self.export_csv_button.setMinimumWidth(140)
         self.export_csv_button.setEnabled(False)
-        self.export_csv_button.clicked.connect(self._export_table_csv_impl)
+        self.export_csv_button.clicked.connect(
+            lambda: self._export_table_csv_impl()
+        )
         main_layout.addWidget(self.export_csv_button)
 
         main_layout.addStretch()
 
-        histogram_widget.dataChanged.connect(self._update_statistics)
+        histogram_widget.dataChanged.connect(lambda: self._update_statistics())
 
     def _update_statistics(self):
         """Recompute the statistics tables from the histogram's data."""
@@ -3246,21 +3266,21 @@ class FileOrderDialog(QDialog):
         btn_layout = QHBoxLayout()
 
         self.move_up_btn = QPushButton("▲ Move Up")
-        self.move_up_btn.clicked.connect(self._move_up)
+        self.move_up_btn.clicked.connect(lambda: self._move_up())
         btn_layout.addWidget(self.move_up_btn)
 
         self.move_down_btn = QPushButton("▼ Move Down")
-        self.move_down_btn.clicked.connect(self._move_down)
+        self.move_down_btn.clicked.connect(lambda: self._move_down())
         btn_layout.addWidget(self.move_down_btn)
 
         btn_layout.addStretch()
 
         self.ok_btn = QPushButton("OK")
-        self.ok_btn.clicked.connect(self.accept)
+        self.ok_btn.clicked.connect(lambda: self.accept())
         btn_layout.addWidget(self.ok_btn)
 
         self.cancel_btn = QPushButton("Cancel")
-        self.cancel_btn.clicked.connect(self.reject)
+        self.cancel_btn.clicked.connect(lambda: self.reject())
         btn_layout.addWidget(self.cancel_btn)
 
         layout.addLayout(btn_layout)

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -10,9 +10,7 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy
-from matplotlib.backends.backend_qt5agg import (
-    FigureCanvasQTAgg as FigureCanvas,
-)
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.collections import LineCollection
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.legend_handler import HandlerBase
@@ -1742,9 +1740,7 @@ class HistogramWidget(QWidget):
 
         canvas = FigureCanvas(self.fig)
         canvas.setFixedHeight(canvas_height)
-        canvas.setSizePolicy(
-            canvas.sizePolicy().Expanding, canvas.sizePolicy().Fixed
-        )
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         layout.addWidget(canvas)
 
         # Settings and export controls in one row

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -76,11 +76,13 @@ class PhasorTransform(QWidget):
         self.scroll_area.setWidget(self.content_widget)
 
         self.search_button = QPushButton("Select file(s) to be read")
-        self.search_button.clicked.connect(self._open_file_dialog)
+        self.search_button.clicked.connect(lambda: self._open_file_dialog())
         self.main_layout.addWidget(self.search_button)
 
         self.multi_file_button = QPushButton("Open 3D stack")
-        self.multi_file_button.clicked.connect(self._open_multi_file_dialog)
+        self.multi_file_button.clicked.connect(
+            lambda: self._open_multi_file_dialog()
+        )
         self.main_layout.addWidget(self.multi_file_button)
 
         self.main_layout.addWidget(QLabel("Path to the selected file(s): "))
@@ -676,7 +678,7 @@ class AdvancedOptionsWidget(QWidget):
                 "Spacing along Z in micrometers (um)."
             )
             self._stack_z_spacing_edit.editingFinished.connect(
-                self._on_stack_z_spacing_changed
+                lambda *args: self._on_stack_z_spacing_changed(*args)
             )
 
             z_layout.addWidget(self._stack_z_spacing_edit)
@@ -734,7 +736,7 @@ class AdvancedOptionsWidget(QWidget):
             self.frames.addItem(str(frame))
         self.frames.setCurrentIndex(0)
         self.frames.currentIndexChanged.connect(
-            self._on_frames_combobox_changed
+            lambda *args: self._on_frames_combobox_changed(*args)
         )
         frame_layout.addWidget(self.frames)
         frame_layout.addStretch()
@@ -771,7 +773,7 @@ class AdvancedOptionsWidget(QWidget):
                 self.channels.addItem(str(channel))
             self.channels.setCurrentIndex(0)
             self.channels.currentIndexChanged.connect(
-                self._on_channels_combobox_changed
+                lambda *args: self._on_channels_combobox_changed(*args)
             )
             self.channels_layout.addWidget(self.channels)
         else:
@@ -824,7 +826,7 @@ class AdvancedOptionsWidget(QWidget):
             self.harmonic_start_edit.setFixedWidth(50)
             self.harmonic_start_edit.setValidator(QDoubleValidator())
             self.harmonic_start_edit.editingFinished.connect(
-                self._on_harmonic_edit_changed
+                lambda *args: self._on_harmonic_edit_changed(*args)
             )
             self.harmonic_layout.addWidget(self.harmonic_start_edit)
 
@@ -836,7 +838,7 @@ class AdvancedOptionsWidget(QWidget):
             self.harmonic_end_edit.setFixedWidth(50)
             self.harmonic_end_edit.setValidator(QDoubleValidator())
             self.harmonic_end_edit.editingFinished.connect(
-                self._on_harmonic_edit_changed
+                lambda *args: self._on_harmonic_edit_changed(*args)
             )
             self.harmonic_layout.addWidget(self.harmonic_end_edit)
         else:
@@ -871,7 +873,7 @@ class AdvancedOptionsWidget(QWidget):
             self.harmonic_slider.setValue((preserved_start, preserved_end))
             self.harmonic_slider.setBarMovesAllHandles(True)
             self.harmonic_slider.valueChanged.connect(
-                self._on_harmonic_slider_changed
+                lambda *args: self._on_harmonic_slider_changed(*args)
             )
 
             harmonic_layout_index = None
@@ -1271,7 +1273,7 @@ class FbdWidget(AdvancedOptionsWidget):
         laser_factor_completer = QCompleter(["0.00022", "2.50012", "2.50016"])
         self.laser_factor.setCompleter(laser_factor_completer)
         self.laser_factor.textChanged.connect(
-            lambda: self._update_signal_plot()
+            lambda *args: self._update_signal_plot()
         )
         laser_layout.addWidget(self.laser_factor)
         laser_layout.addStretch()
@@ -1355,7 +1357,9 @@ class PtuWidget(AdvancedOptionsWidget):
             "If < 0, integrate delay time axis."
             "If > 0, return up to specified bin."
         )
-        self.dtime.textChanged.connect(lambda: self._update_signal_plot())
+        self.dtime.textChanged.connect(
+            lambda *args: self._update_signal_plot()
+        )
         dtime_layout.addWidget(self.dtime)
         dtime_layout.addStretch()
         self.mainLayout.addLayout(dtime_layout)
@@ -1532,7 +1536,9 @@ class SdtWidget(AdvancedOptionsWidget):
             "Index of dataset to read in case the file contains multiple "
             "datasets. By default, the first dataset is read."
         )
-        self.index.textChanged.connect(lambda: self._update_signal_plot())
+        self.index.textChanged.connect(
+            lambda *args: self._update_signal_plot()
+        )
         index_layout.addWidget(self.index)
         index_layout.addStretch()
         self.mainLayout.addLayout(index_layout)
@@ -1713,7 +1719,9 @@ class OmeTifWidget(AdvancedOptionsWidget):
 
             self.channels.setCurrentIndex(0)
             self.channels.currentIndexChanged.connect(
-                self._on_channels_combobox_changed_settings
+                lambda *args: self._on_channels_combobox_changed_settings(
+                    *args
+                )
             )
             self.channels_layout.addWidget(self.channels)
         else:
@@ -1935,7 +1943,9 @@ class LifWidget(AdvancedOptionsWidget):
         image_layout.addWidget(QLabel("Image (regex/index): "))
         self.image = QLineEdit()
         self.image.setToolTip("Index or regex pattern of image to return.")
-        self.image.textChanged.connect(self._on_lif_options_changed)
+        self.image.textChanged.connect(
+            lambda *args: self._on_lif_options_changed()
+        )
         image_layout.addWidget(self.image)
         image_layout.addStretch()
         self.mainLayout.addLayout(image_layout)
@@ -1947,7 +1957,9 @@ class LifWidget(AdvancedOptionsWidget):
         self.dim.setToolTip(
             "Character code of hyperspectral dimension. 'λ' for emission, 'Λ' for excitation."
         )
-        self.dim.currentIndexChanged.connect(self._on_lif_options_changed)
+        self.dim.currentIndexChanged.connect(
+            lambda *args: self._on_lif_options_changed()
+        )
         dim_layout.addWidget(self.dim)
         dim_layout.addStretch()
         self.mainLayout.addLayout(dim_layout)
@@ -2042,7 +2054,9 @@ class JsonWidget(AdvancedOptionsWidget):
         self.channel_entry.setToolTip(
             "Index of channel or empty for all channel reading."
         )
-        self.channel_entry.textChanged.connect(self._on_json_channel_changed)
+        self.channel_entry.textChanged.connect(
+            lambda *args: self._on_json_channel_changed()
+        )
         chan_layout.addWidget(self.channel_entry)
         chan_layout.addStretch()
         self.mainLayout.addLayout(chan_layout)
@@ -2243,11 +2257,15 @@ class WriterWidget(QWidget):
         self.main_layout.addWidget(self.colorbar_checkbox)
 
         self.search_button = QPushButton("Select Export Location and Name")
-        self.search_button.clicked.connect(self._open_file_dialog)
+        self.search_button.clicked.connect(lambda: self._open_file_dialog())
         self.main_layout.addWidget(self.search_button)
 
-        self.viewer.layers.events.inserted.connect(self._populate_combobox)
-        self.viewer.layers.events.removed.connect(self._populate_combobox)
+        self.viewer.layers.events.inserted.connect(
+            lambda *args: self._populate_combobox()
+        )
+        self.viewer.layers.events.removed.connect(
+            lambda *args: self._populate_combobox()
+        )
 
         self._populate_combobox()
 

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -14,9 +14,7 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.backends.backend_qt5agg import (
-    FigureCanvasQTAgg as FigureCanvas,
-)
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from napari.layers import Image
 from napari.utils.notifications import show_error, show_info
@@ -374,9 +372,7 @@ class AdvancedOptionsWidget(QWidget):
         self.figure.patch.set_alpha(0.0)
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setFixedHeight(300)
-        self.canvas.setSizePolicy(
-            self.canvas.sizePolicy().Expanding, self.canvas.sizePolicy().Fixed
-        )
+        self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.ax = self.figure.add_subplot(111)
         self.ax.set_facecolor('none')
 

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -34,19 +34,23 @@ class CalibrationWidget(QWidget):
 
         # Connect callbacks
         self.calibration_widget.calibrate_push_button.clicked.connect(
-            self._on_click
+            lambda: self._on_click()
         )
 
         # Connect layer events to populate combobox and update button state
-        self.viewer.layers.events.inserted.connect(self._populate_comboboxes)
-        self.viewer.layers.events.removed.connect(self._populate_comboboxes)
+        self.viewer.layers.events.inserted.connect(
+            lambda e: self._populate_comboboxes(e)
+        )
+        self.viewer.layers.events.removed.connect(
+            lambda e: self._populate_comboboxes(e)
+        )
 
         # Connect to update button state when layer selection changes
         if hasattr(
             self.parent_widget, 'image_layer_with_phasor_features_combobox'
         ):
             self.parent_widget.image_layer_with_phasor_features_combobox.currentTextChanged.connect(
-                self._update_button_state
+                lambda text: self._update_button_state()
             )
 
         # Populate combobox
@@ -107,7 +111,9 @@ class CalibrationWidget(QWidget):
             for layer in image_layers:
                 with contextlib.suppress(TypeError, ValueError):
                     layer.events.name.disconnect(self._populate_comboboxes)
-                layer.events.name.connect(self._populate_comboboxes)
+                layer.events.name.connect(
+                    lambda e: self._populate_comboboxes(e)
+                )
 
         finally:
             self._populating_comboboxes = False

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -137,7 +137,7 @@ class ComponentsWidget(QWidget):
         self._update_lifetime_inputs_visibility()
         self._update_analysis_options()
         self.parent_widget.harmonic_spinbox.valueChanged.connect(
-            self._on_harmonic_changed
+            lambda *args: self._on_harmonic_changed(*args)
         )
 
     def setup_ui(self):
@@ -164,7 +164,7 @@ class ComponentsWidget(QWidget):
         analysis_layout.addWidget(QLabel("Analysis Type:"))
         self.analysis_type_combo = QComboBox()
         self.analysis_type_combo.currentTextChanged.connect(
-            self._on_analysis_type_changed
+            lambda *args: self._on_analysis_type_changed(*args)
         )
         self.analysis_type_combo.setToolTip(
             "Select the type of component analysis to perform."
@@ -199,19 +199,23 @@ class ComponentsWidget(QWidget):
         # Component management section
         comp_management_layout = QHBoxLayout()
         self.add_component_btn = QPushButton("Add Component")
-        self.add_component_btn.clicked.connect(self._add_component)
+        self.add_component_btn.clicked.connect(lambda: self._add_component())
         self.add_component_btn.setToolTip("Add a new component field.")
         comp_management_layout.addWidget(self.add_component_btn)
 
         self.remove_component_btn = QPushButton("Remove Component")
-        self.remove_component_btn.clicked.connect(self._remove_component)
+        self.remove_component_btn.clicked.connect(
+            lambda: self._remove_component()
+        )
         self.remove_component_btn.setToolTip(
             "Remove the last component field."
         )
         comp_management_layout.addWidget(self.remove_component_btn)
 
         self.clear_components_btn = QPushButton("Clear All")
-        self.clear_components_btn.clicked.connect(self._clear_components)
+        self.clear_components_btn.clicked.connect(
+            lambda: self._clear_components()
+        )
         self.clear_components_btn.setToolTip("Clear all component values.")
         comp_management_layout.addWidget(self.clear_components_btn)
 
@@ -220,7 +224,7 @@ class ComponentsWidget(QWidget):
 
         # Calculate button
         self.calculate_button = QPushButton("Run Component Analysis")
-        self.calculate_button.clicked.connect(self._run_analysis)
+        self.calculate_button.clicked.connect(lambda: self._run_analysis())
         self.calculate_button.setToolTip(
             "Run the selected analysis type on the defined components."
         )
@@ -233,7 +237,9 @@ class ComponentsWidget(QWidget):
 
         buttons_row = QHBoxLayout()
         self.plot_settings_btn = QPushButton("Edit Line Layout...")
-        self.plot_settings_btn.clicked.connect(self._open_plot_settings_dialog)
+        self.plot_settings_btn.clicked.connect(
+            lambda: self._open_plot_settings_dialog()
+        )
         self.plot_settings_btn.setToolTip(
             "Edit the layout of the line(s) between components."
         )
@@ -241,7 +247,9 @@ class ComponentsWidget(QWidget):
 
         # Label style button
         self.label_style_btn = QPushButton("Edit Component Name Layout...")
-        self.label_style_btn.clicked.connect(self._open_label_style_dialog)
+        self.label_style_btn.clicked.connect(
+            lambda: self._open_label_style_dialog()
+        )
         self.label_style_btn.setToolTip(
             "Edit the layout of the component name labels in the plot."
         )
@@ -256,7 +264,7 @@ class ComponentsWidget(QWidget):
             "Select which component's fraction data to display in the histogram."
         )
         self.histogram_component_combobox.currentIndexChanged.connect(
-            self._on_histogram_component_changed
+            lambda *args: self._on_histogram_component_changed(*args)
         )
 
         # NOTE: The widget is created here but NOT added to this tab's layout.
@@ -272,7 +280,7 @@ class ComponentsWidget(QWidget):
             parent=self,
         )
         self.histogram_widget.rangeChanged.connect(
-            self._on_fraction_range_changed
+            lambda *args: self._on_fraction_range_changed(*args)
         )
 
         layout.addStretch()
@@ -1012,7 +1020,7 @@ class ComponentsWidget(QWidget):
 
             finally:
                 fraction_layer.events.colormap.connect(
-                    self._on_colormap_changed
+                    lambda *args: self._on_colormap_changed(*args)
                 )
 
         if (
@@ -1048,14 +1056,14 @@ class ComponentsWidget(QWidget):
         self.colormap_line_checkbox = QCheckBox("Overlay Colormap")
         self.colormap_line_checkbox.setChecked(self.show_colormap_line)
         self.colormap_line_checkbox.stateChanged.connect(
-            self._on_plot_setting_changed
+            lambda *args: self._on_plot_setting_changed(*args)
         )
         row1.addWidget(self.colormap_line_checkbox)
 
         self.show_dots_checkbox = QCheckBox("Show component positions")
         self.show_dots_checkbox.setChecked(self.show_component_dots)
         self.show_dots_checkbox.stateChanged.connect(
-            self._on_plot_setting_changed
+            lambda *args: self._on_plot_setting_changed(*args)
         )
         row1.addWidget(self.show_dots_checkbox)
         row1.addStretch()
@@ -1068,7 +1076,7 @@ class ComponentsWidget(QWidget):
         self.line_offset_slider.setRange(-500, 500)
         self.line_offset_slider.setValue(int(self.line_offset * 1000))
         self.line_offset_slider.valueChanged.connect(
-            self._on_line_offset_changed
+            lambda *args: self._on_line_offset_changed(*args)
         )
         row2.addWidget(self.line_offset_slider)
         self.line_offset_value_label = QLabel(f"{self.line_offset:.3f}")
@@ -1082,7 +1090,9 @@ class ComponentsWidget(QWidget):
         self.line_width_spin.setRange(0.5, 20.0)
         self.line_width_spin.setSingleStep(0.5)
         self.line_width_spin.setValue(self.line_width)
-        self.line_width_spin.valueChanged.connect(self._on_line_width_changed)
+        self.line_width_spin.valueChanged.connect(
+            lambda val: self._on_line_width_changed(val)
+        )
         row3.addWidget(self.line_width_spin)
 
         row3.addWidget(QLabel("Alpha:"))
@@ -1090,7 +1100,7 @@ class ComponentsWidget(QWidget):
         self.line_alpha_slider.setRange(0, 100)
         self.line_alpha_slider.setValue(int(self.line_alpha * 100))
         self.line_alpha_slider.valueChanged.connect(
-            self._on_line_alpha_changed
+            lambda *args: self._on_line_alpha_changed(*args)
         )
         row3.addWidget(self.line_alpha_slider)
         self.line_alpha_value_label = QLabel(f"{self.line_alpha:.2f}")
@@ -1107,7 +1117,9 @@ class ComponentsWidget(QWidget):
         self.color_button.setStyleSheet(
             f"background-color: {self.default_component_color}; border: 1px solid black;"
         )
-        self.color_button.clicked.connect(self._on_color_button_clicked)
+        self.color_button.clicked.connect(
+            lambda: self._on_color_button_clicked()
+        )
         row4.addWidget(self.color_button)
 
         row4.addStretch()
@@ -1117,13 +1129,15 @@ class ComponentsWidget(QWidget):
         buttons_layout = QHBoxLayout()
 
         reset_button = QPushButton("Reset")
-        reset_button.clicked.connect(self._reset_plot_settings)
+        reset_button.clicked.connect(lambda: self._reset_plot_settings())
         buttons_layout.addWidget(reset_button)
 
         buttons_layout.addStretch()
 
         close_button = QPushButton("Close")
-        close_button.clicked.connect(self.plot_dialog.close)
+        close_button.clicked.connect(
+            lambda *args: self.plot_dialog.close(*args)
+        )
         buttons_layout.addWidget(close_button)
 
         vbox.addLayout(buttons_layout)
@@ -1338,28 +1352,34 @@ class ComponentsWidget(QWidget):
         self.fontsize_spin = QSpinBox()
         self.fontsize_spin.setRange(6, 72)
         self.fontsize_spin.setValue(self.label_fontsize)
-        self.fontsize_spin.valueChanged.connect(self._on_label_style_changed)
+        self.fontsize_spin.valueChanged.connect(
+            lambda val: self._on_label_style_changed(val)
+        )
         row.addWidget(self.fontsize_spin)
 
         self.bold_checkbox = QCheckBox("Bold")
         self.bold_checkbox.setChecked(self.label_bold)
-        self.bold_checkbox.stateChanged.connect(self._on_label_style_changed)
+        self.bold_checkbox.stateChanged.connect(
+            lambda val: self._on_label_style_changed(val)
+        )
         row.addWidget(self.bold_checkbox)
 
         self.italic_checkbox = QCheckBox("Italic")
         self.italic_checkbox.setChecked(self.label_italic)
-        self.italic_checkbox.stateChanged.connect(self._on_label_style_changed)
+        self.italic_checkbox.stateChanged.connect(
+            lambda val: self._on_label_style_changed(val)
+        )
         row.addWidget(self.italic_checkbox)
 
         self.color_button = QPushButton("Color")
-        self.color_button.clicked.connect(self._pick_label_color)
+        self.color_button.clicked.connect(lambda: self._pick_label_color())
         row.addWidget(self.color_button)
 
         row.addStretch()
         vbox.addLayout(row)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Close)
-        buttons.rejected.connect(self.style_dialog.close)
+        buttons.rejected.connect(lambda *args: self.style_dialog.close(*args))
         vbox.addWidget(buttons)
 
         self.style_dialog.show()
@@ -1458,10 +1478,10 @@ class ComponentsWidget(QWidget):
                 )
 
                 self.comp1_fractions_layer.events.colormap.connect(
-                    self._on_colormap_changed
+                    lambda *args: self._on_colormap_changed(*args)
                 )
                 self.comp1_fractions_layer.events.contrast_limits.connect(
-                    self._on_contrast_limits_changed
+                    lambda *args: self._on_contrast_limits_changed(*args)
                 )
 
                 self.draw_line_between_components()
@@ -1470,10 +1490,10 @@ class ComponentsWidget(QWidget):
                 print(f"Error applying saved colormap settings: {e}")
                 try:
                     self.comp1_fractions_layer.events.colormap.connect(
-                        self._on_colormap_changed
+                        lambda *args: self._on_colormap_changed(*args)
                     )
                     self.comp1_fractions_layer.events.contrast_limits.connect(
-                        self._on_contrast_limits_changed
+                        lambda *args: self._on_contrast_limits_changed(*args)
                     )
                 except Exception:  # noqa: BLE001
                     pass
@@ -3085,10 +3105,10 @@ class ComponentsWidget(QWidget):
             if idx == 0:
                 self.comp1_fractions_layer = self.viewer.layers[expected_name]
                 self.comp1_fractions_layer.events.colormap.connect(
-                    self._on_colormap_changed
+                    lambda *args: self._on_colormap_changed(*args)
                 )
                 self.comp1_fractions_layer.events.contrast_limits.connect(
-                    self._on_contrast_limits_changed
+                    lambda *args: self._on_contrast_limits_changed(*args)
                 )
         else:
             possible_names = [
@@ -3104,10 +3124,12 @@ class ComponentsWidget(QWidget):
                     if idx == 0:
                         self.comp1_fractions_layer = layer_obj
                         self.comp1_fractions_layer.events.colormap.connect(
-                            self._on_colormap_changed
+                            lambda *args: self._on_colormap_changed(*args)
                         )
                         self.comp1_fractions_layer.events.contrast_limits.connect(
-                            self._on_contrast_limits_changed
+                            lambda *args: self._on_contrast_limits_changed(
+                                *args
+                            )
                         )
                     break
 
@@ -3568,10 +3590,10 @@ class ComponentsWidget(QWidget):
                 )
 
         self.comp1_fractions_layer.events.colormap.connect(
-            self._on_colormap_changed
+            lambda *args: self._on_colormap_changed(*args)
         )
         self.comp1_fractions_layer.events.contrast_limits.connect(
-            self._on_contrast_limits_changed
+            lambda *args: self._on_contrast_limits_changed(*args)
         )
 
         self._update_component_colors()
@@ -3830,9 +3852,11 @@ class ComponentsWidget(QWidget):
                 new_layer.contrast_limits = contrast_limits
 
                 self.fraction_layers.append(new_layer)
-                new_layer.events.colormap.connect(self._on_colormap_changed)
+                new_layer.events.colormap.connect(
+                    lambda *args: self._on_colormap_changed(*args)
+                )
                 new_layer.events.contrast_limits.connect(
-                    self._on_contrast_limits_changed
+                    lambda *args: self._on_contrast_limits_changed(*args)
                 )
 
                 if (

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -146,7 +146,9 @@ class FilterWidget(QWidget):
         self.log_scale_checkbox = QToggleSwitch("Log Scale Histogram")
         self.log_scale_checkbox.onColor = QColor("#27ae60")  # Nice Green
         self.log_scale_checkbox.setChecked(False)
-        self.log_scale_checkbox.toggled.connect(self.on_log_scale_changed)
+        self.log_scale_checkbox.toggled.connect(
+            lambda checked: self.on_log_scale_changed(checked)
+        )
         threshold_method_layout.addWidget(self.log_scale_checkbox)
         threshold_method_layout.addStretch()
 

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -85,7 +85,7 @@ class FilterWidget(QWidget):
         self.setup_ui()
 
         self.parent_widget.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
-            self._on_image_layer_changed
+            lambda index: self._on_image_layer_changed()
         )
 
     def _is_tab_visible(self):
@@ -211,23 +211,23 @@ class FilterWidget(QWidget):
 
         # Connect signals (once, not on every tab switch)
         self.threshold_slider.valueChanged.connect(
-            self.on_threshold_slider_change
+            lambda: self.on_threshold_slider_change()
         )
         self.threshold_method_combobox.currentTextChanged.connect(
-            self.on_threshold_method_changed
+            lambda text: self.on_threshold_method_changed()
         )
         self.filter_method_combobox.currentTextChanged.connect(
-            self.on_filter_method_changed
+            lambda text: self.on_filter_method_changed()
         )
         self.median_filter_spinbox.valueChanged.connect(
-            self.on_median_kernel_size_change
+            lambda val: self.on_median_kernel_size_change()
         )
-        self.apply_button.clicked.connect(self.apply_button_clicked)
+        self.apply_button.clicked.connect(lambda: self.apply_button_clicked())
         self.min_threshold_edit.editingFinished.connect(
-            self.on_min_threshold_edit_changed
+            lambda: self.on_min_threshold_edit_changed()
         )
         self.max_threshold_edit.editingFinished.connect(
-            self.on_max_threshold_edit_changed
+            lambda: self.on_max_threshold_edit_changed()
         )
 
         # Initialize UI state

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -3,9 +3,7 @@ from math import ceil, log10
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.backends.backend_qt5agg import (
-    FigureCanvasQTAgg as FigureCanvas,
-)
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from napari.utils.notifications import show_error
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
@@ -17,6 +15,7 @@ from qtpy.QtWidgets import (
     QLineEdit,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -186,9 +185,7 @@ class FilterWidget(QWidget):
         # Embed the Matplotlib figure into the widget with fixed size
         canvas = FigureCanvas(self.hist_fig)
         canvas.setFixedHeight(150)
-        canvas.setSizePolicy(
-            canvas.sizePolicy().Expanding, canvas.sizePolicy().Fixed
-        )
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self._canvas = canvas
 
         # Connect mouse events for draggable threshold line

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -82,8 +82,12 @@ class FretWidget(QWidget):
         self.setup_ui()
 
         # Connect to layer events to update background combobox
-        self.viewer.layers.events.inserted.connect(self._on_layer_changed)
-        self.viewer.layers.events.removed.connect(self._on_layer_changed)
+        self.viewer.layers.events.inserted.connect(
+            lambda *args: self._on_layer_changed()
+        )
+        self.viewer.layers.events.removed.connect(
+            lambda *args: self._on_layer_changed()
+        )
 
     def setup_ui(self):
         """Set up the user interface for the FRET widget with a scroll area."""
@@ -106,7 +110,9 @@ class FretWidget(QWidget):
         self.frequency_input.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Fixed
         )
-        self.frequency_input.textChanged.connect(self._on_parameters_changed)
+        self.frequency_input.textChanged.connect(
+            lambda *args: self._on_parameters_changed(*args)
+        )
         self.frequency_input.setToolTip(
             "Enter the laser pulse or modulation frequency in MHz"
         )
@@ -125,7 +131,7 @@ class FretWidget(QWidget):
             QSizePolicy.Expanding, QSizePolicy.Fixed
         )
         self.donor_source_selector.currentIndexChanged.connect(
-            self._on_donor_source_changed
+            lambda *args: self._on_donor_source_changed(*args)
         )
         self.donor_source_selector.setToolTip(
             "Select whether to input donor lifetime manually or derive it from a layer"
@@ -146,7 +152,9 @@ class FretWidget(QWidget):
         self.donor_line_edit.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Fixed
         )
-        self.donor_line_edit.textChanged.connect(self._on_parameters_changed)
+        self.donor_line_edit.textChanged.connect(
+            lambda *args: self._on_parameters_changed(*args)
+        )
         self.donor_line_edit.setToolTip(
             "Enter the donor lifetime in nanoseconds"
         )
@@ -162,7 +170,7 @@ class FretWidget(QWidget):
             enable_primary_layer=False
         )
         self.donor_lifetime_combobox.selectionChanged.connect(
-            self._calculate_donor_lifetime
+            lambda *args: self._calculate_donor_lifetime(*args)
         )
         self.donor_lifetime_combobox.setToolTip(
             "Select one or more layers from which to derive the donor lifetime (averaged)"
@@ -180,7 +188,7 @@ class FretWidget(QWidget):
             ]
         )
         self.lifetime_type_combobox.currentIndexChanged.connect(
-            self._calculate_donor_lifetime
+            lambda *args: self._calculate_donor_lifetime(*args)
         )
         self.lifetime_type_combobox.setToolTip(
             "Select the method to calculate donor lifetime from phasor coordinates"
@@ -203,7 +211,7 @@ class FretWidget(QWidget):
             QSizePolicy.Expanding, QSizePolicy.Fixed
         )
         self.background_slider.valueChanged.connect(
-            self._on_background_slider_changed
+            lambda *args: self._on_background_slider_changed(*args)
         )
         self.background_slider.setToolTip(
             "Weight of background fluorescence in donor channel relative to fluorescence of donor without FRET. A weight of 1 means the fluorescence of background and donor without FRET are equal."
@@ -223,7 +231,7 @@ class FretWidget(QWidget):
             QComboBox.AdjustToMinimumContentsLengthWithIcon
         )
         self.bg_source_selector.currentIndexChanged.connect(
-            self._on_bg_source_changed
+            lambda *args: self._on_bg_source_changed(*args)
         )
         self.bg_source_selector.setToolTip(
             "Select whether to input background position manually or derive it from a layer"
@@ -244,7 +252,7 @@ class FretWidget(QWidget):
         self.background_real_edit.setValidator(QDoubleValidator())
         self.background_real_edit.setText("0.0")
         self.background_real_edit.textChanged.connect(
-            self._on_background_position_changed
+            lambda *args: self._on_background_position_changed()
         )
         self.background_real_edit.setToolTip(
             "Real component of background fluorescence phasor coordinate at frequency"
@@ -256,7 +264,7 @@ class FretWidget(QWidget):
         self.background_imag_edit.setValidator(QDoubleValidator())
         self.background_imag_edit.setText("0.0")
         self.background_imag_edit.textChanged.connect(
-            self._on_background_position_changed
+            lambda *args: self._on_background_position_changed()
         )
         self.background_imag_edit.setToolTip(
             "Imaginary component of background fluorescence phasor coordinate at frequency"
@@ -273,7 +281,7 @@ class FretWidget(QWidget):
             enable_primary_layer=False
         )
         self.background_image_combobox.selectionChanged.connect(
-            self._calculate_background_position
+            lambda *args: self._calculate_background_position()
         )
         self.background_image_combobox.setToolTip(
             "Select one or more layers from which to derive the background position (averaged)"
@@ -295,7 +303,7 @@ class FretWidget(QWidget):
             QSizePolicy.Expanding, QSizePolicy.Fixed
         )
         self.fretting_slider.valueChanged.connect(
-            self._on_fretting_slider_changed
+            lambda *args: self._on_fretting_slider_changed()
         )
         self.fretting_slider.setToolTip(
             "Fraction of donors participating in FRET"
@@ -316,7 +324,7 @@ class FretWidget(QWidget):
         self.colormap_checkbox.onColor = QColor("#27ae60")  # Nice Green
         self.colormap_checkbox.setChecked(True)
         self.colormap_checkbox.toggled.connect(
-            self._on_colormap_checkbox_changed
+            lambda *args: self._on_colormap_checkbox_changed(*args)
         )
         layout.addWidget(self.colormap_checkbox)
 
@@ -325,7 +333,7 @@ class FretWidget(QWidget):
             "Calculate FRET efficiency"
         )
         self.calculate_fret_efficiency_button.clicked.connect(
-            self.calculate_fret_efficiency
+            lambda *args: self.calculate_fret_efficiency()
         )
         layout.addWidget(self.calculate_fret_efficiency_button)
 
@@ -343,7 +351,9 @@ class FretWidget(QWidget):
         )
 
         # Connect range-slider signal
-        self.histogram_widget.rangeChanged.connect(self._on_fret_range_changed)
+        self.histogram_widget.rangeChanged.connect(
+            lambda *args: self._on_fret_range_changed(*args)
+        )
 
         layout.addStretch()
 
@@ -673,7 +683,9 @@ class FretWidget(QWidget):
                         layer.events.name.disconnect(
                             self._update_background_combobox
                         )
-                    layer.events.name.connect(self._update_background_combobox)
+                    layer.events.name.connect(
+                        lambda *args: self._update_background_combobox()
+                    )
 
         finally:
             self._updating_background_combobox = False
@@ -713,7 +725,9 @@ class FretWidget(QWidget):
                             self._update_donor_lifetime_combobox
                         )
                     layer.events.name.connect(
-                        self._update_donor_lifetime_combobox
+                        lambda *args: self._update_donor_lifetime_combobox(
+                            *args
+                        )
                     )
 
         finally:
@@ -1457,10 +1471,10 @@ class FretWidget(QWidget):
                 self.colormap_contrast_limits = self.fret_layer.contrast_limits
 
                 self.fret_layer.events.colormap.connect(
-                    self._on_colormap_changed
+                    lambda *args: self._on_colormap_changed(*args)
                 )
                 self.fret_layer.events.contrast_limits.connect(
-                    self._on_contrast_limits_changed
+                    lambda *args: self._on_contrast_limits_changed(*args)
                 )
 
                 self.plot_donor_trajectory()
@@ -1469,10 +1483,10 @@ class FretWidget(QWidget):
                 print(f"Error applying saved colormap settings: {e}")
                 try:
                     self.fret_layer.events.colormap.connect(
-                        self._on_colormap_changed
+                        lambda *args: self._on_colormap_changed(*args)
                     )
                     self.fret_layer.events.contrast_limits.connect(
-                        self._on_contrast_limits_changed
+                        lambda *args: self._on_contrast_limits_changed(*args)
                     )
                 except Exception:  # noqa: BLE001
                     pass
@@ -1484,9 +1498,11 @@ class FretWidget(QWidget):
         if fret_layer_name in self.viewer.layers:
             self.fret_layer = self.viewer.layers[fret_layer_name]
 
-            self.fret_layer.events.colormap.connect(self._on_colormap_changed)
+            self.fret_layer.events.colormap.connect(
+                lambda *args: self._on_colormap_changed(*args)
+            )
             self.fret_layer.events.contrast_limits.connect(
-                self._on_contrast_limits_changed
+                lambda *args: self._on_contrast_limits_changed(*args)
             )
 
             if hasattr(self, '_saved_colormap_name'):
@@ -1828,9 +1844,11 @@ class FretWidget(QWidget):
 
             # Add to list of FRET layers and connect events
             self.fret_layers.append(fret_layer)
-            fret_layer.events.colormap.connect(self._on_colormap_changed)
+            fret_layer.events.colormap.connect(
+                lambda *args: self._on_colormap_changed(*args)
+            )
             fret_layer.events.contrast_limits.connect(
-                self._on_contrast_limits_changed
+                lambda *args: self._on_contrast_limits_changed(*args)
             )
 
             # Store reference to first FRET layer for backward compatibility

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -98,7 +98,7 @@ class PhasorMappingWidget(QWidget):
         self._mesh_axes_update_timer.setSingleShot(True)
         self._mesh_axes_update_timer.setInterval(75)
         self._mesh_axes_update_timer.timeout.connect(
-            self._apply_mesh_after_axes_change
+            lambda *args: self._apply_mesh_after_axes_change(*args)
         )
         self._mesh_grid_cache = {}
         self._mesh_grid_cache_order = []
@@ -177,7 +177,9 @@ class PhasorMappingWidget(QWidget):
         self.custom_color_button.setFixedSize(22, 22)
         self.custom_color_button.setToolTip("Select custom color")
         self.custom_color_button.setVisible(False)
-        self.custom_color_button.clicked.connect(self._on_custom_color_clicked)
+        self.custom_color_button.clicked.connect(
+            lambda *args: self._on_custom_color_clicked()
+        )
         colormap_layout.addWidget(self.custom_color_button)
 
         self.main_layout.addWidget(self.colormap_widget)
@@ -197,19 +199,19 @@ class PhasorMappingWidget(QWidget):
 
         # Connect signals
         self.lifetime_type_combobox.currentTextChanged.connect(
-            self._on_lifetime_type_changed
+            lambda *args: self._on_lifetime_type_changed(*args)
         )
         self.output_mode_combobox.currentTextChanged.connect(
-            self._on_output_mode_changed
+            lambda *args: self._on_output_mode_changed(*args)
         )
         self.colormap_combobox.currentTextChanged.connect(
-            self._on_colormap_combobox_changed
+            lambda *args: self._on_colormap_combobox_changed(*args)
         )
         self.apply_2d_colormap_checkbox.toggled.connect(
-            self._on_apply_2d_colormap_checkbox_changed
+            lambda *args: self._on_apply_2d_colormap_checkbox_changed(*args)
         )
         self.frequency_input.editingFinished.connect(
-            self._on_frequency_changed
+            lambda *args: self._on_frequency_changed()
         )
 
         # NOTE: The widget is created here but NOT added to this tab's layout.
@@ -234,7 +236,7 @@ class PhasorMappingWidget(QWidget):
 
         # Connect the histogram widget's rangeChanged signal
         self.histogram_widget.rangeChanged.connect(
-            self._on_range_changed_from_histogram
+            lambda *args: self._on_range_changed_from_histogram(*args)
         )
         self._configure_histogram_labels_for_output(
             self.lifetime_type_combobox.currentText()
@@ -359,41 +361,41 @@ class PhasorMappingWidget(QWidget):
             "Calculate and display the selected output for all selected layers"
         )
         self.calculate_lifetime_button.clicked.connect(
-            self._on_calculate_lifetime_clicked
+            lambda *args: self._on_calculate_lifetime_clicked()
         )
         self.main_layout.addWidget(self.calculate_lifetime_button)
         self.main_layout.addStretch(1)
 
         # Connect signals for mesh overlay
         self.mesh_overlay_checkbox.toggled.connect(
-            self._on_mesh_overlay_toggled
+            lambda *args: self._on_mesh_overlay_toggled(*args)
         )
         self.mesh_clip_semicircle_checkbox.toggled.connect(
-            self._on_mesh_clip_toggled
+            lambda *args: self._on_mesh_clip_toggled(*args)
         )
         self.mesh_colorbar_checkbox.toggled.connect(
-            self._on_mesh_colorbar_toggled
+            lambda *args: self._on_mesh_colorbar_toggled(*args)
         )
         self.phase_range_slider.valueChanged.connect(
-            self._on_phase_slider_changed
+            lambda *args: self._on_phase_slider_changed(*args)
         )
         self.phase_min_edit.editingFinished.connect(
-            self._on_phase_edits_changed
+            lambda *args: self._on_phase_edits_changed()
         )
         self.phase_max_edit.editingFinished.connect(
-            self._on_phase_edits_changed
+            lambda *args: self._on_phase_edits_changed()
         )
         self.modulation_range_slider.valueChanged.connect(
-            self._on_modulation_slider_changed
+            lambda *args: self._on_modulation_slider_changed(*args)
         )
         self.modulation_min_edit.editingFinished.connect(
-            self._on_modulation_edits_changed
+            lambda *args: self._on_modulation_edits_changed()
         )
         self.modulation_max_edit.editingFinished.connect(
-            self._on_modulation_edits_changed
+            lambda *args: self._on_modulation_edits_changed()
         )
         self.mesh_alpha_spinbox.valueChanged.connect(
-            self._on_mesh_alpha_changed
+            lambda *args: self._on_mesh_alpha_changed(*args)
         )
 
         self._sync_mode_widgets()
@@ -403,10 +405,10 @@ class PhasorMappingWidget(QWidget):
         # Connect to plot type changes in the parent widget
         if self.parent_widget is not None:
             self.parent_widget.plotter_inputs_widget.plot_type_combobox.currentTextChanged.connect(
-                self.update_apply_2d_text
+                lambda *args: self.update_apply_2d_text()
             )
             self.parent_widget.plotter_inputs_widget.semi_circle_checkbox.toggled.connect(
-                self._on_plot_geometry_mode_toggled
+                lambda *args: self._on_plot_geometry_mode_toggled(*args)
             )
             self._connect_axes_limit_callbacks()
 
@@ -420,10 +422,12 @@ class PhasorMappingWidget(QWidget):
             return
         self._axes_limit_callback_cids = [
             axes.callbacks.connect(
-                'xlim_changed', self._on_axes_limits_changed
+                'xlim_changed',
+                lambda *args: self._on_axes_limits_changed(*args),
             ),
             axes.callbacks.connect(
-                'ylim_changed', self._on_axes_limits_changed
+                'ylim_changed',
+                lambda *args: self._on_axes_limits_changed(*args),
             ),
         ]
 
@@ -1471,9 +1475,11 @@ class PhasorMappingWidget(QWidget):
 
             self.metric_layers.append(output_layer)
             self.lifetime_layers.append(output_layer)
-            output_layer.events.colormap.connect(self._on_colormap_changed)
+            output_layer.events.colormap.connect(
+                lambda *args: self._on_colormap_changed(*args)
+            )
             output_layer.events.contrast_limits.connect(
-                self._on_colormap_changed
+                lambda *args: self._on_colormap_changed(*args)
             )
 
             if self.lifetime_layer is None:

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -65,6 +65,51 @@ from .phasor_mapping_tab import PhasorMappingWidget
 from .selection_tab import SelectionWidget
 
 
+def _patch_nap_plot_tools_toolbar_disconnect():
+    try:
+        from nap_plot_tools.tools import CustomToolbarWidget
+    except ImportError:
+        return
+
+    if getattr(
+        CustomToolbarWidget, '_napari_phasors_disconnect_patched', False
+    ):
+        return
+
+    def connect_button_callback(self, name, callback):
+        if name in self.buttons:
+            button = self.buttons[name]
+            checkable = button.isCheckable()
+            previous_callback = getattr(
+                button, '_napari_phasors_toolbar_callback', None
+            )
+
+            if previous_callback is not None:
+                signal = button.toggled if checkable else button.clicked
+                with contextlib.suppress(TypeError, RuntimeError):
+                    signal.disconnect(previous_callback)
+
+            if callback:
+                if checkable:
+                    button._napari_phasors_toolbar_callback = callback
+                    button.toggled.connect(callback)
+                else:
+
+                    def _wrapped_callback(*args, **kwargs):
+                        callback()
+
+                    button._napari_phasors_toolbar_callback = _wrapped_callback
+                    button.clicked.connect(_wrapped_callback)
+            else:
+                button._napari_phasors_toolbar_callback = None
+
+    CustomToolbarWidget.connect_button_callback = connect_button_callback
+    CustomToolbarWidget._napari_phasors_disconnect_patched = True
+
+
+_patch_nap_plot_tools_toolbar_disconnect()
+
+
 class MaskAssignmentDialog(QDialog):
     """Dialog to assign a mask layer to each selected image layer.
 
@@ -127,7 +172,7 @@ class MaskAssignmentDialog(QDialog):
         self._apply_all_combo = QComboBox()
         self._apply_all_combo.addItems(mask_options)
         self._apply_all_combo.currentTextChanged.connect(
-            self._on_apply_all_changed
+            lambda *args: self._on_apply_all_changed(*args)
         )
         apply_all_layout.addWidget(self._apply_all_combo, 1)
         layout.addLayout(apply_all_layout)
@@ -136,8 +181,8 @@ class MaskAssignmentDialog(QDialog):
         button_box = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
-        button_box.accepted.connect(self.accept)
-        button_box.rejected.connect(self.reject)
+        button_box.accepted.connect(lambda *args: self.accept(*args))
+        button_box.rejected.connect(lambda *args: self.reject(*args))
         layout.addWidget(button_box)
 
     def _on_apply_all_changed(self, text):
@@ -262,7 +307,7 @@ class ContourLayerSettingsDialog(QDialog):
         if merged_style == "solid":
             self._merged_colormap_combo.setCurrentIndex(0)
         self._merged_colormap_combo.currentTextChanged.connect(
-            self._on_merged_colormap_changed
+            lambda *args: self._on_merged_colormap_changed(*args)
         )
         self._merged_color_btn = QPushButton()
         self._merged_color_btn.setFixedSize(24, 24)
@@ -385,18 +430,20 @@ class ContourLayerSettingsDialog(QDialog):
 
         add_group_btn = QPushButton("+ Add Group")
         add_group_btn.setMaximumWidth(120)
-        add_group_btn.clicked.connect(self._on_add_group)
+        add_group_btn.clicked.connect(lambda: self._on_add_group())
         group_layout.addWidget(add_group_btn)
         root.addWidget(self._group_section)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(lambda *args: self.accept(*args))
+        buttons.rejected.connect(lambda *args: self.reject(*args))
         root.addWidget(buttons)
 
-        self.mode_combo.currentTextChanged.connect(self._update_ui_for_mode)
+        self.mode_combo.currentTextChanged.connect(
+            lambda val: self._update_ui_for_mode(val)
+        )
         self._update_ui_for_mode(self.mode_combo.currentText())
 
     @staticmethod
@@ -852,18 +899,20 @@ class PhasorCenterLayerSettingsDialog(QDialog):
 
         add_group_btn = QPushButton("+ Add Group")
         add_group_btn.setMaximumWidth(120)
-        add_group_btn.clicked.connect(self._on_add_group)
+        add_group_btn.clicked.connect(lambda: self._on_add_group())
         group_layout.addWidget(add_group_btn)
         root.addWidget(self._group_section)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(lambda *args: self.accept(*args))
+        buttons.rejected.connect(lambda *args: self.reject(*args))
         root.addWidget(buttons)
 
-        self.mode_combo.currentTextChanged.connect(self._update_ui_for_mode)
+        self.mode_combo.currentTextChanged.connect(
+            lambda val: self._update_ui_for_mode(val)
+        )
         self._update_ui_for_mode(self.mode_combo.currentText())
 
     @staticmethod
@@ -1327,7 +1376,7 @@ class PlotterWidget(QWidget):
             "Assign different mask layers to each selected image layer."
         )
         self.mask_assign_button.clicked.connect(
-            self._open_mask_assignment_dialog
+            lambda *args: self._open_mask_assignment_dialog(*args)
         )
         self.mask_assign_button.setVisible(False)
         harmonics_and_mask_container.addWidget(self.mask_assign_button, 1)
@@ -1364,19 +1413,25 @@ class PlotterWidget(QWidget):
             "Re-open the Phasor Analysis dock"
         )
         self.show_analysis_button.setVisible(False)
-        self.show_analysis_button.clicked.connect(self._show_analysis_dock)
+        self.show_analysis_button.clicked.connect(
+            lambda: self._show_analysis_dock()
+        )
         dock_buttons_layout.addWidget(self.show_analysis_button)
 
         self.show_histogram_button = QPushButton("Show Histogram")
         self.show_histogram_button.setToolTip("Re-open the Histogram dock")
         self.show_histogram_button.setVisible(False)
-        self.show_histogram_button.clicked.connect(self._show_histogram_dock)
+        self.show_histogram_button.clicked.connect(
+            lambda: self._show_histogram_dock()
+        )
         dock_buttons_layout.addWidget(self.show_histogram_button)
 
         self.show_statistics_button = QPushButton("Show Statistics Table")
         self.show_statistics_button.setToolTip("Re-open the Statistics dock")
         self.show_statistics_button.setVisible(False)
-        self.show_statistics_button.clicked.connect(self._show_statistics_dock)
+        self.show_statistics_button.clicked.connect(
+            lambda: self._show_statistics_dock()
+        )
         dock_buttons_layout.addWidget(self.show_statistics_button)
 
         self._dock_buttons_widget = QWidget()
@@ -1387,7 +1442,9 @@ class PlotterWidget(QWidget):
         # Timer that polls dock visibility — reliable for both the hide and
         # close-X buttons (the latter destroys the dock without emitting signals).
         self._dock_check_timer = QTimer(self)
-        self._dock_check_timer.timeout.connect(self._check_dock_visibility)
+        self._dock_check_timer.timeout.connect(
+            lambda: self._check_dock_visibility()
+        )
         self._dock_check_timer.start(500)
 
         # Create tab widget
@@ -1458,12 +1515,14 @@ class PlotterWidget(QWidget):
         self._analysis_dock_init_timer = QTimer(self)
         self._analysis_dock_init_timer.setSingleShot(True)
         self._analysis_dock_init_timer.timeout.connect(
-            self._add_analysis_dock_widget
+            lambda *args: self._add_analysis_dock_widget(*args)
         )
 
         self._dock_resize_timer = QTimer(self)
         self._dock_resize_timer.setSingleShot(True)
-        self._dock_resize_timer.timeout.connect(self._resize_initial_docks)
+        self._dock_resize_timer.timeout.connect(
+            lambda: self._resize_initial_docks()
+        )
 
         self._analysis_dock_init_timer.start(20)
 
@@ -1480,13 +1539,13 @@ class PlotterWidget(QWidget):
         self._layer_selection_timer.setSingleShot(True)
         self._layer_selection_timer.setInterval(300)  # 300ms delay
         self._layer_selection_timer.timeout.connect(
-            self._process_layer_selection_change
+            lambda *args: self._process_layer_selection_change(*args)
         )
 
         self._bins_timer = QTimer(self)
         self._bins_timer.setSingleShot(True)
         self._bins_timer.setInterval(500)  # 500ms delay
-        self._bins_timer.timeout.connect(self._process_bins_change)
+        self._bins_timer.timeout.connect(lambda: self._process_bins_change())
 
         # Create Settings tab
         self.settings_tab = QWidget()
@@ -1520,8 +1579,12 @@ class PlotterWidget(QWidget):
         self._create_fret_tab()
 
         # Connect napari signals when new layer is inseted or removed
-        self.viewer.layers.events.inserted.connect(self.reset_layer_choices)
-        self.viewer.layers.events.removed.connect(self.reset_layer_choices)
+        self.viewer.layers.events.inserted.connect(
+            lambda *args: self.reset_layer_choices()
+        )
+        self.viewer.layers.events.removed.connect(
+            lambda *args: self.reset_layer_choices()
+        )
 
         # Set contour single-layer defaults before wiring UI signals.
         # Combo-box population can emit callbacks during initialization.
@@ -1536,58 +1599,60 @@ class PlotterWidget(QWidget):
         # Connect callbacks
         # When primary layer changes, update all tab UIs (but don't run analyses)
         self.image_layers_checkable_combobox.primaryLayerChanged.connect(
-            self._on_primary_layer_changed
+            lambda *args: self._on_primary_layer_changed(*args)
         )
         # When selection changes, only update the plot
         self.image_layers_checkable_combobox.selectionChanged.connect(
-            self._on_selection_changed
+            lambda *args: self._on_selection_changed(*args)
         )
         # Update mask UI mode when selection changes (combobox vs button)
         self.image_layers_checkable_combobox.selectionChanged.connect(
-            self._update_mask_ui_mode
+            lambda *args: self._update_mask_ui_mode(*args)
         )
         # Update all frequency widgets from layer metadata if primary layer changes
         self.image_layers_checkable_combobox.primaryLayerChanged.connect(
-            self._sync_frequency_inputs_from_metadata
+            lambda *args: self._sync_frequency_inputs_from_metadata(*args)
         )
         # Update mask when mask layer selection changes
         self.mask_layer_combobox.currentTextChanged.connect(
-            self._on_mask_layer_changed
+            lambda *args: self._on_mask_layer_changed(*args)
         )
         self.plotter_inputs_widget.semi_circle_checkbox.toggled.connect(
-            self._on_semi_circle_changed
+            lambda *args: self._on_semi_circle_changed(*args)
         )
-        self.harmonic_spinbox.valueChanged.connect(self._on_harmonic_changed)
+        self.harmonic_spinbox.valueChanged.connect(
+            lambda val: self._on_harmonic_changed(val)
+        )
         self.plotter_inputs_widget.plot_type_combobox.currentIndexChanged.connect(
-            self._on_plot_type_changed
+            lambda *args: self._on_plot_type_changed()
         )
         self.plotter_inputs_widget.colormap_combobox.currentIndexChanged.connect(
-            self._on_colormap_changed
+            lambda *args: self._on_colormap_changed()
         )
         self.plotter_inputs_widget.number_of_bins_spinbox.valueChanged.connect(
-            self._on_bins_changed
+            lambda *args: self._on_bins_changed(*args)
         )
         self.plotter_inputs_widget.log_scale_checkbox.toggled.connect(
-            self._on_log_scale_changed
+            lambda *args: self._on_log_scale_changed(*args)
         )
         self.plotter_inputs_widget.white_background_checkbox.toggled.connect(
-            self._on_white_background_changed
+            lambda *args: self._on_white_background_changed(*args)
         )
 
         self.plotter_inputs_widget.marker_size_spinbox.valueChanged.connect(
-            self._on_marker_size_changed
+            lambda *args: self._on_marker_size_changed(*args)
         )
         self.plotter_inputs_widget.marker_color_button.clicked.connect(
-            self._on_marker_color_clicked
+            lambda *args: self._on_marker_color_clicked(*args)
         )
         self.plotter_inputs_widget.marker_alpha_spinbox.valueChanged.connect(
-            self._on_marker_alpha_changed
+            lambda *args: self._on_marker_alpha_changed(*args)
         )
         self.plotter_inputs_widget.contour_levels_spinbox.valueChanged.connect(
-            self._on_contour_levels_changed
+            lambda *args: self._on_contour_levels_changed(*args)
         )
         self.plotter_inputs_widget.contour_linewidth_spinbox.valueChanged.connect(
-            self._on_contour_linewidth_changed
+            lambda *args: self._on_contour_linewidth_changed(*args)
         )
 
         contour_settings_parent = self.plotter_inputs_widget.findChild(
@@ -1614,7 +1679,7 @@ class PlotterWidget(QWidget):
             "Choose solid contour color"
         )
         self.plotter_inputs_widget.contour_single_color_button.clicked.connect(
-            self._on_single_contour_color_clicked
+            lambda *args: self._on_single_contour_color_clicked()
         )
         self.plotter_inputs_widget.contour_single_color_button.setVisible(
             False
@@ -1659,7 +1724,7 @@ class PlotterWidget(QWidget):
             "Configure Multi-Layer Display..."
         )
         self.plotter_inputs_widget.contour_layer_settings_button.clicked.connect(
-            self._on_contour_layer_settings_clicked
+            lambda *args: self._on_contour_layer_settings_clicked()
         )
         contour_settings_layout.addWidget(
             self.plotter_inputs_widget.label_contour_layer_settings,
@@ -1683,14 +1748,14 @@ class PlotterWidget(QWidget):
             "#27ae60"
         )
         self.plotter_inputs_widget.phasor_center_checkbox.toggled.connect(
-            self._on_phasor_center_toggled
+            lambda *args: self._on_phasor_center_toggled(*args)
         )
 
         self.plotter_inputs_widget.pc_configure_button = QPushButton(
             "Configure center display..."
         )
         self.plotter_inputs_widget.pc_configure_button.clicked.connect(
-            self._on_phasor_center_configure_clicked
+            lambda *args: self._on_phasor_center_configure_clicked()
         )
         self.plotter_inputs_widget.pc_configure_button.setVisible(False)
 
@@ -1720,10 +1785,10 @@ class PlotterWidget(QWidget):
         )
 
         self.import_from_layer_button.clicked.connect(
-            self._import_settings_from_layer
+            lambda *args: self._import_settings_from_layer()
         )
         self.import_from_file_button.clicked.connect(
-            self._import_settings_from_file
+            lambda *args: self._import_settings_from_file()
         )
 
         # Populate plot type combobox with display names
@@ -1792,7 +1857,7 @@ class PlotterWidget(QWidget):
         self._connect_active_artist_signals()
         self._connect_selector_signals()
         self.canvas_widget.show_color_overlay_signal.connect(
-            self._enforce_axes_aspect
+            lambda *args: self._enforce_axes_aspect()
         )
 
         # Set the initial plot
@@ -1803,7 +1868,9 @@ class PlotterWidget(QWidget):
         self.reset_layer_choices()
 
         # Connect tab change signal
-        self.tab_widget.currentChanged.connect(self._on_tab_changed)
+        self.tab_widget.currentChanged.connect(
+            lambda *args: self._on_tab_changed(*args)
+        )
         self._set_selection_visibility(False)
 
         # Phasor center statistics widget
@@ -1909,7 +1976,10 @@ class PlotterWidget(QWidget):
             getattr(self, 'canvas_container', None),
             getattr(self, 'controls_container', None),
         }
-        if obj in watched and event.type() in {QEvent.Resize, QEvent.Show}:
+        if obj in watched and event.type() in {
+            QEvent.Type.Resize,
+            QEvent.Type.Show,
+        }:
             QTimer.singleShot(0, self._resize_canvas_to_available_space)
         return super().eventFilter(obj, event)
 
@@ -2497,8 +2567,8 @@ class PlotterWidget(QWidget):
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
         layout.addWidget(button_box)
-        button_box.accepted.connect(dialog.accept)
-        button_box.rejected.connect(dialog.reject)
+        button_box.accepted.connect(lambda *args: dialog.accept(*args))
+        button_box.rejected.connect(lambda *args: dialog.reject(*args))
 
         dialog.setLayout(layout)
         if dialog.exec_() == QDialog.Accepted:
@@ -2745,8 +2815,8 @@ class PlotterWidget(QWidget):
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
         layout.addWidget(button_box)
-        button_box.accepted.connect(dialog.accept)
-        button_box.rejected.connect(dialog.reject)
+        button_box.accepted.connect(lambda *args: dialog.accept(*args))
+        button_box.rejected.connect(lambda *args: dialog.reject(*args))
         dialog.setLayout(layout)
 
         if dialog.exec_() == QDialog.Accepted and layer_combo.currentText():
@@ -4209,7 +4279,7 @@ class PlotterWidget(QWidget):
             )
         )
         self.harmonic_spinbox.valueChanged.connect(
-            self.fret_tab._on_harmonic_changed
+            lambda *args: self.fret_tab._on_harmonic_changed(*args)
         )
 
     @property
@@ -4752,7 +4822,7 @@ class PlotterWidget(QWidget):
         """Connect selection applied signal from all selectors to enforce axes aspect."""
         for selector in self.canvas_widget.selectors.values():
             selector.selection_applied_signal.connect(
-                self._enforce_axes_aspect
+                lambda *args: self._enforce_axes_aspect()
             )
 
     def _connect_active_artist_signals(self):
@@ -4763,13 +4833,17 @@ class PlotterWidget(QWidget):
             self.canvas_widget.artists[
                 'HISTOGRAM2D'
             ].color_indices_changed_signal.connect(
-                self.selection_tab.manual_selection_changed
+                lambda *args: self.selection_tab.manual_selection_changed(
+                    *args
+                )
             )
         elif self.plot_type == 'SCATTER':
             self.canvas_widget.artists[
                 'SCATTER'
             ].color_indices_changed_signal.connect(
-                self.selection_tab.manual_selection_changed
+                lambda *args: self.selection_tab.manual_selection_changed(
+                    *args
+                )
             )
 
     def _disconnect_all_artist_signals(self):
@@ -4914,17 +4988,23 @@ class PlotterWidget(QWidget):
                 if isinstance(layer, Image):
                     with contextlib.suppress(TypeError, ValueError):
                         layer.events.name.disconnect(self.reset_layer_choices)
-                    layer.events.name.connect(self.reset_layer_choices)
+                    layer.events.name.connect(
+                        lambda *args: self.reset_layer_choices(*args)
+                    )
                 if isinstance(layer, (Shapes, Labels)):
                     with contextlib.suppress(TypeError, ValueError):
                         layer.events.name.disconnect(self.reset_layer_choices)
-                    layer.events.name.connect(self.reset_layer_choices)
+                    layer.events.name.connect(
+                        lambda *args: self.reset_layer_choices(*args)
+                    )
                 if isinstance(layer, Shapes):
                     with contextlib.suppress(TypeError, ValueError):
                         layer.events.data.disconnect(
                             self._on_mask_data_changed
                         )
-                    layer.events.data.connect(self._on_mask_data_changed)
+                    layer.events.data.connect(
+                        lambda *args: self._on_mask_data_changed(*args)
+                    )
                 if isinstance(layer, Labels):
                     try:
                         layer.events.paint.disconnect(
@@ -4935,8 +5015,12 @@ class PlotterWidget(QWidget):
                         )
                     except (TypeError, ValueError):
                         pass  # Not connected, ignore
-                    layer.events.paint.connect(self._on_mask_data_changed)
-                    layer.events.set_data.connect(self._on_mask_data_changed)
+                    layer.events.paint.connect(
+                        lambda *args: self._on_mask_data_changed(*args)
+                    )
+                    layer.events.set_data.connect(
+                        lambda *args: self._on_mask_data_changed(*args)
+                    )
 
             self._mask_layers_by_id = mask_layers_by_id
 

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (
     QPushButton,
     QSpinBox,
     QStackedWidget,
+    QStyle,
     QTableWidget,
     QVBoxLayout,
     QWidget,
@@ -116,12 +117,12 @@ class SelectionWidget(QWidget):
         self.refresh_selection_button = QPushButton()
         self.refresh_selection_button.setIcon(
             self.refresh_selection_button.style().standardIcon(
-                self.refresh_selection_button.style().SP_BrowserReload
+                QStyle.SP_BrowserReload
             )
         )
         self.refresh_selection_button.setMaximumWidth(35)
         self.refresh_selection_button.clicked.connect(
-            self._on_refresh_selection_clicked
+            lambda: self._on_refresh_selection_clicked()
         )
 
         # Find the grid layout and add the button to row 4, column 3
@@ -133,10 +134,10 @@ class SelectionWidget(QWidget):
 
         # Connect to multiple signals to handle both selection and text editing
         self.selection_input_widget.phasor_selection_id_combobox.currentIndexChanged.connect(
-            self.on_selection_id_changed
+            lambda index: self.on_selection_id_changed()
         )
         self.selection_input_widget.phasor_selection_id_combobox.activated.connect(
-            self.on_selection_id_changed
+            lambda index: self.on_selection_id_changed()
         )
         if hasattr(
             self.selection_input_widget.phasor_selection_id_combobox,
@@ -146,7 +147,9 @@ class SelectionWidget(QWidget):
                 self.selection_input_widget.phasor_selection_id_combobox.lineEdit()
             )
             if line_edit:
-                line_edit.editingFinished.connect(self.on_selection_id_changed)
+                line_edit.editingFinished.connect(
+                    lambda: self.on_selection_id_changed()
+                )
 
         # === Circular Cursor Mode Widget ===
         self.circular_cursor_widget = CircularCursorWidget(
@@ -176,7 +179,7 @@ class SelectionWidget(QWidget):
 
         # Connect mode change
         self.selection_mode_combobox.currentIndexChanged.connect(
-            self._on_selection_mode_changed
+            lambda index: self._on_selection_mode_changed(index)
         )
 
     def on_harmonic_changed(self):
@@ -405,7 +408,7 @@ class SelectionWidget(QWidget):
                 self._on_show_color_overlay
             )
         self.parent_widget.canvas_widget.show_color_overlay_signal.connect(
-            self._on_show_color_overlay
+            lambda visible: self._on_show_color_overlay(visible)
         )
 
     def _on_refresh_selection_clicked(self):
@@ -974,7 +977,7 @@ class AutomaticClusteringWidget(QWidget):
 
         # Apply clustering button
         self.apply_button = QPushButton("Apply Clustering")
-        self.apply_button.clicked.connect(self._apply_clustering)
+        self.apply_button.clicked.connect(lambda: self._apply_clustering())
         layout.addWidget(self.apply_button)
 
         # Table for clusters
@@ -1017,7 +1020,7 @@ class AutomaticClusteringWidget(QWidget):
         # Clear button
         self.clear_button = QPushButton("Clear Clusters")
         self.clear_button.setEnabled(False)
-        self.clear_button.clicked.connect(self._clear_clusters)
+        self.clear_button.clicked.connect(lambda: self._clear_clusters())
         layout.addWidget(self.clear_button)
 
         layout.addStretch()
@@ -1680,7 +1683,7 @@ class ColorButton(QPushButton):
         self._color = color or QColor(255, 0, 0)
         self.setFixedSize(25, 25)
         self._update_style()
-        self.clicked.connect(self._on_clicked)
+        self.clicked.connect(lambda: self._on_clicked())
 
     def _update_style(self):
         """Update the button style to show the current color."""
@@ -1784,11 +1787,13 @@ class CircularCursorWidget(QWidget):
         buttons_layout = QHBoxLayout()
 
         self.add_cursor_button = QPushButton("Add Cursor")
-        self.add_cursor_button.clicked.connect(self._add_cursor)
+        self.add_cursor_button.clicked.connect(lambda: self._add_cursor())
         buttons_layout.addWidget(self.add_cursor_button)
 
         self.clear_all_button = QPushButton("Clear All")
-        self.clear_all_button.clicked.connect(self._clear_all_cursors)
+        self.clear_all_button.clicked.connect(
+            lambda: self._clear_all_cursors()
+        )
         buttons_layout.addWidget(self.clear_all_button)
 
         layout.addLayout(buttons_layout)
@@ -1797,7 +1802,9 @@ class CircularCursorWidget(QWidget):
         calculate_layout = QHBoxLayout()
 
         self.calculate_button = QPushButton("Calculate")
-        self.calculate_button.clicked.connect(self._on_calculate_clicked)
+        self.calculate_button.clicked.connect(
+            lambda: self._on_calculate_clicked()
+        )
         calculate_layout.addWidget(self.calculate_button)
 
         self.autoupdate_checkbox = QWidget()
@@ -1806,7 +1813,9 @@ class CircularCursorWidget(QWidget):
         self.autoupdate_check = QToggleSwitch("Autoupdate")
         self.autoupdate_check.onColor = QColor("#27ae60")  # Nice Green
         self.autoupdate_check.setChecked(False)
-        self.autoupdate_check.toggled.connect(self._on_autoupdate_changed)
+        self.autoupdate_check.toggled.connect(
+            lambda val: self._on_autoupdate_changed(val)
+        )
         autoupdate_layout.addWidget(self.autoupdate_check)
         calculate_layout.addWidget(self.autoupdate_checkbox)
 
@@ -2765,11 +2774,13 @@ class PolarCursorWidget(QWidget):
         buttons_layout = QHBoxLayout()
 
         self.add_cursor_button = QPushButton("Add Cursor")
-        self.add_cursor_button.clicked.connect(self._add_cursor)
+        self.add_cursor_button.clicked.connect(lambda: self._add_cursor())
         buttons_layout.addWidget(self.add_cursor_button)
 
         self.clear_all_button = QPushButton("Clear All")
-        self.clear_all_button.clicked.connect(self._clear_all_cursors)
+        self.clear_all_button.clicked.connect(
+            lambda: self._clear_all_cursors()
+        )
         buttons_layout.addWidget(self.clear_all_button)
 
         layout.addLayout(buttons_layout)
@@ -2778,7 +2789,9 @@ class PolarCursorWidget(QWidget):
         calculate_layout = QHBoxLayout()
 
         self.calculate_button = QPushButton("Calculate")
-        self.calculate_button.clicked.connect(self._on_calculate_clicked)
+        self.calculate_button.clicked.connect(
+            lambda: self._on_calculate_clicked()
+        )
         calculate_layout.addWidget(self.calculate_button)
 
         self.autoupdate_checkbox = QWidget()
@@ -2787,7 +2800,9 @@ class PolarCursorWidget(QWidget):
         self.autoupdate_check = QToggleSwitch("Autoupdate")
         self.autoupdate_check.onColor = QColor("#27ae60")  # Nice Green
         self.autoupdate_check.setChecked(False)
-        self.autoupdate_check.toggled.connect(self._on_autoupdate_changed)
+        self.autoupdate_check.toggled.connect(
+            lambda val: self._on_autoupdate_changed(val)
+        )
         autoupdate_layout.addWidget(self.autoupdate_check)
         calculate_layout.addWidget(self.autoupdate_checkbox)
 
@@ -3631,11 +3646,13 @@ class EllipticalCursorWidget(QWidget):
         buttons_layout = QHBoxLayout()
 
         self.add_cursor_button = QPushButton("Add Cursor")
-        self.add_cursor_button.clicked.connect(self._add_cursor)
+        self.add_cursor_button.clicked.connect(lambda: self._add_cursor())
         buttons_layout.addWidget(self.add_cursor_button)
 
         self.clear_all_button = QPushButton("Clear All")
-        self.clear_all_button.clicked.connect(self._clear_all_cursors)
+        self.clear_all_button.clicked.connect(
+            lambda: self._clear_all_cursors()
+        )
         buttons_layout.addWidget(self.clear_all_button)
 
         layout.addLayout(buttons_layout)
@@ -3644,7 +3661,9 @@ class EllipticalCursorWidget(QWidget):
         calculate_layout = QHBoxLayout()
 
         self.calculate_button = QPushButton("Calculate")
-        self.calculate_button.clicked.connect(self._on_calculate_clicked)
+        self.calculate_button.clicked.connect(
+            lambda: self._on_calculate_clicked()
+        )
         calculate_layout.addWidget(self.calculate_button)
 
         self.autoupdate_checkbox = QWidget()
@@ -3653,7 +3672,9 @@ class EllipticalCursorWidget(QWidget):
         self.autoupdate_check = QToggleSwitch("Autoupdate")
         self.autoupdate_check.onColor = QColor("#27ae60")  # Nice Green
         self.autoupdate_check.setChecked(False)
-        self.autoupdate_check.toggled.connect(self._on_autoupdate_changed)
+        self.autoupdate_check.toggled.connect(
+            lambda val: self._on_autoupdate_changed(val)
+        )
         autoupdate_layout.addWidget(self.autoupdate_check)
         calculate_layout.addWidget(self.autoupdate_checkbox)
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ python =
 PLATFORM =
     ubuntu-latest: linux
     macos-latest: macos
+    macos-14: macos
+    macos-15: macos
     windows-latest: windows
 
 QT_BINDING =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{312, 313, 314}-{linux,macos,windows}
+envlist = py{312, 313, 314}-{linux,macos,windows}-{pyqt6,pyside6}
 isolated_build=true
 
 [gh-actions]
@@ -15,6 +15,10 @@ PLATFORM =
     macos-latest: macos
     windows-latest: windows
 
+QT_BINDING =
+    pyqt6: pyqt6
+    pyside6: pyside6
+
 [testenv]
 platform =
     macos: darwin
@@ -27,10 +31,13 @@ passenv =
     XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
+    QT_API
 extras =
     testing
 deps =
     setuptools
     tox
     tox-gh-actions
+    pyqt6: PyQt6
+    pyside6: PySide6
 commands = pytest -v --color=yes --cov=napari_phasors --cov-report=xml


### PR DESCRIPTION
This pull request updates the project to support both PyQt6 and PySide6 as Qt backends, removes the hard dependency on PyQt5, and ensures compatibility with the latest Matplotlib Qt backend changes. It also updates CI and test configurations to run against both PyQt6 and PySide6, and adjusts documentation to reflect these changes.

Closes #249 

**Qt Backend and Dependency Updates:**

* Removed hard dependencies on PyQt5 from `pyproject.toml`, `docs/requirements.txt`, and testing dependencies; now, the Qt binding (PyQt6 or PySide6) is provided by the environment or napari. (F7d9bcf7L41R41, [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L56) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R70) [[3]](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90L4)
* Updated all imports from `matplotlib.backends.backend_qt5agg` to `matplotlib.backends.backend_qtagg` for compatibility with newer Matplotlib and Qt versions. [[1]](diffhunk://#diff-a3bd65b73d7f6ec2a33a86407335ac391d4e5d7501118c158f5a616702a08c93L812-R812) [[2]](diffhunk://#diff-cde263035f355315f484281fdc350d6f58faa814e37d10e7939ff11f5aa33e63L5-R5) [[3]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L13-R13) [[4]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cL17-R17) [[5]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caL6-R6)

**Continuous Integration and Testing Improvements:**

* Modified GitHub Actions workflow (`.github/workflows/run-tests.yml`) and `tox.ini` to test across both PyQt6 and PySide6, and all supported Python versions and platforms. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L20-R26) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R61-R62) [[3]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L3-R3) [[4]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R18-R21) [[5]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R34-R42)
* Set `QT_API` and `QT_BINDING` environment variables in CI to ensure correct backend selection during tests. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R61-R62) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R18-R21)

**Documentation Updates:**

* Updated installation instructions in `README.md` and `docs/installation.md` to recommend PyQt6 or PySide6, and to clarify backend options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L6-R6) [[3]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L16-R16)

**Code Modernization:**

* Replaced deprecated `setSizePolicy` usage with the recommended `QSizePolicy.Expanding` and `QSizePolicy.Fixed` pattern for Qt widgets. [[1]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L1745-R1743) [[2]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cL377-R375) [[3]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caL189-R188) [[4]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caR18)

These changes modernize the codebase, improve compatibility with current and future Qt and Matplotlib versions, and ensure robust cross-backend testing.