### PR TITLE
feat: add mask inversion toggle

### DIFF
--- a/docs/guides/mask.md
+++ b/docs/guides/mask.md
@@ -36,6 +36,20 @@ When you use the cursor selection tools (circular, polar, elliptical) in the **S
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/mask%20cursor.mp4" type="video/mp4">
 </video>
 
+## Inverting a mask
+
+You can invert a mask so that pixels **outside** the drawn region are included in the analysis instead of those **inside**. This is useful when you want to exclude a specific region rather than select it.
+
+1. Select a mask layer (Labels or Shapes) in the **Phasor Plot** widget.
+2. Check the **Invert** checkbox next to the mask layer dropdown.
+3. The mask is now inverted: labeled pixels are excluded and unlabeled pixels are included.
+
+When using the **Assign Masks** dialog (for multiple image layers), each layer has its own **Invert** checkbox, allowing independent inversion per layer.
+
+## NaN-aware mask painting
+
+When painting a labels layer to use as a mask, pixels that have no intensity data (NaN values) are automatically excluded. This means the paint bucket tool will not label background pixels that lack signal data, ensuring only meaningful regions are included in the mask.
+
 ## Assigning masks to image layers
 
 - You can assign a mask to a single image layer, restricting phasor analysis to that region only.

--- a/docs/guides/mask.md
+++ b/docs/guides/mask.md
@@ -46,10 +46,6 @@ You can invert a mask so that pixels **outside** the drawn region are included i
 
 When using the **Assign Masks** dialog (for multiple image layers), each layer has its own **Invert** checkbox, allowing independent inversion per layer.
 
-## NaN-aware mask painting
-
-When painting a labels layer to use as a mask, pixels that have no intensity data (NaN values) are automatically excluded. This means the paint bucket tool will not label background pixels that lack signal data, ensuring only meaningful regions are included in the mask.
-
 ## Assigning masks to image layers
 
 - You can assign a mask to a single image layer, restricting phasor analysis to that region only.

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -7,6 +7,7 @@ import pytest
 from biaplotter.plotter import CanvasWidget
 from napari.layers import Image
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QLabel,
     QPushButton,
@@ -24,6 +25,7 @@ from napari_phasors.components_tab import ComponentsWidget
 from napari_phasors.filter_tab import FilterWidget
 from napari_phasors.fret_tab import FretWidget
 from napari_phasors.plotter import (
+    MaskAssignmentDialog,
     PhasorCenterLayerSettingsDialog,
     PlotterWidget,
 )
@@ -2781,3 +2783,284 @@ def test_phasor_center_grouped_median_uses_pooled_samples(make_napari_viewer):
     assert not np.allclose(pooled_center, arithmetic_mean, atol=1e-6)
 
     plotter.deleteLater()
