### PR TITLE
Fix phase range limits and mesh rendering

### DIFF
--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -144,6 +144,30 @@ def test_phasor_mapping_widget_histogram_styling(make_napari_viewer):
     assert lifetime_widget.histogram_widget.ax.get_xlabel() == "Lifetime (ns)"
 
 
+def test_mesh_alpha_map_is_cached_for_repeated_refreshes(make_napari_viewer):
+    """Test that the blurred mesh alpha map is reused for identical mesh state."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    lifetime_widget = parent.phasor_mapping_tab
+
+    mesh_mask = np.array([[False, True], [True, False]])
+    alpha_key = (1, 2, 3, 4, True, 320, 0, 628, 0, 100, False)
+    blurred_base = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=float)
+
+    with patch(
+        'napari_phasors.phasor_mapping_tab.gaussian_filter',
+        return_value=blurred_base,
+    ) as mock_filter:
+        first = lifetime_widget._get_mesh_alpha_map(mesh_mask, alpha_key, 0.5)
+        second = lifetime_widget._get_mesh_alpha_map(
+            mesh_mask, alpha_key, 0.25
+        )
+
+    assert mock_filter.call_count == 1
+    np.testing.assert_allclose(first, blurred_base * 0.5)
+    np.testing.assert_allclose(second, blurred_base * 0.25)
+
+
 def test_phasor_mapping_widget_frequency_input_validation(make_napari_viewer):
     """Test frequency input validation."""
     viewer = make_napari_viewer()

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -3,6 +3,7 @@ import warnings
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 from biaplotter.plotter import CanvasWidget
 from napari.layers import Image
 from qtpy.QtWidgets import (
@@ -41,6 +42,8 @@ def create_image_layer_with_phasors(harmonic=None):
 
 def test_nap_plot_tools_safe_disconnect_patch_is_applied_and_idempotent():
     """The runtime patch should be installed once and remain safe to re-run."""
+    pytest.importorskip("nap_plot_tools")
+
     from nap_plot_tools.tools import CustomToolbarWidget
 
     from napari_phasors import plotter as plotter_module
@@ -66,6 +69,8 @@ def test_nap_plot_tools_safe_disconnect_rewires_callbacks_without_warning(
     qtbot,
 ):
     """Rewiring toolbar callbacks should not emit Qt disconnect RuntimeWarning."""
+    pytest.importorskip("nap_plot_tools")
+
     from nap_plot_tools.tools import CustomToolbarWidget
 
     toolbar = CustomToolbarWidget()
@@ -132,6 +137,27 @@ def test_nap_plot_tools_safe_disconnect_rewires_callbacks_without_warning(
         and 'toggled(bool)' in str(w.message)
     ]
     assert not disconnect_warnings
+
+
+def test_biaplotter_toggle_callback_handles_missing_sender(
+    make_napari_viewer,
+):
+    """Pan/zoom toggles emitted via non-Qt signals must not rely on sender()."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    canvas = plotter.canvas_widget
+
+    canvas.toolbar.mode = 'pan/zoom'
+
+    with (
+        patch.object(
+            canvas, '_deactivate_and_remove_all_selectors'
+        ) as mock_deactivate,
+        patch.object(CanvasWidget, 'sender', return_value=None),
+    ):
+        canvas._on_toggle_button(True)
+
+    mock_deactivate.assert_called_once()
 
 
 def test_phasor_plotter_initialization_values(make_napari_viewer):

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1,4 +1,5 @@
 import contextlib
+import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -36,6 +37,101 @@ def create_image_layer_with_phasors(harmonic=None):
     raw_flim_data = make_raw_flim_data(time_constants=time_constants)
     harmonic = harmonic
     return make_intensity_layer_with_phasors(raw_flim_data, harmonic=harmonic)
