### PR TITLE
Fix log scale toggle persistence for histogram in FilterWidget

### DIFF
--- a/src/napari_phasors/_tests/test_filter_tab.py
+++ b/src/napari_phasors/_tests/test_filter_tab.py
@@ -833,6 +833,32 @@ def test_log_scale_checkbox_functionality(make_napari_viewer):
     assert filter_widget.hist_ax.get_yscale() == 'linear'
 
 
+def test_log_scale_persists_after_new_layer_redraw(make_napari_viewer):
+    """Test that histogram redraws keep the current log scale setting."""
+    viewer = make_napari_viewer()
+    first_layer = create_image_layer_with_phasors()
+    viewer.add_layer(first_layer)
+    parent = PlotterWidget(viewer)
+    filter_widget = parent.filter_tab
+
+    filter_tab_index = parent.tab_widget.indexOf(filter_widget)
+    parent.tab_widget.setCurrentIndex(filter_tab_index)
+
+    filter_widget.plot_mean_histogram()
+    filter_widget.log_scale_checkbox.setChecked(True)
+    filter_widget.on_log_scale_changed(2)  # Qt.Checked = 2
+
+    second_layer = create_image_layer_with_phasors()
+    viewer.add_layer(second_layer)
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(
+        second_layer.name
+    )
+    filter_widget._on_image_layer_changed()
+
+    assert filter_widget.log_scale_checkbox.isChecked()
+    assert filter_widget.hist_ax.get_yscale() == 'log'
+
+
 def test_log_scale_checkbox_with_no_layer(make_napari_viewer):
     """Test log scale checkbox when no layer is selected."""
     viewer = make_napari_viewer()

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -718,6 +718,13 @@ class FilterWidget(QWidget):
             axis='y', which='minor', labelsize=7, colors='grey'
         )
 
+    def _apply_histogram_scale(self):
+        """Apply the histogram y-axis scale based on the toggle state."""
+        if self.log_scale_checkbox.isChecked():
+            self.hist_ax.set_yscale('log')
+        else:
+            self.hist_ax.set_yscale('linear')
+
     def plot_mean_histogram(self):
         """Plot the histogram of the mean intensity data from all selected layers."""
         selected_layers = self.parent_widget.get_selected_layers()
@@ -756,6 +763,7 @@ class FilterWidget(QWidget):
             merged_mean_data, bins=100, color='white', edgecolor='white'
         )
         self.style_histogram_axes()
+        self._apply_histogram_scale()
 
         self.update_threshold_lines()
         self.hist_fig.canvas.draw_idle()
@@ -882,13 +890,8 @@ class FilterWidget(QWidget):
                 edgecolor='white',
             )
 
-            # Set scale before styling to ensure proper tick formatting
-            if checked:
-                self.hist_ax.set_yscale('log')
-            else:
-                self.hist_ax.set_yscale('linear')
-
             self.style_histogram_axes()
+            self._apply_histogram_scale()
             self.update_threshold_lines()
             self.hist_fig.canvas.draw_idle()
 


### PR DESCRIPTION
This pull request improves the handling and persistence of the histogram y-axis log scale setting in the filter tab of the napari phasors plugin. The main changes include refactoring the logic for applying the histogram scale, ensuring the log scale setting persists after layer changes and redraws, and adding a test to validate this behavior.

Fixes #258 

**Histogram scale handling improvements:**

* Added a private method `_apply_histogram_scale` to centralize and simplify the logic for setting the histogram y-axis scale based on the state of the `log_scale_checkbox` (`src/napari_phasors/filter_tab.py`).
* Updated both `plot_mean_histogram` and `on_log_scale_changed` to use the new `_apply_histogram_scale` method, ensuring consistent application of the y-axis scale during redraws and log scale toggling (`src/napari_phasors/filter_tab.py`) [[1]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caR766) [[2]](diffhunk://#diff-caf7bf9073910396e094d5a3b1e57afc76c834735c131f527b98d8ac0f9889caL885-R894).

**Testing improvements:**

* Added a new test `test_log_scale_persists_after_new_layer_redraw` to verify that the log scale setting persists after adding a new layer and redrawing the histogram (`src/napari_phasors/_tests/test_filter_tab.py`).