+
+
+# ------------------------------------------------------------------ #
+#  Tests for Issue #257: Mask inversion & NaN-aware mask painting     #
+# ------------------------------------------------------------------ #
+
+
+def _make_mask_shape(layer):
+    """Get the spatial shape for creating a mask from a layer."""
+    G = layer.metadata["G"]
+    return G.shape[1:] if G.ndim == 3 else G.shape
+
+
+# --- Feature 1: Invert Mask (single-layer mode) ---
+
+
+def test_invert_mask_checkbox_exists_and_default(make_napari_viewer):
+    """Test that the invert mask checkbox exists and is unchecked."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    assert hasattr(plotter, 'mask_invert_checkbox')
+    assert isinstance(plotter.mask_invert_checkbox, QCheckBox)
+    assert not plotter.mask_invert_checkbox.isChecked()
+
+
+def test_invert_mask_checkbox_disabled_when_no_mask(
+    make_napari_viewer,
+):
+    """Test that invert checkbox is disabled when mask is 'None'."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    assert not plotter.mask_invert_checkbox.isEnabled()
+
+
+def test_invert_mask_checkbox_enabled_when_mask_selected(
+    make_napari_viewer,
+):
+    """Test invert checkbox enables when a mask layer is selected."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    shape = _make_mask_shape(layer)
+    mask_data = np.ones(shape, dtype=int)
+    viewer.add_labels(mask_data, name="test_mask")
+
+    plotter.mask_layer_combobox.setCurrentText("test_mask")
+
+    assert plotter.mask_invert_checkbox.isEnabled()
+
+
+def test_invert_mask_applies_inverted_logic(make_napari_viewer):
+    """Test that invert param applies mask with inverted logic."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    shape = _make_mask_shape(layer)
+    # Mask bottom half (label=1), top half (label=0)
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[shape[0] // 2 :, :] = 1
+    labels_layer = viewer.add_labels(mask_data, name="test_mask")
+
+    # Normal mask: top half -> NaN, bottom half -> kept
+    plotter._apply_mask_to_phasor_data(labels_layer, layer, invert=False)
+    g = layer.metadata["G"]
+    g_2d = g[0] if g.ndim == 3 else g
+    assert np.isnan(g_2d[: shape[0] // 2, :]).all()
+    assert not np.isnan(g_2d[shape[0] // 2 :, :]).all()
+
+    # Restore and apply inverted mask: bottom half -> NaN,
+    # top half -> kept
+    plotter._restore_original_phasor_data(layer)
+    plotter._apply_mask_to_phasor_data(labels_layer, layer, invert=True)
+    g_inv = layer.metadata["G"]
+    g_inv_2d = g_inv[0] if g_inv.ndim == 3 else g_inv
+    assert not np.isnan(g_inv_2d[: shape[0] // 2, :]).all()
+    assert np.isnan(g_inv_2d[shape[0] // 2 :, :]).all()
+
+
+def test_invert_mask_resets_on_none(make_napari_viewer):
+    """Test that invert checkbox resets when mask is set to None."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    shape = _make_mask_shape(layer)
+    mask_data = np.ones(shape, dtype=int)
+    viewer.add_labels(mask_data, name="test_mask")
+
+    # Select mask, enable invert
+    plotter.mask_layer_combobox.setCurrentText("test_mask")
+    plotter.mask_invert_checkbox.setChecked(True)
+    assert plotter.mask_invert_checkbox.isChecked()
+
+    # Set mask to None - invert should reset
+    plotter.mask_layer_combobox.setCurrentText("None")
+    assert not plotter.mask_invert_checkbox.isChecked()
+    assert not plotter.mask_invert_checkbox.isEnabled()
+
+
+def test_invert_mask_empty_mask_keeps_all_pixels(
+    make_napari_viewer,
+):
+    """Test invert with empty mask (all zeros): all pixels kept."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    original_g = layer.metadata["G"].copy()
+    shape = _make_mask_shape(layer)
+    mask_data = np.zeros(shape, dtype=int)
+    labels_layer = viewer.add_labels(mask_data, name="empty_mask")
+
+    # Inverted empty mask should keep all pixels
+    plotter._apply_mask_to_phasor_data(labels_layer, layer, invert=True)
+    np.testing.assert_array_equal(
+        np.isnan(layer.metadata["G"]),
+        np.isnan(original_g),
+    )
+
+
+# --- Feature 1: Invert Mask (multi-layer mode) ---
+
+
+def test_mask_assignment_dialog_has_invert_option(
+    make_napari_viewer,
+):
+    """Test MaskAssignmentDialog includes invert option."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+
+    shape = _make_mask_shape(layer1)
+    viewer.add_labels(np.ones(shape, dtype=int), name="mask1")
+
+    dialog = MaskAssignmentDialog(
+        image_layer_names=[layer1.name, layer2.name],
+        mask_layer_names=["mask1"],
+        current_assignments={},
+    )
+
+    # Dialog should support invert assignments
+    invert_assignments = dialog.get_invert_assignments()
+    assert isinstance(invert_assignments, dict)
+    for name in [layer1.name, layer2.name]:
+        assert name in invert_assignments
+        assert invert_assignments[name] is False
+
+
+def test_apply_mask_assignments_with_invert(make_napari_viewer):
+    """Test per-layer invert via _apply_mask_assignments."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+    plotter = PlotterWidget(viewer)
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer1.name, layer2.name]
+    )
+
+    shape = _make_mask_shape(layer1)
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[shape[0] // 2 :, :] = 1
+    viewer.add_labels(mask_data, name="half_mask")
+
+    # Apply same mask, invert only layer2
+    assignments = {
+        layer1.name: "half_mask",
+        layer2.name: "half_mask",
+    }
+    invert_assignments = {
+        layer1.name: False,
+        layer2.name: True,
+    }
+    plotter._apply_mask_assignments(
+        assignments, invert_assignments=invert_assignments
+    )
+
+    # layer1: normal mask — top half NaN
+    g1 = layer1.metadata["G"]
+    g1_2d = g1[0] if g1.ndim == 3 else g1
+    assert np.isnan(g1_2d[: shape[0] // 2, :]).all()
+
+    # layer2: inverted mask — bottom half NaN
+    g2 = layer2.metadata["G"]
+    g2_2d = g2[0] if g2.ndim == 3 else g2
+    assert np.isnan(g2_2d[shape[0] // 2 :, :]).all()
+
+
+# --- Feature 2: NaN-aware mask painting ---
+
+
+def test_nan_pixels_cleared_after_mask_paint(make_napari_viewer):
+    """Test labels on NaN-intensity pixels cleared after paint."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    # Set first row to NaN in original data
+    layer.metadata['original_mean'] = layer.data.copy()
+    layer.data[0, :] = np.nan
+    layer.metadata['original_mean'][0, :] = np.nan
+
+    shape = _make_mask_shape(layer)
+    mask_data = np.ones(shape, dtype=int)
+    labels_layer = viewer.add_labels(mask_data, name="paint_mask")
+
+    plotter.mask_layer_combobox.setCurrentText("paint_mask")
+
+    # Simulate paint event
+    labels_layer.data[:] = 1
+    event = type('Event', (), {'source': labels_layer})()
+    plotter._on_mask_data_changed(event)
+
+    # NaN pixels (first row) should have labels cleared
+    assert np.all(labels_layer.data[0, :] == 0)
+    # Non-NaN pixels should retain labels
+    assert np.all(labels_layer.data[1:, :] == 1)
+
+
+def test_nan_pixel_clearing_no_infinite_recursion(
+    make_napari_viewer,
+):
+    """Test NaN clearing does not trigger infinite recursion."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    shape = _make_mask_shape(layer)
+    mask_data = np.ones(shape, dtype=int)
+    labels_layer = viewer.add_labels(mask_data, name="paint_mask")
+
+    plotter.mask_layer_combobox.setCurrentText("paint_mask")
+
+    # Call multiple times — should not recurse
+    event = type('Event', (), {'source': labels_layer})()
+    for _ in range(5):
+        plotter._on_mask_data_changed(event)
+
+
+def test_nan_pixel_clearing_uses_original_data(
+    make_napari_viewer,
+):
+    """Test NaN clearing uses original data, not masked data."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    # Set only first row as originally NaN
+    original_data = layer.data.copy()
+    original_data[0, :] = np.nan
+    layer.metadata['original_mean'] = original_data.copy()
+    layer.data = original_data.copy()
+
+    shape = _make_mask_shape(layer)
+    mask_data = np.ones(shape, dtype=int)
+    labels_layer = viewer.add_labels(mask_data, name="paint_mask")
+
+    plotter.mask_layer_combobox.setCurrentText("paint_mask")
+
+    # Simulate mask making row 1 NaN too (not original)
+    layer.data[1, :] = np.nan
+
+    # Only original NaN (row 0) should be cleared
+    plotter._clear_labels_on_nan_pixels(labels_layer, layer)
+    assert np.all(labels_layer.data[0, :] == 0)
+    assert np.all(labels_layer.data[1, :] == 1)

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1,6 +1,6 @@
 import contextlib
 import warnings
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -3204,3 +3204,90 @@ def test_on_mask_data_changed_multi_layer_no_affected(
     # Should return early — no masks applied
     assert "mask" not in layer1.metadata
     assert "mask" not in layer2.metadata
+
+
+def test_clear_labels_on_nan_skips_non_labels(
+    make_napari_viewer,
+):
+    """Test _clear_labels_on_nan_pixels skips non-Labels layers."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    shape = _make_mask_shape(layer)
+    rect = np.array(
+        [[0, 0], [0, shape[1]], [shape[0], shape[1]], [shape[0], 0]]
+    )
+    shapes_layer = viewer.add_shapes(
+        [rect], shape_type="polygon", name="shape_mask"
+    )
+
+    # Should return early without error
+    plotter._clear_labels_on_nan_pixels(shapes_layer, layer)
+
+
+def test_clear_labels_on_nan_uses_current_data_fallback(
+    make_napari_viewer,
+):
+    """Test _clear_labels_on_nan_pixels uses image data when
+    original_mean is absent."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    # Remove original_mean so the fallback is used
+    layer.metadata.pop("original_mean", None)
+
+    # Set first row to NaN directly in current data
+    layer.data[0, :] = np.nan
+
+    shape = _make_mask_shape(layer)
+    labels_layer = viewer.add_labels(np.ones(shape, dtype=int), name="mask")
+
+    plotter._clear_labels_on_nan_pixels(labels_layer, layer)
+
+    # First row NaN pixels should have labels cleared
+    assert np.all(labels_layer.data[0, :] == 0)
+    assert np.all(labels_layer.data[1:, :] == 1)
+
+
+def test_open_mask_assignment_dialog_applies_invert(
+    make_napari_viewer,
+):
+    """Test _open_mask_assignment_dialog passes invert state."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+    plotter = PlotterWidget(viewer)
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer1.name, layer2.name]
+    )
+
+    shape = _make_mask_shape(layer1)
+    viewer.add_labels(np.ones(shape, dtype=int), name="mask1")
+
+    # Mock dialog to simulate user accepting with invert
+    mock_dialog = MagicMock()
+    mock_dialog.exec.return_value = 1  # QDialog.Accepted
+    mock_dialog.get_assignments.return_value = {
+        layer1.name: "mask1",
+        layer2.name: "None",
+    }
+    mock_dialog.get_invert_assignments.return_value = {
+        layer1.name: True,
+        layer2.name: False,
+    }
+
+    with patch(
+        "napari_phasors.plotter.MaskAssignmentDialog",
+        return_value=mock_dialog,
+    ):
+        plotter._open_mask_assignment_dialog()
+
+    # layer1 should have inverted mask applied
+    assert plotter._mask_invert_assignments.get(layer1.name, False)

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -3064,3 +3064,143 @@ def test_nan_pixel_clearing_uses_original_data(
     plotter._clear_labels_on_nan_pixels(labels_layer, layer)
     assert np.all(labels_layer.data[0, :] == 0)
     assert np.all(labels_layer.data[1, :] == 1)
+
+
+# --- Coverage gap tests for issue #257 ---
+
+
+def test_mask_assignment_dialog_fallback_to_none(
+    make_napari_viewer,
+):
+    """Test dialog sets 'None' when current assignment is invalid."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    shape = _make_mask_shape(layer)
+    viewer.add_labels(np.ones(shape, dtype=int), name="mask1")
+
+    # Pass an assignment that references a non-existent mask
+    dialog = MaskAssignmentDialog(
+        image_layer_names=[layer.name],
+        mask_layer_names=["mask1"],
+        current_assignments={layer.name: "deleted_mask"},
+    )
+
+    assignments = dialog.get_assignments()
+    assert assignments[layer.name] == "None"
+
+
+def test_apply_mask_shapes_layer(make_napari_viewer):
+    """Test _apply_mask_to_phasor_data with a Shapes layer."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    shape = _make_mask_shape(layer)
+    # Create a shapes layer with a rectangle covering the image
+    rect = np.array(
+        [[0, 0], [0, shape[1]], [shape[0], shape[1]], [shape[0], 0]]
+    )
+    shapes_layer = viewer.add_shapes(
+        [rect], shape_type="polygon", name="shape_mask"
+    )
+
+    plotter._apply_mask_to_phasor_data(shapes_layer, layer)
+
+    assert "mask" in layer.metadata
+
+
+def test_apply_mask_non_invert_empty_labels_returns(
+    make_napari_viewer,
+):
+    """Test non-invert empty Labels mask early returns."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+
+    original_g = layer.metadata["G"].copy()
+    shape = _make_mask_shape(layer)
+    empty_labels = viewer.add_labels(np.zeros(shape, dtype=int), name="empty")
+
+    # Non-invert + empty mask should early return (no changes)
+    plotter._apply_mask_to_phasor_data(empty_labels, layer, invert=False)
+    np.testing.assert_array_equal(layer.metadata["G"], original_g)
+    assert "mask" not in layer.metadata
+
+
+def test_on_mask_data_changed_no_selected_layers(
+    make_napari_viewer,
+):
+    """Test _on_mask_data_changed returns early with no layers."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+
+    shape = (5, 5)
+    labels_layer = viewer.add_labels(np.ones(shape, dtype=int), name="mask")
+
+    # No image layers selected — should return early
+    event = type("Event", (), {"source": labels_layer})()
+    plotter._on_mask_data_changed(event)
+
+
+def test_on_mask_data_changed_multi_layer_branch(
+    make_napari_viewer,
+):
+    """Test _on_mask_data_changed multi-layer path."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+    plotter = PlotterWidget(viewer)
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer1.name, layer2.name]
+    )
+
+    shape = _make_mask_shape(layer1)
+    mask_data = np.ones(shape, dtype=int)
+    labels_layer = viewer.add_labels(mask_data, name="shared_mask")
+
+    # Assign mask only to layer1
+    plotter._mask_assignments = {layer1.name: "shared_mask"}
+
+    # Trigger mask data change — should only affect layer1
+    event = type("Event", (), {"source": labels_layer})()
+    plotter._on_mask_data_changed(event)
+
+    assert "mask" in layer1.metadata
+
+
+def test_on_mask_data_changed_multi_layer_no_affected(
+    make_napari_viewer,
+):
+    """Test _on_mask_data_changed multi-layer with no affected."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+    plotter = PlotterWidget(viewer)
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer1.name, layer2.name]
+    )
+
+    shape = _make_mask_shape(layer1)
+    labels_layer = viewer.add_labels(
+        np.ones(shape, dtype=int), name="unassigned_mask"
+    )
+
+    # No layer has this mask assigned
+    plotter._mask_assignments = {}
+
+    event = type("Event", (), {"source": labels_layer})()
+    plotter._on_mask_data_changed(event)
+
+    # Should return early — no masks applied
+    assert "mask" not in layer1.metadata
+    assert "mask" not in layer2.metadata

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -2786,7 +2786,7 @@ def test_phasor_center_grouped_median_uses_pooled_samples(make_napari_viewer):
 
 
 # ------------------------------------------------------------------ #
-#  Tests for Issue #257: Mask inversion & NaN-aware mask painting     #
+#  Tests for Issue #257: Mask inversion                              #
 # ------------------------------------------------------------------ #
 
 
@@ -2983,87 +2983,7 @@ def test_apply_mask_assignments_with_invert(make_napari_viewer):
     assert np.isnan(g2_2d[shape[0] // 2 :, :]).all()
 
 
-# --- Feature 2: NaN-aware mask painting ---
-
-
-def test_nan_pixels_cleared_after_mask_paint(make_napari_viewer):
-    """Test labels on NaN-intensity pixels cleared after paint."""
-    viewer = make_napari_viewer()
-    layer = create_image_layer_with_phasors()
-    viewer.add_layer(layer)
-    plotter = PlotterWidget(viewer)
-
-    # Set first row to NaN in original data
-    layer.metadata['original_mean'] = layer.data.copy()
-    layer.data[0, :] = np.nan
-    layer.metadata['original_mean'][0, :] = np.nan
-
-    shape = _make_mask_shape(layer)
-    mask_data = np.ones(shape, dtype=int)
-    labels_layer = viewer.add_labels(mask_data, name="paint_mask")
-
-    plotter.mask_layer_combobox.setCurrentText("paint_mask")
-
-    # Simulate paint event
-    labels_layer.data[:] = 1
-    event = type('Event', (), {'source': labels_layer})()
-    plotter._on_mask_data_changed(event)
-
-    # NaN pixels (first row) should have labels cleared
-    assert np.all(labels_layer.data[0, :] == 0)
-    # Non-NaN pixels should retain labels
-    assert np.all(labels_layer.data[1:, :] == 1)
-
-
-def test_nan_pixel_clearing_no_infinite_recursion(
-    make_napari_viewer,
-):
-    """Test NaN clearing does not trigger infinite recursion."""
-    viewer = make_napari_viewer()
-    layer = create_image_layer_with_phasors()
-    viewer.add_layer(layer)
-    plotter = PlotterWidget(viewer)
-
-    shape = _make_mask_shape(layer)
-    mask_data = np.ones(shape, dtype=int)
-    labels_layer = viewer.add_labels(mask_data, name="paint_mask")
-
-    plotter.mask_layer_combobox.setCurrentText("paint_mask")
-
-    # Call multiple times — should not recurse
-    event = type('Event', (), {'source': labels_layer})()
-    for _ in range(5):
-        plotter._on_mask_data_changed(event)
-
-
-def test_nan_pixel_clearing_uses_original_data(
-    make_napari_viewer,
-):
-    """Test NaN clearing uses original data, not masked data."""
-    viewer = make_napari_viewer()
-    layer = create_image_layer_with_phasors()
-    viewer.add_layer(layer)
-    plotter = PlotterWidget(viewer)
-
-    # Set only first row as originally NaN
-    original_data = layer.data.copy()
-    original_data[0, :] = np.nan
-    layer.metadata['original_mean'] = original_data.copy()
-    layer.data = original_data.copy()
-
-    shape = _make_mask_shape(layer)
-    mask_data = np.ones(shape, dtype=int)
-    labels_layer = viewer.add_labels(mask_data, name="paint_mask")
-
-    plotter.mask_layer_combobox.setCurrentText("paint_mask")
-
-    # Simulate mask making row 1 NaN too (not original)
-    layer.data[1, :] = np.nan
-
-    # Only original NaN (row 0) should be cleared
-    plotter._clear_labels_on_nan_pixels(labels_layer, layer)
-    assert np.all(labels_layer.data[0, :] == 0)
-    assert np.all(labels_layer.data[1, :] == 1)
+# --- NaN-aware mask painting removed (moved to a follow-up PR per #257) ---
 
 
 # --- Coverage gap tests for issue #257 ---
@@ -3204,53 +3124,6 @@ def test_on_mask_data_changed_multi_layer_no_affected(
     # Should return early — no masks applied
     assert "mask" not in layer1.metadata
     assert "mask" not in layer2.metadata
-
-
-def test_clear_labels_on_nan_skips_non_labels(
-    make_napari_viewer,
-):
-    """Test _clear_labels_on_nan_pixels skips non-Labels layers."""
-    viewer = make_napari_viewer()
-    layer = create_image_layer_with_phasors()
-    viewer.add_layer(layer)
-    plotter = PlotterWidget(viewer)
-
-    shape = _make_mask_shape(layer)
-    rect = np.array(
-        [[0, 0], [0, shape[1]], [shape[0], shape[1]], [shape[0], 0]]
-    )
-    shapes_layer = viewer.add_shapes(
-        [rect], shape_type="polygon", name="shape_mask"
-    )
-
-    # Should return early without error
-    plotter._clear_labels_on_nan_pixels(shapes_layer, layer)
-
-
-def test_clear_labels_on_nan_uses_current_data_fallback(
-    make_napari_viewer,
-):
-    """Test _clear_labels_on_nan_pixels uses image data when
-    original_mean is absent."""
-    viewer = make_napari_viewer()
-    layer = create_image_layer_with_phasors()
-    viewer.add_layer(layer)
-    plotter = PlotterWidget(viewer)
-
-    # Remove original_mean so the fallback is used
-    layer.metadata.pop("original_mean", None)
-
-    # Set first row to NaN directly in current data
-    layer.data[0, :] = np.nan
-
-    shape = _make_mask_shape(layer)
-    labels_layer = viewer.add_labels(np.ones(shape, dtype=int), name="mask")
-
-    plotter._clear_labels_on_nan_pixels(labels_layer, layer)
-
-    # First row NaN pixels should have labels cleared
-    assert np.all(labels_layer.data[0, :] == 0)
-    assert np.all(labels_layer.data[1:, :] == 1)
 
 
 def test_open_mask_assignment_dialog_applies_invert(

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -3480,7 +3480,6 @@ def test_on_mask_data_changed_multi_layer_no_assignments_returns(
     plotter.deleteLater()
 
 
-
 def _make_mask_shape(layer):
     """Get the spatial shape for creating a mask from a layer."""
     G = layer.metadata["G"]

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -22,6 +22,7 @@ from qtpy import uic
 from qtpy.QtCore import QEvent, Qt, QTimer
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QDialog,
     QDialogButtonBox,
@@ -166,6 +167,8 @@ class MaskAssignmentDialog(QDialog):
         Names of available mask layers (Labels/Shapes).
     current_assignments : dict, optional
         Current mapping of image layer name -> mask layer name.
+    current_invert_assignments : dict, optional
+        Current mapping of image layer name -> bool (invert).
     parent : QWidget, optional
         Parent widget.
     """
@@ -175,6 +178,7 @@ class MaskAssignmentDialog(QDialog):
         image_layer_names,
         mask_layer_names,
         current_assignments=None,
+        current_invert_assignments=None,
         parent=None,
     ):
         super().__init__(parent)
@@ -183,6 +187,8 @@ class MaskAssignmentDialog(QDialog):
 
         if current_assignments is None:
             current_assignments = {}
+        if current_invert_assignments is None:
+            current_invert_assignments = {}
 
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Assign a mask layer to each image layer:"))
@@ -195,9 +201,14 @@ class MaskAssignmentDialog(QDialog):
         form_layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
 
         self._combos = {}  # image_layer_name -> QComboBox
+        self._invert_checks = {}  # image_layer_name -> QCheckBox
         mask_options = ["None"] + list(mask_layer_names)
 
         for name in image_layer_names:
+            row_widget = QWidget()
+            row_layout = QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+
             combo = QComboBox()
             combo.addItems(mask_options)
             current = current_assignments.get(name, "None")
@@ -206,7 +217,22 @@ class MaskAssignmentDialog(QDialog):
             else:
                 combo.setCurrentText("None")
             self._combos[name] = combo
-            form_layout.addRow(QLabel(name), combo)
+            row_layout.addWidget(combo, 1)
+
+            invert_check = QCheckBox("Invert")
+            invert_check.setChecked(
+                current_invert_assignments.get(name, False)
+            )
+            invert_check.setEnabled(current != "None")
+            self._invert_checks[name] = invert_check
+            row_layout.addWidget(invert_check)
+
+            # Enable/disable invert when mask changes
+            combo.currentTextChanged.connect(
+                lambda text, cb=invert_check: cb.setEnabled(text != "None")
+            )
+
+            form_layout.addRow(QLabel(name), row_widget)
 
         scroll.setWidget(form_widget)
         layout.addWidget(scroll)
@@ -231,7 +257,7 @@ class MaskAssignmentDialog(QDialog):
         layout.addWidget(button_box)
 
     def _on_apply_all_changed(self, text):
-        """Automatically set all per-layer combos when a mask is selected."""
+        """Auto-set all per-layer combos when a mask is selected."""
         self._apply_to_all()
 
     def _apply_to_all(self):
@@ -250,6 +276,18 @@ class MaskAssignmentDialog(QDialog):
         """
         return {
             name: combo.currentText() for name, combo in self._combos.items()
+        }
+
+    def get_invert_assignments(self):
+        """Return the invert assignments as a dict.
+
+        Returns
+        -------
+        dict
+            Mapping of image layer name -> bool (invert flag).
+        """
+        return {
+            name: cb.isChecked() for name, cb in self._invert_checks.items()
         }
 
 
@@ -1400,17 +1438,30 @@ class PlotterWidget(QWidget):
 
         # Per-layer mask assignments: {image_layer_name: mask_layer_name}
         self._mask_assignments = {}
+        # Per-layer invert state: {image_layer_name: bool}
+        self._mask_invert_assignments = {}
 
         # Mask label and combobox (shown when 0-1 layers selected)
         self.mask_layer_label = QLabel("Mask Layer:")
         harmonics_and_mask_container.addWidget(self.mask_layer_label)
         self.mask_layer_combobox = QComboBox()
         self.mask_layer_combobox.setToolTip(
-            "Create or select a Labels or Shapes layer with a mask to restrict analysis to specific regions. "
+            "Create or select a Labels or Shapes layer with a "
+            "mask to restrict analysis to specific regions. "
             "Selecting 'None' will disable masking."
         )
         self.mask_layer_combobox.addItem("None")
         harmonics_and_mask_container.addWidget(self.mask_layer_combobox, 1)
+
+        # Invert mask checkbox (next to combobox)
+        self.mask_invert_checkbox = QCheckBox("Invert")
+        self.mask_invert_checkbox.setToolTip(
+            "Invert the mask: exclude pixels inside the mask "
+            "instead of those outside."
+        )
+        self.mask_invert_checkbox.setEnabled(False)
+        self.mask_invert_checkbox.toggled.connect(self._on_mask_invert_changed)
+        harmonics_and_mask_container.addWidget(self.mask_invert_checkbox)
 
         # Mask assign button (shown when >1 layers selected)
         self.mask_assign_button = QPushButton("Assign Masks...")
@@ -5021,6 +5072,11 @@ class PlotterWidget(QWidget):
                 for k, v in self._mask_assignments.items()
                 if k in current_selected and v in mask_layer_names
             }
+            self._mask_invert_assignments = {
+                k: v
+                for k, v in self._mask_invert_assignments.items()
+                if k in self._mask_assignments
+            }
 
             self.image_layers_checkable_combobox.blockSignals(False)
             self.mask_layer_combobox.blockSignals(False)
@@ -5158,9 +5214,12 @@ class PlotterWidget(QWidget):
 
             # Reset masks
             self._mask_assignments.clear()
+            self._mask_invert_assignments.clear()
             self.mask_layer_combobox.blockSignals(True)
             self.mask_layer_combobox.setCurrentText("None")
             self.mask_layer_combobox.blockSignals(False)
+            self.mask_invert_checkbox.setChecked(False)
+            self.mask_invert_checkbox.setEnabled(False)
             self._update_mask_ui_mode()
             self._update_contour_controls_visibility()
 
@@ -5258,9 +5317,12 @@ class PlotterWidget(QWidget):
 
             # Reset masks
             self._mask_assignments.clear()
+            self._mask_invert_assignments.clear()
             self.mask_layer_combobox.blockSignals(True)
             self.mask_layer_combobox.setCurrentText("None")
             self.mask_layer_combobox.blockSignals(False)
+            self.mask_invert_checkbox.setChecked(False)
+            self.mask_invert_checkbox.setEnabled(False)
             self._update_mask_ui_mode()
             self._update_contour_controls_visibility()
 
@@ -5421,8 +5483,10 @@ class PlotterWidget(QWidget):
         image_layer.metadata['S'] = image_layer.metadata['S_original']
         image_layer.data = image_layer.metadata["original_mean"].copy()
 
-    def _apply_mask_to_phasor_data(self, mask_layer, image_layer):
-        """Apply mask to phasor data by setting G and S values outside mask to NaN.
+    def _apply_mask_to_phasor_data(
+        self, mask_layer, image_layer, invert=False
+    ):
+        """Apply mask to phasor data by setting values outside mask to NaN.
 
         Parameters
         ----------
@@ -5430,19 +5494,26 @@ class PlotterWidget(QWidget):
             The mask layer to apply.
         image_layer : napari.layers.Image
             The image layer to store mask metadata.
+        invert : bool
+            If True, invert the mask so pixels inside the mask
+            are excluded instead of those outside.
         """
         if isinstance(mask_layer, Shapes) and len(mask_layer.data) > 0:
             mask_data = mask_layer.to_labels(
                 labels_shape=image_layer.data.shape
             )
-        elif isinstance(mask_layer, Labels) and mask_layer.data.any():
+        elif isinstance(mask_layer, Labels):
+            if not invert and not mask_layer.data.any():
+                return
             mask_data = mask_layer.data
         else:
             return
 
         image_layer.metadata['mask'] = mask_data.copy()
+        image_layer.metadata['mask_invert'] = invert
 
-        mask_invalid = mask_data <= 0
+        mask_invalid = mask_data > 0 if invert else mask_data <= 0
+
         image_layer.data = np.where(mask_invalid, np.nan, image_layer.data)
 
         g_array = image_layer.metadata['G']
@@ -5466,19 +5537,34 @@ class PlotterWidget(QWidget):
         if not selected_layers:
             return
 
-        # In single-layer mode, apply the same mask to all selected layers
-        # and update the assignments dict accordingly
+        # Update invert checkbox state
+        if text == "None":
+            self.mask_invert_checkbox.setChecked(False)
+            self.mask_invert_checkbox.setEnabled(False)
+        else:
+            self.mask_invert_checkbox.setEnabled(True)
+
+        invert = self.mask_invert_checkbox.isChecked()
+
+        # In single-layer mode, apply the same mask to all selected
+        # layers and update the assignments dict accordingly
         for image_layer in selected_layers:
             self._restore_original_phasor_data(image_layer)
 
             if text == "None":
                 if 'mask' in image_layer.metadata:
                     del image_layer.metadata['mask']
+                if 'mask_invert' in image_layer.metadata:
+                    del image_layer.metadata['mask_invert']
                 self._mask_assignments.pop(image_layer.name, None)
+                self._mask_invert_assignments.pop(image_layer.name, None)
             else:
                 mask_layer = self.viewer.layers[text]
-                self._apply_mask_to_phasor_data(mask_layer, image_layer)
+                self._apply_mask_to_phasor_data(
+                    mask_layer, image_layer, invert=invert
+                )
                 self._mask_assignments[image_layer.name] = text
+                self._mask_invert_assignments[image_layer.name] = invert
 
         if hasattr(self, 'filter_tab'):
             self.filter_tab._on_image_layer_changed()
@@ -5495,21 +5581,27 @@ class PlotterWidget(QWidget):
 
     def _on_mask_data_changed(self, event):
         """Handle changes to the mask layer data."""
+        if getattr(self, '_in_mask_update', False):
+            return
+        self._in_mask_update = True
+        try:
+            self._on_mask_data_changed_inner(event)
+        finally:
+            self._in_mask_update = False
+
+    def _on_mask_data_changed_inner(self, event):
+        """Inner handler for mask data changes."""
         mask_name = event.source.name
 
-        # Check if this mask is relevant: either the combobox selection
-        # (single-layer mode) or any per-layer assignment (multi-layer mode)
         selected_layers = self.get_selected_layers()
         if not selected_layers:
             return
 
         if len(selected_layers) <= 1:
-            # Single-layer mode: use combobox
             if self.mask_layer_combobox.currentText() != mask_name:
                 return
             affected_layers = selected_layers
         else:
-            # Multi-layer mode: only affect layers assigned to this mask
             affected_layers = [
                 layer
                 for layer in selected_layers
@@ -5520,9 +5612,16 @@ class PlotterWidget(QWidget):
 
         mask_layer = event.source
 
+        # Clear labels on NaN pixels before applying the mask
         for image_layer in affected_layers:
+            self._clear_labels_on_nan_pixels(mask_layer, image_layer)
+
+        for image_layer in affected_layers:
+            invert = self._mask_invert_assignments.get(image_layer.name, False)
             self._restore_original_phasor_data(image_layer)
-            self._apply_mask_to_phasor_data(mask_layer, image_layer)
+            self._apply_mask_to_phasor_data(
+                mask_layer, image_layer, invert=invert
+            )
 
         if hasattr(self, 'filter_tab'):
             self.filter_tab._on_image_layer_changed()
@@ -5537,6 +5636,41 @@ class PlotterWidget(QWidget):
 
         self.refresh_current_plot()
 
+    def _clear_labels_on_nan_pixels(self, mask_layer, image_layer):
+        """Clear labels on pixels where original image data is NaN.
+
+        Parameters
+        ----------
+        mask_layer : napari.layers.Labels
+            The mask labels layer to modify.
+        image_layer : napari.layers.Image
+            The image layer whose original data defines NaN pixels.
+        """
+        if not isinstance(mask_layer, Labels):
+            return
+
+        # Use original data to find true NaN pixels
+        original = image_layer.metadata.get('original_mean')
+        if original is None:
+            original = image_layer.data
+
+        nan_mask = np.isnan(original)
+        if not nan_mask.any():
+            return
+
+        # Only modify if there are labels on NaN pixels
+        if np.any(mask_layer.data[nan_mask] != 0):
+            new_data = mask_layer.data.copy()
+            new_data[nan_mask] = 0
+            mask_layer.data = new_data
+
+    def _on_mask_invert_changed(self, checked):
+        """Handle invert checkbox state change."""
+        text = self.mask_layer_combobox.currentText()
+        if text == "None":
+            return
+        self._on_mask_layer_changed(text)
+
     def _update_mask_ui_mode(self):
         """Switch between single combobox and assign-masks button based on selection count."""
         selected = self.get_selected_layer_names()
@@ -5544,12 +5678,14 @@ class PlotterWidget(QWidget):
             # Multi-layer mode: show button, hide combobox
             self.mask_layer_label.setVisible(False)
             self.mask_layer_combobox.setVisible(False)
+            self.mask_invert_checkbox.setVisible(False)
             self.mask_assign_button.setVisible(True)
             self._update_mask_assign_button_text()
         else:
             # Single-layer mode: show combobox, hide button
             self.mask_layer_label.setVisible(True)
             self.mask_layer_combobox.setVisible(True)
+            self.mask_invert_checkbox.setVisible(True)
             self.mask_assign_button.setVisible(False)
             # Sync the combobox with current assignment for the single selected layer
             if selected:
@@ -5561,14 +5697,16 @@ class PlotterWidget(QWidget):
                 if assigned_mask in available_masks:
                     current_mask = assigned_mask
                 elif self.mask_layer_combobox.currentText() in available_masks:
-                    # Preserve the current valid selection when there is no
-                    # explicit assignment for this layer.
                     current_mask = self.mask_layer_combobox.currentText()
                 else:
                     current_mask = "None"
                 self.mask_layer_combobox.blockSignals(True)
                 self.mask_layer_combobox.setCurrentText(current_mask)
                 self.mask_layer_combobox.blockSignals(False)
+                # Sync invert checkbox
+                invert = self._mask_invert_assignments.get(selected[0], False)
+                self.mask_invert_checkbox.setChecked(invert)
+                self.mask_invert_checkbox.setEnabled(current_mask != "None")
 
     def _update_mask_assign_button_text(self):
         """Update the mask assign button text to show assignment summary."""
@@ -5601,23 +5739,37 @@ class PlotterWidget(QWidget):
             image_layer_names=selected_names,
             mask_layer_names=mask_layer_names,
             current_assignments=self._mask_assignments,
+            current_invert_assignments=(self._mask_invert_assignments),
             parent=self,
         )
 
         if dialog.exec() == QDialog.Accepted:
             new_assignments = dialog.get_assignments()
-            self._apply_mask_assignments(new_assignments)
+            new_invert = dialog.get_invert_assignments()
+            self._apply_mask_assignments(
+                new_assignments,
+                invert_assignments=new_invert,
+            )
 
-    def _apply_mask_assignments(self, assignments):
+    def _apply_mask_assignments(self, assignments, invert_assignments=None):
         """Apply per-layer mask assignments.
 
         Parameters
         ----------
         assignments : dict
-            Mapping of image layer name -> mask layer name (or "None").
+            Mapping of image layer name -> mask layer name
+            (or "None").
+        invert_assignments : dict, optional
+            Mapping of image layer name -> bool (invert flag).
         """
+        if invert_assignments is None:
+            invert_assignments = {}
+
         self._mask_assignments = {
             k: v for k, v in assignments.items() if v != "None"
+        }
+        self._mask_invert_assignments = {
+            k: invert_assignments.get(k, False) for k in self._mask_assignments
         }
 
         selected_layers = self.get_selected_layers()
@@ -5628,9 +5780,14 @@ class PlotterWidget(QWidget):
             if mask_name == "None":
                 if 'mask' in image_layer.metadata:
                     del image_layer.metadata['mask']
+                if 'mask_invert' in image_layer.metadata:
+                    del image_layer.metadata['mask_invert']
             else:
+                invert = invert_assignments.get(image_layer.name, False)
                 mask_layer = self.viewer.layers[mask_name]
-                self._apply_mask_to_phasor_data(mask_layer, image_layer)
+                self._apply_mask_to_phasor_data(
+                    mask_layer, image_layer, invert=invert
+                )
 
         if hasattr(self, 'filter_tab'):
             self.filter_tab._on_image_layer_changed()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -5612,10 +5612,6 @@ class PlotterWidget(QWidget):
 
         mask_layer = event.source
 
-        # Clear labels on NaN pixels before applying the mask
-        for image_layer in affected_layers:
-            self._clear_labels_on_nan_pixels(mask_layer, image_layer)
-
         for image_layer in affected_layers:
             invert = self._mask_invert_assignments.get(image_layer.name, False)
             self._restore_original_phasor_data(image_layer)
@@ -5635,34 +5631,6 @@ class PlotterWidget(QWidget):
                 self.filter_tab.apply_button_clicked()
 
         self.refresh_current_plot()
-
-    def _clear_labels_on_nan_pixels(self, mask_layer, image_layer):
-        """Clear labels on pixels where original image data is NaN.
-
-        Parameters
-        ----------
-        mask_layer : napari.layers.Labels
-            The mask labels layer to modify.
-        image_layer : napari.layers.Image
-            The image layer whose original data defines NaN pixels.
-        """
-        if not isinstance(mask_layer, Labels):
-            return
-
-        # Use original data to find true NaN pixels
-        original = image_layer.metadata.get('original_mean')
-        if original is None:
-            original = image_layer.data
-
-        nan_mask = np.isnan(original)
-        if not nan_mask.any():
-            return
-
-        # Only modify if there are labels on NaN pixels
-        if np.any(mask_layer.data[nan_mask] != 0):
-            new_data = mask_layer.data.copy()
-            new_data[nan_mask] = 0
-            mask_layer.data = new_data
 
     def _on_mask_invert_changed(self, checked):
         """Handle invert checkbox state change."""


### PR DESCRIPTION
## Add mask inversion toggle

Closes #257 (invert mask portion). NaN-aware mask painting was originally part of this PR but was reverted per @bruno-pannunzio's review — the right design for NaN-aware painting is more involved and will be addressed in a separate PR.

### What's included

**Invert mask toggle:**
- Adds an `Invert` checkbox next to the mask layer combobox.
- When checked, pixels inside the mask are excluded instead of pixels outside.
- The `MaskAssignmentDialog` exposes a per-layer `Invert` checkbox so different image layers in a multi-layer workflow can be inverted independently.
- Invert state is persisted in layer metadata so it survives session save/restore.

### What was reverted (will be a follow-up PR)

- The `_clear_labels_on_nan_pixels` helper and its call site in `_on_mask_data_changed`.
- The associated 5 tests.
- The `NaN-aware mask painting` section in `docs/guides/mask.md`.

### Testing

- 25 mask/invert/assignment tests pass.
- Lint clean (ruff, black, isort).
- Manually tested in napari: invert toggle works for both single-layer and multi-layer flows.