+
+
+def test_nap_plot_tools_safe_disconnect_patch_is_applied_and_idempotent():
+    """The runtime patch should be installed once and remain safe to re-run."""
+    from nap_plot_tools.tools import CustomToolbarWidget
+
+    from napari_phasors import plotter as plotter_module
+
+    assert getattr(
+        CustomToolbarWidget,
+        '_napari_phasors_safe_disconnect_patch',
+        False,
+    )
+
+    # Reapplying should be a no-op (idempotent guard path).
+    plotter_module._patch_nap_plot_tools_safe_disconnect()
+    plotter_module._patch_nap_plot_tools_safe_disconnect()
+
+    assert getattr(
+        CustomToolbarWidget,
+        '_napari_phasors_safe_disconnect_patch',
+        False,
+    )
+
+
+def test_nap_plot_tools_safe_disconnect_rewires_callbacks_without_warning(
+    qtbot,
+):
+    """Rewiring toolbar callbacks should not emit Qt disconnect RuntimeWarning."""
+    from nap_plot_tools.tools import CustomToolbarWidget
+
+    toolbar = CustomToolbarWidget()
+    qtbot.addWidget(toolbar)
+
+    toggle_calls = []
+    click_calls = []
+
+    def toggle_cb_1(checked):
+        toggle_calls.append(('toggle_cb_1', bool(checked)))
+
+    def toggle_cb_2(checked):
+        toggle_calls.append(('toggle_cb_2', bool(checked)))
+
+    def click_cb_1():
+        click_calls.append('click_cb_1')
+
+    def click_cb_2():
+        click_calls.append('click_cb_2')
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+
+        # Checkable path (toggled signal).
+        toolbar.add_custom_button(
+            name='SEL',
+            default_icon_path='dummy_default.png',
+            checked_icon_path='dummy_checked.png',
+            callback=toggle_cb_1,
+        )
+        toolbar.buttons['SEL'].setChecked(True)
+        toolbar.connect_button_callback('SEL', toggle_cb_2)
+        toolbar.buttons['SEL'].setChecked(False)
+        toolbar.connect_button_callback('SEL', None)
+        toolbar.buttons['SEL'].setChecked(True)
+
+        # Non-checkable path (clicked signal).
+        toolbar.add_custom_button(
+            name='ACT',
+            default_icon_path='dummy_action.png',
+            callback=click_cb_1,
+        )
+        toolbar.buttons['ACT'].click()
+        toolbar.connect_button_callback('ACT', click_cb_2)
+        toolbar.buttons['ACT'].click()
+        toolbar.connect_button_callback('ACT', None)
+        toolbar.buttons['ACT'].click()
+
+        # Unknown button name should be safely ignored.
+        toolbar.connect_button_callback('MISSING', toggle_cb_1)
+
+    assert ('toggle_cb_1', True) in toggle_calls
+    assert ('toggle_cb_2', False) in toggle_calls
+    assert all(name != 'toggle_cb_1' for name, _ in toggle_calls[1:])
+
+    assert click_calls[:2] == ['click_cb_1', 'click_cb_2']
+    assert click_calls.count('click_cb_1') == 1
+    assert click_calls.count('click_cb_2') == 1
+
+    disconnect_warnings = [
+        w
+        for w in caught
+        if 'Failed to disconnect' in str(w.message)
+        and 'toggled(bool)' in str(w.message)
+    ]
+    assert not disconnect_warnings
 
 
 def test_phasor_plotter_initialization_values(make_napari_viewer):

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from scipy.ndimage import gaussian_filter
 from scipy.stats import binned_statistic_2d
 from superqt import QRangeSlider, QToggleSwitch
 
@@ -556,7 +557,7 @@ class PhasorMappingWidget(QWidget):
         return True
 
     def _phase_max_allowed(self) -> float:
-        return (np.pi / 2.0) if self._is_semicircle_mode() else (2.0 * np.pi)
+        return 2.0 * np.pi
 
     def _update_phase_slider_bounds_from_plot_mode(self):
         max_phase = self._phase_max_allowed()
@@ -1769,9 +1770,9 @@ class PhasorMappingWidget(QWidget):
     def _get_mesh_grid_resolution(self, ax) -> int:
         with contextlib.suppress(Exception):
             bbox = ax.get_window_extent()
-            target = int(max(float(bbox.width), float(bbox.height)) * 0.6)
-            return int(np.clip(target, 160, 400))
-        return 280
+            target = int(max(float(bbox.width), float(bbox.height)) * 1.2)
+            return int(np.clip(target, 320, 900))
+        return 480
 
     def _make_mesh_grid_cache_key(self, ax, resolution: int):
         x_min, x_max = ax.get_xlim()
@@ -1920,8 +1921,15 @@ class PhasorMappingWidget(QWidget):
                     mesh_mask |= is_outside_semi
 
             stat_display = p_grid if output_type == "Phase" else m_grid
-            stat_display = np.where(mesh_mask, np.nan, stat_display)
+            stat_display = np.ma.array(stat_display, mask=mesh_mask)
             extent = mesh_grid['extent']
