### PR TITLE
Enhance PTU file handling by improving channel label management

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -376,8 +376,17 @@ def raw_file_reader(
     else:
         # Handle multi-channel files with iteration axis
         iter_axis_index = raw_data.dims.index(iter_axis)
-        for channel in range(raw_data.shape[iter_axis_index]):
-            channel_data = raw_data.sel(C=channel)
+        channel_coord = raw_data.coords.get(iter_axis)
+        if (
+            channel_coord is not None
+            and len(channel_coord) == raw_data.shape[iter_axis_index]
+        ):
+            channel_labels = list(channel_coord.values)
+        else:
+            channel_labels = list(range(raw_data.shape[iter_axis_index]))
+
+        for channel_pos, channel_label in enumerate(channel_labels):
+            channel_data = raw_data.isel({iter_axis: channel_pos})
             histogram_axis = channel_data.dims.index("H")
 
             # Calculate summed signal over spatial dimensions for this channel
@@ -394,7 +403,12 @@ def raw_file_reader(
 
             # Create settings dict for this channel
             channel_settings = settings.copy()
-            channel_settings['channel'] = channel
+            try:
+                channel_settings['channel'] = int(
+                    np.asarray(channel_label).item()
+                )
+            except (TypeError, ValueError):
+                channel_settings['channel'] = channel_label
 
             mean_intensity_image, G_image, S_image = phasor_from_signal(
                 channel_data,
@@ -402,7 +416,9 @@ def raw_file_reader(
                 harmonic=harmonics,
             )
             add_kwargs = {
-                "name": f"{filename} Intensity Image: Channel {channel}",
+                "name": (
+                    f"{filename} Intensity Image: Channel {channel_label}"
+                ),
                 "metadata": {
                     "original_mean": mean_intensity_image,
                     "settings": channel_settings,

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -2,6 +2,7 @@ import json
 
 import numpy as np
 import pytest
+import xarray as xr
 from phasorpy.datasets import fetch
 from phasorpy.io import (
     phasor_from_ometiff,
@@ -65,6 +66,49 @@ def test_reader_ptu():
     assert G_original.shape == (2, 256, 256)
     assert S_original.shape == (2, 256, 256)
     assert list(harmonics) == [1, 2]
+
+
+def test_reader_ptu_nonzero_channel_label(monkeypatch):
+    """PTU channel selection should not assume labels start at zero."""
+    data = xr.DataArray(
+        np.ones((2, 2, 1, 4), dtype=np.uint16),
+        dims=("Y", "X", "C", "H"),
+        coords={"Y": [0, 1], "X": [0, 1], "C": [3], "H": [0, 1, 2, 3]},
+    )
+
+    monkeypatch.setitem(
+        reader_module.extension_mapping["raw"],
+        ".ptu",
+        lambda path, reader_options: data,
+    )
+
+    layer_data_list = reader_module.raw_file_reader("example.ptu")
+
+    assert len(layer_data_list) == 1
+    assert layer_data_list[0][1]["name"].endswith("Channel 3")
+    assert layer_data_list[0][1]["metadata"]["settings"]["channel"] == 3
+
+
+@pytest.mark.parametrize("extension", [".ptu", ".fbd", ".json"])
+def test_raw_reader_nonzero_channel_label(monkeypatch, extension):
+    """Raw readers should use channel position, not channel label, for selection."""
+    data = xr.DataArray(
+        np.ones((2, 2, 1, 4), dtype=np.uint16),
+        dims=("Y", "X", "C", "H"),
+        coords={"Y": [0, 1], "X": [0, 1], "C": [3], "H": [0, 1, 2, 3]},
+    )
+
+    monkeypatch.setitem(
+        reader_module.extension_mapping["raw"],
+        extension,
+        lambda path, reader_options: data,
+    )
+
+    layer_data_list = reader_module.raw_file_reader(f"example{extension}")
+
+    assert len(layer_data_list) == 1
+    assert layer_data_list[0][1]["name"].endswith("Channel 3")
+    assert layer_data_list[0][1]["metadata"]["settings"]["channel"] == 3
 
 
 def test_reader_fbd():

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 from unittest.mock import patch
@@ -284,11 +285,12 @@ def test_phasor_transform_fbd_widget(make_napari_viewer):
     # TODO: test laser factor parameter
 
 
-def test_phasor_transform_ptu_widget(make_napari_viewer):
+def test_phasor_transform_ptu_widget(make_napari_viewer, caplog):
     """Test PtuWidget from PhasorTransfrom widget."""
     viewer = make_napari_viewer()
     PhasorTransform(viewer)
     test_file_path = get_test_file_path("test_file.ptu")
+    caplog.set_level(logging.ERROR, logger="ptufile")
     widget = PtuWidget(viewer, path=test_file_path)
     assert widget.viewer is viewer
     # Init values
@@ -327,6 +329,10 @@ def test_phasor_transform_ptu_widget(make_napari_viewer):
     assert widget.reader_options == {"frame": 0, "channel": None}
     # Click button of phasor transform and check layers
     widget.btn.click()
+    assert not any(
+        "tag with index not in tags" in record.message
+        for record in caplog.records
+    )
     assert len(viewer.layers) == 1
     assert viewer.layers[0].name == "test_file Intensity Image: Channel 0"
     assert viewer.layers[0].data.shape == (256, 256)

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -9,7 +9,9 @@ This module contains widgets to:
 
 import glob
 import json
+import logging
 import os
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
@@ -50,6 +52,19 @@ from ._utils import (
     natural_sort_key,
 )
 from ._writer import export_layer_as_csv, export_layer_as_image, write_ome_tiff
+
+
+@contextmanager
+def _silence_ptufile_logger():
+    """Temporarily suppress noisy ptufile diagnostics for PTU imports."""
+    logger = logging.getLogger("ptufile")
+    previous_level = logger.level
+    try:
+        logger.setLevel(logging.CRITICAL)
+        yield
+    finally:
+        logger.setLevel(previous_level)
+
 
 if TYPE_CHECKING:
     import napari
@@ -1216,6 +1231,7 @@ def _estimate_output_shape_from_options(
 ):
     """Estimate output shape with current reader options and harmonics."""
     try:
+        _, extension = _get_filename_extension(path)
         reader = napari_get_reader(
             path,
             reader_options=reader_options,
@@ -1224,7 +1240,11 @@ def _estimate_output_shape_from_options(
         if reader is None:
             return None
 
-        layers = reader(path)
+        if extension == ".ptu":
+            with _silence_ptufile_logger():
+                layers = reader(path)
+        else:
+            layers = reader(path)
         if not layers:
             return None
         base_shape = tuple(np.shape(layers[0][0]))
@@ -1328,9 +1348,10 @@ class PtuWidget(AdvancedOptionsWidget):
         """Initialize the widget."""
         import ptufile
 
-        with ptufile.PtuFile(path) as ptu:
-            self.all_frames = ptu.shape[0]
-            self.all_channels = ptu.shape[-2]
+        with _silence_ptufile_logger():
+            with ptufile.PtuFile(path) as ptu:
+                self.all_frames = ptu.shape[0]
+                self.all_channels = ptu.shape[-2]
 
         super().__init__(viewer, path)
         self.reader_options["frame"] = -1
@@ -1381,7 +1402,8 @@ class PtuWidget(AdvancedOptionsWidget):
             options["dtime"] = float(self.dtime.text())
 
         try:
-            signal = signal_from_ptu(self.path, **options)
+            with _silence_ptufile_logger():
+                signal = signal_from_ptu(self.path, **options)
             return signal
         except Exception as e:  # noqa: BLE001
             show_error(f"Error reading PTU signal: {str(e)}")
@@ -1401,7 +1423,8 @@ class PtuWidget(AdvancedOptionsWidget):
         """Callback whenever the calculate phasor button is clicked."""
         if self.dtime.text():
             reader_options["dtime"] = float(self.dtime.text())
-        super()._on_click(path, reader_options, harmonics)
+        with _silence_ptufile_logger():
+            super()._on_click(path, reader_options, harmonics)
 
 
 class LsmWidget(AdvancedOptionsWidget):


### PR DESCRIPTION
This pull request improves the robustness and user experience of channel handling in PTU and related raw data files, as well as suppresses noisy logging from the `ptufile` library during PTU file operations. The main changes ensure that channel labels are handled correctly even when they do not start at zero and that the UI and tests properly reflect these labels. Additionally, the code now silences unnecessary error logs from the `ptufile` logger to provide a cleaner user experience.

**Channel label handling improvements:**

* Updated `raw_file_reader` in `src/napari_phasors/_reader.py` to use actual channel labels from coordinates if available, instead of assuming channels start at zero. The channel label is now used in layer names and metadata, and is robust to non-integer and non-zero-based labels. [[1]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598L379-R389) [[2]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598L397-R421)
* Added new tests in `src/napari_phasors/_tests/test_reader.py` to verify correct handling of nonzero and non-integer channel labels in PTU and other raw file formats.

**Logging and diagnostics improvements:**

* Introduced a `_silence_ptufile_logger` context manager in `src/napari_phasors/_widget.py` to temporarily suppress noisy diagnostics from the `ptufile` logger during PTU file reading and processing. This is used throughout the widget code and in shape estimation to prevent unwanted log messages from surfacing to users. [[1]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR12-R14) [[2]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR56-R68) [[3]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR1234) [[4]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR1243-R1246) [[5]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR1351) [[6]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR1405) [[7]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR1426)

**Test improvements:**

* Modified the PTU widget test in `src/napari_phasors/_tests/test_widget.py` to use `caplog` and assert that no "tag with index not in tags" errors are logged, ensuring the widget does not trigger spurious errors with nonzero channel labels. [[1]](diffhunk://#diff-a918119f4b439f5937b77c15179af7e000ad425fec46a2f13d0821657e4f8f0eR2) [[2]](diffhunk://#diff-a918119f4b439f5937b77c15179af7e000ad425fec46a2f13d0821657e4f8f0eL287-R293) [[3]](diffhunk://#diff-a918119f4b439f5937b77c15179af7e000ad425fec46a2f13d0821657e4f8f0eR332-R335)