### PR TITLE
Fix histogram slider bug

### DIFF
--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -45,6 +45,7 @@ def test_components_widget_initialization_values(make_napari_viewer):
     assert comp_widget.components[1].s_edit is not None
     assert comp_widget.components[1].select_button is not None
     assert comp_widget.components[1].lifetime_edit is not None
+    assert comp_widget.histogram_widget.isVisible()
 
 
 def test_components_widget_lifetime_inputs_visibility_no_frequency(

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -11,6 +11,7 @@ def test_components_widget_initialization_values(make_napari_viewer):
     viewer = make_napari_viewer()
     parent = PlotterWidget(viewer)
     comp_widget = parent.components_tab
+    parent.tab_widget.setCurrentWidget(comp_widget)
 
     assert comp_widget.viewer is viewer
     assert comp_widget.parent_widget is parent
@@ -45,7 +46,7 @@ def test_components_widget_initialization_values(make_napari_viewer):
     assert comp_widget.components[1].s_edit is not None
     assert comp_widget.components[1].select_button is not None
     assert comp_widget.components[1].lifetime_edit is not None
-    assert comp_widget.histogram_widget.isVisible()
+    assert not comp_widget.histogram_widget.isHidden()
 
 
 def test_components_widget_lifetime_inputs_visibility_no_frequency(

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -1636,7 +1636,7 @@ def test_mesh_overlay_independent_from_apply_colormap_toggle(
 
     # Turning on apply-colormap should add the plot overlay without
     # removing mesh overlay.
-    mapping_widget.update_settings({"apply_colormap": True})
+    mapping_widget.apply_2d_colormap_checkbox.setChecked(True)
     assert mapping_widget._mesh_overlay_imshow is not None
     assert mapping_widget._overlay_imshow is not None
     assert not histogram_img.get_visible()

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -213,11 +213,12 @@ def test_phasor_mapping_widget_plot_histogram_no_data(make_napari_viewer):
     viewer = make_napari_viewer()
     parent = PlotterWidget(viewer)
     lifetime_widget = parent.phasor_mapping_tab
+    parent.tab_widget.setCurrentWidget(lifetime_widget)
 
     # No data should leave the histogram empty but VISIBLE with controls disabled.
     lifetime_widget.plot_lifetime_histogram()
     assert lifetime_widget.histogram_widget.counts is None
-    assert lifetime_widget.histogram_widget.isVisible()
+    assert not lifetime_widget.histogram_widget.isHidden()
     assert not lifetime_widget.histogram_widget._settings_button.isEnabled()
     assert not lifetime_widget.histogram_widget.save_png_button.isEnabled()
 
@@ -1635,7 +1636,7 @@ def test_mesh_overlay_independent_from_apply_colormap_toggle(
 
     # Turning on apply-colormap should add the plot overlay without
     # removing mesh overlay.
-    mapping_widget.apply_2d_colormap_checkbox.setChecked(True)
+    mapping_widget.update_settings({"apply_colormap": True})
     assert mapping_widget._mesh_overlay_imshow is not None
     assert mapping_widget._overlay_imshow is not None
     assert not histogram_img.get_visible()

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -214,9 +214,10 @@ def test_phasor_mapping_widget_plot_histogram_no_data(make_napari_viewer):
     parent = PlotterWidget(viewer)
     lifetime_widget = parent.phasor_mapping_tab
 
-    # No data should leave the histogram empty with controls disabled.
+    # No data should leave the histogram empty but VISIBLE with controls disabled.
     lifetime_widget.plot_lifetime_histogram()
     assert lifetime_widget.histogram_widget.counts is None
+    assert lifetime_widget.histogram_widget.isVisible()
     assert not lifetime_widget.histogram_widget._settings_button.isEnabled()
     assert not lifetime_widget.histogram_widget.save_png_button.isEnabled()
 

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -222,17 +222,18 @@ def test_phasor_center_statistics_widget_update(qtbot):
 
 def test_histogram_widget_respects_range_slider_limits(qtbot):
     """HistogramWidget axes should match the range slider even if data is outside."""
-    widget = HistogramWidget(range_slider_enabled=True)
+    # Use explicit range_factor for easy testing
+    widget = HistogramWidget(range_slider_enabled=True, range_factor=100)
     qtbot.addWidget(widget)
 
     # Data from 0 to 1
     data = np.array([0.1, 0.5, 0.9])
 
-    # Set range slider to 2 to 3 (outside data) - default factor 100
-    widget.range_slider.setValue((200, 300))
+    # Set range slider to 2 to 3 (outside data) using set_range helper
+    widget.set_range(2.0, 3.0)
     widget.update_data(data)
 
-    # X-axis should be 2 to 3
+    # X-axis should be exactly 2 to 3
     xlim = widget.ax.get_xlim()
     assert xlim[0] == 2.0
     assert xlim[1] == 3.0

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -230,7 +230,9 @@ def test_histogram_widget_respects_range_slider_limits(qtbot):
     data = np.array([0.1, 0.5, 0.9])
 
     # Set range slider to 2 to 3 (outside data) using set_range helper
-    widget.set_range(2.0, 3.0)
+    # We must also update the slider's absolute limits (slider_min/max)
+    # otherwise it will be clipped to the default 0-100 (which is 1.0 with factor 100)
+    widget.set_range(2.0, 3.0, slider_min=0.0, slider_max=5.0)
     widget.update_data(data)
 
     # X-axis should be exactly 2 to 3

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -218,3 +218,21 @@ def test_phasor_center_statistics_widget_update(qtbot):
     assert table.item(0, 2).text() == "0.400000"
     assert table.item(0, 3).text() == "45.0000"
     assert table.item(0, 4).text() == "0.707100"
+
+
+def test_histogram_widget_respects_range_slider_limits(qtbot):
+    """HistogramWidget axes should match the range slider even if data is outside."""
+    widget = HistogramWidget(range_slider_enabled=True)
+    qtbot.addWidget(widget)
+
+    # Data from 0 to 1
+    data = np.array([0.1, 0.5, 0.9])
+
+    # Set range slider to 2 to 3 (outside data) - default factor 100
+    widget.range_slider.setValue((200, 300))
+    widget.update_data(data)
+
+    # X-axis should be 2 to 3
+    xlim = widget.ax.get_xlim()
+    assert xlim[0] == 2.0
+    assert xlim[1] == 3.0

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2133,13 +2133,6 @@ class HistogramWidget(QWidget):
         if len(valid) == 0:
             self.ax.clear()
             self._style_axes()
-            self.ax.text(
-                0.5,
-                0.5,
-                "No valid data",
-                transform=self.ax.transAxes,
-                ha="center",
-            )
             self.fig.canvas.draw_idle()
             self._settings_button.setEnabled(False)
             self.save_png_button.setEnabled(False)
@@ -2152,7 +2145,10 @@ class HistogramWidget(QWidget):
         self._raw_valid_data = valid
         self._previous_dataset_count = 0
 
-        self.counts, self.bin_edges = np.histogram(valid, bins=self.bins)
+        hist_range = self.get_range() if self._range_slider_enabled else None
+        self.counts, self.bin_edges = np.histogram(
+            valid, bins=self.bins, range=hist_range
+        )
         self.bin_centers = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2
 
         self._counts_per_dataset = {"Layer": self.counts}
@@ -2186,13 +2182,6 @@ class HistogramWidget(QWidget):
         if not self._datasets:
             self.ax.clear()
             self._style_axes()
-            self.ax.text(
-                0.5,
-                0.5,
-                "No valid data",
-                transform=self.ax.transAxes,
-                ha="center",
-            )
             self.fig.canvas.draw_idle()
             self._settings_button.setEnabled(False)
             self.save_png_button.setEnabled(False)
@@ -2203,7 +2192,10 @@ class HistogramWidget(QWidget):
 
         all_valid = np.concatenate(list(self._datasets.values()))
         self._raw_valid_data = all_valid
-        self.counts, self.bin_edges = np.histogram(all_valid, bins=self.bins)
+        hist_range = self.get_range() if self._range_slider_enabled else None
+        self.counts, self.bin_edges = np.histogram(
+            all_valid, bins=self.bins, range=hist_range
+        )
         self.bin_centers = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2
 
         self._counts_per_dataset = {}
@@ -2329,6 +2321,14 @@ class HistogramWidget(QWidget):
             spine.set_linewidth(1)
         self.ax.set_ylabel(self.ylabel, fontsize=6, color=color)
         self.ax.set_xlabel(self.xlabel, fontsize=6, color=color)
+
+        if self._range_slider_enabled:
+            lo, hi = self.get_range()
+            self.ax.set_xlim(lo, hi)
+        elif self.bin_centers is not None and len(self.bin_centers) > 1:
+            self.ax.set_xlim(
+                float(self.bin_centers[0]), float(self.bin_centers[-1])
+            )
         for which in ("major", "minor"):
             self.ax.tick_params(
                 axis="x", which=which, labelsize=7, colors=color
@@ -2530,10 +2530,13 @@ class HistogramWidget(QWidget):
             y_max = y_min + 1
 
         n_pixels = 256
-        gradient_values = np.linspace(
-            float(x[0]), float(x[-1]), n_pixels
-        ).reshape(1, -1)
-        extent = [float(x[0]), float(x[-1]), y_min, y_max * 1.02]
+        lo, hi = (
+            self.get_range()
+            if self._range_slider_enabled
+            else (float(self.bin_centers[0]), float(self.bin_centers[-1]))
+        )
+        gradient_values = np.linspace(lo, hi, n_pixels).reshape(1, -1)
+        extent = [lo, hi, y_min, y_max * 1.02]
 
         im = self.ax.imshow(
             gradient_values,
@@ -2552,7 +2555,6 @@ class HistogramWidget(QWidget):
         clip_poly = MplPolygon(verts, closed=True, transform=self.ax.transData)
         im.set_clip_path(clip_poly)
 
-        self.ax.set_xlim(float(x[0]), float(x[-1]))
         self.ax.set_ylim(0, y_max * 1.05)
 
     def _draw_gradient_line(

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2423,10 +2423,9 @@ class HistogramWidget(QWidget):
             if bin_centers is None or bin_edges is None:
                 return float(np.mean(data))
             counts, _ = np.histogram(data, bins=bin_edges)
-            total = counts.sum()
-            if total == 0:
+            if counts.sum() == 0:
                 return None
-            return float(np.sum(bin_centers * counts) / total)
+            return float(np.average(bin_centers, weights=counts))
         return None
 
     def _draw_central_tendency_lines(self) -> None:

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -13,6 +13,7 @@ import scipy
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.collections import LineCollection
 from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.figure import Figure
 from matplotlib.legend_handler import HandlerBase
 from matplotlib.patches import Polygon as MplPolygon
 from napari.layers import Image
@@ -1757,9 +1758,8 @@ class HistogramWidget(QWidget):
             )
 
         # Matplotlib canvas
-        self.fig, self.ax = plt.subplots(
-            figsize=(8, 4), constrained_layout=True
-        )
+        self.fig = Figure(figsize=(8, 4), constrained_layout=True)
+        self.ax = self.fig.add_subplot(111)
         self._style_axes()
 
         canvas = FigureCanvas(self.fig)

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -4048,6 +4048,8 @@ class ComponentsWidget(QWidget):
             first_data = next(iter(clipped_data.values()))
             self.histogram_widget.update_data(first_data)
 
+        self.draw_line_between_components()
+
     def update_component_histogram(self):
         """Update the histogram with the fraction data of the selected component."""
         selected_text = self.histogram_component_combobox.currentText()

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -1,9 +1,9 @@
 import contextlib
 from math import ceil, log10
 
-import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
 from napari.utils.notifications import show_error
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
@@ -64,9 +64,9 @@ class FilterWidget(QWidget):
         self._phasors_selected_layer = None
         self.threshold_factor = 1
         self._histogram_data = None
-        self.hist_fig, self.hist_ax = plt.subplots(
-            figsize=(3.5, 1.5), constrained_layout=True
-        )
+        self.hist_fig = Figure(figsize=(3.5, 1.5), constrained_layout=True)
+        self.hist_ax = self.hist_fig.add_subplot(111)
+
         self.threshold_line_lower = None
         self.threshold_line_upper = None
         self.threshold_area_lower = None

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -240,6 +240,7 @@ class PhasorMappingWidget(QWidget):
         self._configure_histogram_labels_for_output(
             self.lifetime_type_combobox.currentText()
         )
+        self.histogram_widget.update_data(np.array([]))
 
         # Mesh Overlay Settings (at the end of the tab)
         self.mesh_overlay_group = QWidget()
@@ -1037,7 +1038,7 @@ class PhasorMappingWidget(QWidget):
                     self.mesh_alpha_spinbox.blockSignals(False)
                 self._sync_mode_widgets()
                 self._clear_2d_coloring()
-                self.histogram_widget.hide()
+                self.histogram_widget.update_data(np.array([]))
             finally:
                 self._updating_settings = False
             return
@@ -1114,7 +1115,7 @@ class PhasorMappingWidget(QWidget):
                     )
             elif frequency_text == "":
                 self.frequency = None
-                self.histogram_widget.hide()
+                self.histogram_widget.update_data(np.array([]))
 
     def _set_frequency_input_enabled(self, enabled: bool):
         self.frequency_input.setEnabled(enabled)
@@ -1387,14 +1388,12 @@ class PhasorMappingWidget(QWidget):
 
     def plot_lifetime_histogram(self):
         """Plot the histogram of the merged lifetime data from all selected layers."""
-        if self.current_metric_data is None:
-            self.histogram_widget.hide()
-            return
-        if not self.parent_widget.has_phasor_data():
-            self.histogram_widget.hide()
-            return
-        if self.parent_widget.harmonic is None:
-            self.histogram_widget.hide()
+        if (
+            self.current_metric_data is None
+            or not self.parent_widget.has_phasor_data()
+            or self.parent_widget.harmonic is None
+        ):
+            self.histogram_widget.update_data(np.array([]))
             return
 
         self.histogram_widget.update_colormap(
@@ -1555,8 +1554,8 @@ class PhasorMappingWidget(QWidget):
             self._clear_2d_coloring()
             # Don't auto-calculate - just restore UI state
             # User must click "Calculate" to run analysis
-            self.histogram_widget.hide()
         else:
+            self.histogram_widget.update_data(np.array([]))
             # Disconnect events from all lifetime layers
             for layer in self.metric_layers:
                 if layer in self.viewer.layers:
@@ -2149,6 +2148,9 @@ class PhasorMappingWidget(QWidget):
         if self._coloring_paused_by_tab:
             self._clear_2d_coloring()
             return
+
+        self.plot_lifetime_histogram()
+
         output_type = self._get_selected_output_type()
         if output_type in {"Phase", "Modulation"} and (
             self.apply_2d_colormap_checkbox.isChecked()


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the histogram widgets and related UI components in the napari-phasors plugin. The main focus is on ensuring histogram widgets remain visible (even when empty), that their axes respect the range slider limits, and on refactoring Matplotlib usage for better consistency and reliability. Additionally, test coverage is improved to verify these behaviors.

**Histogram Widget Behavior and UI Consistency:**

* Histogram widgets in both the Components and Phasor Mapping tabs are now always visible, even when there is no data to display. Instead of hiding the widget, the data is cleared, ensuring consistent UI and preventing issues when switching tabs or changing settings. [[1]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1040-R1041) [[2]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1117-R1118) [[3]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1390-R1396) [[4]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1558-R1558) [[5]](diffhunk://#diff-cde263035f355315f484281fdc350d6f58faa814e37d10e7939ff11f5aa33e63R216-R221) [[6]](diffhunk://#diff-df1d790b76075ad60325493133ba9517442831d41e73a5b6c2b438d3bdc5976dR14) [[7]](diffhunk://#diff-df1d790b76075ad60325493133ba9517442831d41e73a5b6c2b438d3bdc5976dR49)
* The histogram widget's axes now always match the range slider limits, even if the underlying data falls outside those limits. This ensures that the displayed histogram accurately reflects user-selected ranges. [[1]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R2324-R2331) [[2]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L2155-R2151) [[3]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L2206-R2198) [[4]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L2533-R2539) [[5]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L2555) [[6]](diffhunk://#diff-59fee090652bc67654dca105f1fb1b8de710c477038a85d8300c2efe158a4cf4R221-R238)

**Refactoring and Matplotlib Usage:**

* All Matplotlib figures and axes are now created using `matplotlib.figure.Figure` instead of `plt.subplots`, which is more robust in a Qt context and avoids backend issues. This change is applied across utility, filter, and tab files. [[1]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3R16) [[2]](diffhunk://#diff-4ab03c8ca7740b851a4bb28bb82d04309c96182f151b6bdd8558d2c72b463bf3L1760-R1762) [[3]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caL4-R6) [[4]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caL67-R69)

**Testing Improvements:**

* New and updated tests verify that histogram widgets remain visible when empty, that axes respect range slider limits, and that UI initialization is correct. [[1]](diffhunk://#diff-df1d790b76075ad60325493133ba9517442831d41e73a5b6c2b438d3bdc5976dR14) [[2]](diffhunk://#diff-df1d790b76075ad60325493133ba9517442831d41e73a5b6c2b438d3bdc5976dR49) [[3]](diffhunk://#diff-cde263035f355315f484281fdc350d6f58faa814e37d10e7939ff11f5aa33e63R216-R221) [[4]](diffhunk://#diff-59fee090652bc67654dca105f1fb1b8de710c477038a85d8300c2efe158a4cf4R221-R238)

**Bug Fixes and Minor Enhancements:**

* The histogram widget is now explicitly updated with empty data arrays in various lifecycle and event methods, preventing stale displays or UI inconsistencies. [[1]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1040-R1041) [[2]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1117-R1118) [[3]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1390-R1396) [[4]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1558-R1558) [[5]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79R2151-R2153) [[6]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79R243)
* When toggling 2D colormap overlays, the correct update method is now called to ensure overlays are managed independently.

These changes collectively improve the reliability, usability, and maintainability of histogram-related features in the plugin.