+            mesh_cmap = cmap.copy()
+            mesh_cmap.set_bad((0, 0, 0, 0))
+            mesh_alpha = float(self.mesh_alpha_spinbox.value())
+            mesh_alpha_map = gaussian_filter(
+                (~mesh_mask).astype(float), sigma=1.2, mode="nearest"
+            )
+            mesh_alpha_map = np.clip(mesh_alpha_map, 0.0, 1.0) * mesh_alpha
 
             self._remove_mesh_overlay()
 
@@ -1929,12 +1937,13 @@ class PhasorMappingWidget(QWidget):
                 stat_display,
                 extent=extent,
                 origin="lower",
-                cmap=cmap,
+                cmap=mesh_cmap,
                 vmin=vmin,
                 vmax=vmax,
-                interpolation="bilinear",
+                interpolation="lanczos",
+                interpolation_stage="rgba",
                 zorder=0.1,  # Behind all phasor artists
-                alpha=float(self.mesh_alpha_spinbox.value()),
+                alpha=mesh_alpha_map,
                 aspect="auto",
             )
             ax.set_aspect(1, adjustable="box")

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -105,6 +105,9 @@ class PhasorMappingWidget(QWidget):
         self._mesh_grid_cache = {}
         self._mesh_grid_cache_order = []
         self._mesh_grid_cache_max_entries = 8
+        self._mesh_alpha_cache = {}
+        self._mesh_alpha_cache_order = []
+        self._mesh_alpha_cache_max_entries = 8
 
         # Create scroll area
         scroll_area = QScrollArea()
@@ -1771,7 +1774,7 @@ class PhasorMappingWidget(QWidget):
         with contextlib.suppress(Exception):
             bbox = ax.get_window_extent()
             target = int(max(float(bbox.width), float(bbox.height)) * 1.2)
-            return int(np.clip(target, 320, 900))
+            return int(np.clip(target, 320, 640))
         return 480
 
     def _make_mesh_grid_cache_key(self, ax, resolution: int):
@@ -1825,6 +1828,30 @@ class PhasorMappingWidget(QWidget):
             self._mesh_grid_cache.pop(stale_key, None)
 
         return grid
+
+    def _get_mesh_alpha_map(self, mesh_mask, alpha_key, mesh_alpha: float):
+        cached = self._mesh_alpha_cache.get(alpha_key)
+        if cached is not None:
+            with contextlib.suppress(ValueError):
+                self._mesh_alpha_cache_order.remove(alpha_key)
+            self._mesh_alpha_cache_order.append(alpha_key)
+            return cached * mesh_alpha
+
+        alpha_base = gaussian_filter(
+            (~mesh_mask).astype(float), sigma=1.2, mode="nearest"
+        )
+        alpha_base = np.clip(alpha_base, 0.0, 1.0)
+        self._mesh_alpha_cache[alpha_key] = alpha_base
+        self._mesh_alpha_cache_order.append(alpha_key)
+
+        while (
+            len(self._mesh_alpha_cache_order)
+            > self._mesh_alpha_cache_max_entries
+        ):
+            stale_key = self._mesh_alpha_cache_order.pop(0)
+            self._mesh_alpha_cache.pop(stale_key, None)
+
+        return alpha_base * mesh_alpha
 
     def _get_clim_from_metric_layers(self):
         for layer in self.metric_layers:
@@ -1926,26 +1953,44 @@ class PhasorMappingWidget(QWidget):
             mesh_cmap = cmap.copy()
             mesh_cmap.set_bad((0, 0, 0, 0))
             mesh_alpha = float(self.mesh_alpha_spinbox.value())
-            mesh_alpha_map = gaussian_filter(
-                (~mesh_mask).astype(float), sigma=1.2, mode="nearest"
+            alpha_key = (
+                *self._make_mesh_grid_cache_key(ax, resolution),
+                int(phase_min_i),
+                int(phase_max_i),
+                int(mod_min_i),
+                int(mod_max_i),
+                bool(self.mesh_clip_semicircle_checkbox.isChecked()),
             )
-            mesh_alpha_map = np.clip(mesh_alpha_map, 0.0, 1.0) * mesh_alpha
+            mesh_alpha_map = self._get_mesh_alpha_map(
+                mesh_mask,
+                alpha_key,
+                mesh_alpha,
+            )
 
             self._remove_mesh_overlay()
 
-            self._mesh_overlay_imshow = ax.imshow(
-                stat_display,
-                extent=extent,
-                origin="lower",
-                cmap=mesh_cmap,
-                vmin=vmin,
-                vmax=vmax,
-                interpolation="lanczos",
-                interpolation_stage="rgba",
-                zorder=0.1,  # Behind all phasor artists
-                alpha=mesh_alpha_map,
-                aspect="auto",
-            )
+            mesh_imshow_kwargs = {
+                "extent": extent,
+                "origin": "lower",
+                "cmap": mesh_cmap,
+                "vmin": vmin,
+                "vmax": vmax,
+                "interpolation": "lanczos",
+                "zorder": 0.1,  # Behind all phasor artists
+                "alpha": mesh_alpha_map,
+                "aspect": "auto",
+            }
+            try:
+                self._mesh_overlay_imshow = ax.imshow(
+                    stat_display,
+                    interpolation_stage="rgba",
+                    **mesh_imshow_kwargs,
+                )
+            except TypeError:
+                self._mesh_overlay_imshow = ax.imshow(
+                    stat_display,
+                    **mesh_imshow_kwargs,
+                )
             ax.set_aspect(1, adjustable="box")
             pw.canvas_widget.figure.canvas.draw_idle()
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -133,7 +133,10 @@ def _patch_biaplotter_safe_toggle_sender():
 
     def _on_toggle_button_safe(self, checked: bool):
         sender_obj = self.sender()
-        sender_name = None if sender_obj is None else sender_obj.text()
+        sender_name = None
+        if sender_obj is not None:
+            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                sender_name = sender_obj.text()
 
         # Non-Qt emitters (psygnal) can call this with sender=None.
         # Preserve expected behavior for toolbar pan/zoom toggles.

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -65,6 +65,60 @@ from .phasor_mapping_tab import PhasorMappingWidget
 from .selection_tab import SelectionWidget
 
 
+def _patch_nap_plot_tools_safe_disconnect():
+    """Patch nap_plot_tools toolbar callback wiring to avoid warning spam.
+
+    nap_plot_tools currently calls ``button.toggled.disconnect()`` for
+    checkable buttons. Under PySide/Qt this can emit a RuntimeWarning when no
+    callback is connected. We patch it to disconnect only the previously
+    connected callback we track locally.
+    """
+    try:
+        from nap_plot_tools.tools import CustomToolbarWidget
+    except ImportError:
+        return
+
+    if getattr(
+        CustomToolbarWidget, "_napari_phasors_safe_disconnect_patch", False
+    ):
+        return
+
+    def _connect_button_callback_safe(self, name, callback):
+        if name not in self.buttons:
+            return
+
+        button = self.buttons[name]
+        signal = button.toggled if button.isCheckable() else button.clicked
+
+        connected = getattr(self, "_napari_phasors_connected_callbacks", {})
+        previous = connected.get(name)
+        if previous is not None:
+            with contextlib.suppress(TypeError, RuntimeError):
+                signal.disconnect(previous)
+
+        if callback:
+            if button.isCheckable():
+                to_connect = callback
+            else:
+
+                def _clicked_callback(checked=False, cb=callback):
+                    cb()
+
+                to_connect = _clicked_callback
+            signal.connect(to_connect)
+            connected[name] = to_connect
+        else:
+            connected.pop(name, None)
+
+        self._napari_phasors_connected_callbacks = connected
+
+    CustomToolbarWidget.connect_button_callback = _connect_button_callback_safe
+    CustomToolbarWidget._napari_phasors_safe_disconnect_patch = True
+
+
+_patch_nap_plot_tools_safe_disconnect()
+
+
 class MaskAssignmentDialog(QDialog):
     """Dialog to assign a mask layer to each selected image layer.
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -116,7 +116,40 @@ def _patch_nap_plot_tools_safe_disconnect():
     CustomToolbarWidget._napari_phasors_safe_disconnect_patch = True
 
 
+def _patch_biaplotter_safe_toggle_sender():
+    """Patch biaplotter toggle callback to tolerate missing Qt sender.
+
+    biaplotter wires ``pan_toggled_signal`` and ``zoom_toggled_signal``
+    (non-Qt signals) to ``CanvasWidget._on_toggle_button``. In that path,
+    ``self.sender()`` can be ``None``, which raises an AttributeError when the
+    callback unconditionally accesses ``.text()``.
+    """
+    if getattr(
+        CanvasWidget, "_napari_phasors_safe_toggle_sender_patch", False
+    ):
+        return
+
+    original = CanvasWidget._on_toggle_button
+
+    def _on_toggle_button_safe(self, checked: bool):
+        sender_obj = self.sender()
+        sender_name = None if sender_obj is None else sender_obj.text()
+
+        # Non-Qt emitters (psygnal) can call this with sender=None.
+        # Preserve expected behavior for toolbar pan/zoom toggles.
+        if sender_name is None:
+            if checked and self.toolbar.mode in {'pan/zoom', 'zoom rect'}:
+                self._deactivate_and_remove_all_selectors()
+            return
+
+        return original(self, checked)
+
+    CanvasWidget._on_toggle_button = _on_toggle_button_safe
+    CanvasWidget._napari_phasors_safe_toggle_sender_patch = True
+
+
 _patch_nap_plot_tools_safe_disconnect()
+_patch_biaplotter_safe_toggle_sender()
 
 
 class MaskAssignmentDialog(QDialog):

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -2869,7 +2869,7 @@ class PolarCursorWidget(QWidget):
 
         # Phase Min spinbox
         phase_min_spinbox = QDoubleSpinBox()
-        phase_min_spinbox.setRange(-180.0, 180.0)
+        phase_min_spinbox.setRange(-360.0, 360.0)
         phase_min_spinbox.setSingleStep(1.0)
         phase_min_spinbox.setDecimals(1)
         phase_min_spinbox.setValue(phase_min)
@@ -2880,7 +2880,7 @@ class PolarCursorWidget(QWidget):
 
         # Phase Max spinbox
         phase_max_spinbox = QDoubleSpinBox()
-        phase_max_spinbox.setRange(-180.0, 180.0)
+        phase_max_spinbox.setRange(-360.0, 360.0)
         phase_max_spinbox.setSingleStep(1.0)
         phase_max_spinbox.setDecimals(1)
         phase_max_spinbox.setValue(phase_max)
@@ -3130,7 +3130,7 @@ class PolarCursorWidget(QWidget):
 
                 # Phase Min spinbox
                 phase_min_spinbox = QDoubleSpinBox()
-                phase_min_spinbox.setRange(-180.0, 180.0)
+                phase_min_spinbox.setRange(-360.0, 360.0)
                 phase_min_spinbox.setSingleStep(1.0)
                 phase_min_spinbox.setDecimals(1)
                 phase_min_spinbox.setValue(cursor['phase_min'])
@@ -3143,7 +3143,7 @@ class PolarCursorWidget(QWidget):
 
                 # Phase Max spinbox
                 phase_max_spinbox = QDoubleSpinBox()
-                phase_max_spinbox.setRange(-180.0, 180.0)
+                phase_max_spinbox.setRange(-360.0, 360.0)
                 phase_max_spinbox.setSingleStep(1.0)
                 phase_max_spinbox.setDecimals(1)
                 phase_max_spinbox.setValue(cursor['phase_max'])


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the napari-phasors plugin, focusing on enhancing the mesh overlay rendering, improving toolbar callback handling to avoid Qt warnings, and expanding the valid range for phase selection in the UI. The changes also include new tests to ensure the robustness of the toolbar patch and callback behavior.

Fixes #263 

**Rendering and Visualization Improvements:**

* The mesh overlay rendering in the phasor mapping tab now uses masked arrays for more accurate handling of invalid regions, applies a transparent colormap for masked areas, uses a higher-quality interpolation method (`lanczos`), and dynamically adjusts alpha transparency with a Gaussian blur for smoother edges. The mesh grid resolution is also increased for higher fidelity. [[1]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1923-R1946) [[2]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79L1772-R1775)

**Toolbar Callback Handling and Testing:**

* Introduced a runtime patch (`_patch_nap_plot_tools_safe_disconnect`) to the `CustomToolbarWidget` in `nap_plot_tools` to prevent RuntimeWarnings when disconnecting callbacks from toolbar buttons. This patch ensures disconnects only affect previously connected callbacks and is idempotent to avoid repeated patching.
* Added comprehensive tests to verify the patch is applied only once and that rewiring toolbar callbacks does not emit Qt disconnect warnings, even when callbacks are changed or removed repeatedly.

**User Interface Range Expansion:**

* Expanded the allowed range for phase selection spinboxes in the selection tab from ±180° to ±360°, both during cursor addition and when harmonics are changed, allowing users to select a broader phase range. [[1]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL2872-R2872) [[2]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL2883-R2883) [[3]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL3133-R3133) [[4]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL3146-R3146)

**Other Notable Changes:**

* The maximum allowed phase value in the phasor mapping tab is now consistently set to 2π, regardless of semicircle mode, simplifying the logic for phase bounds.
* Minor import and dependency adjustments, such as adding `gaussian_filter` from `scipy.ndimage` where needed.

These updates collectively improve the reliability, usability, and visual quality of the napari-phasors plugin.