### PR TITLE
Fix max phase in full polar plot mode

### DIFF
--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -1511,6 +1511,80 @@ def test_phasor_mapping_widget_phase_modulation_layer_display(
     assert modulation_layer.colormap.name == "plasma"
 
 
+def test_phase_output_wraps_to_full_circle_in_full_polar_mode(
+    make_napari_viewer,
+):
+    """Phase output should be wrapped to [0, 2pi] in full polar mode."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    mapping_widget = parent.phasor_mapping_tab
+
+    # Build a minimal layer with known negative phase values from phasor_to_polar.
+    # S < 0 yields negative angles that must wrap in full polar mode.
+    real = np.array([[[0.5, -0.5], [0.25, -0.25]]], dtype=float)
+    imag = np.array([[[-0.5, -0.5], [-0.25, -0.25]]], dtype=float)
+    layer = Image(
+        np.ones((2, 2), dtype=float),
+        name="PhaseWrapLayer",
+        metadata={
+            "original_mean": np.ones((2, 2), dtype=float),
+            "settings": {},
+            "G": real,
+            "S": imag,
+            "G_original": real.copy(),
+            "S_original": imag.copy(),
+            "harmonics": np.array([1]),
+        },
+    )
+    viewer.add_layer(layer)
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+
+    expected_phase, _ = phasor_to_polar(real[0], imag[0])
+    expected_wrapped = np.mod(expected_phase, 2.0 * np.pi).flatten()
+
+    # Full Polar Plot toggle ON means full-circle mode.
+    parent.plotter_inputs_widget.semi_circle_checkbox.setChecked(True)
+    mapping_widget.output_mode_combobox.setCurrentText("Phase")
+    mapping_widget.calculate_output_data()
+
+    np.testing.assert_allclose(
+        mapping_widget.current_metric_data_original,
+        expected_wrapped,
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    assert np.all(mapping_widget.current_metric_data_original >= 0.0)
+    assert np.all(mapping_widget.current_metric_data_original <= 2.0 * np.pi)
+
+
+def test_phase_range_defaults_to_0_2pi_in_full_polar_mode(
+    make_napari_viewer,
+):
+    """Phase map slider range should initialize to 0..2pi in full polar mode."""
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    mapping_widget = parent.phasor_mapping_tab
+
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+
+    # Full Polar Plot toggle ON means full-circle mode.
+    parent.plotter_inputs_widget.semi_circle_checkbox.setChecked(True)
+    mapping_widget.output_mode_combobox.setCurrentText("Phase")
+    mapping_widget._on_calculate_lifetime_clicked()
+
+    expected_max = int(2.0 * np.pi * mapping_widget.lifetime_range_factor)
+    min_slider, max_slider = mapping_widget.lifetime_range_slider.value()
+
+    assert mapping_widget.lifetime_range_slider.minimum() == 0
+    assert mapping_widget.lifetime_range_slider.maximum() == expected_max
+    assert min_slider == 0
+    assert max_slider == expected_max
+    assert abs(mapping_widget.min_lifetime - 0.0) < 1e-9
+    assert abs(mapping_widget.max_lifetime - (2.0 * np.pi)) < 1e-6
+
+
 def test_phasor_mapping_widget_select_color_uses_napari_colormap(
     make_napari_viewer,
 ):

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -1262,6 +1262,10 @@ class PhasorMappingWidget(QWidget):
                     phase_values, modulation_values = phasor_to_polar(
                         real, imag
                     )
+                if output_type == "Phase" and not self._is_semicircle_mode():
+                    # Full polar mode expects phase in [0, 2pi].
+                    with np.errstate(invalid='ignore'):
+                        phase_values = np.mod(phase_values, 2.0 * np.pi)
                 output_values = (
                     phase_values
                     if output_type == "Phase"
@@ -1352,34 +1356,54 @@ class PhasorMappingWidget(QWidget):
                 self.max_lifetime * self.lifetime_range_factor
             )
         else:
-            self.min_lifetime = np.min(valid_data)
-            self.max_lifetime = np.max(valid_data)
-
-            if (
-                self._output_requires_frequency(output_type)
-                and effective_frequency is not None
-                and (
-                    not np.isfinite(self.min_lifetime)
-                    or not np.isfinite(self.max_lifetime)
-                    or self.max_lifetime > (2e3 / effective_frequency)
-                    or self.min_lifetime < 0
-                )
-            ):
+            if output_type == "Phase" and not self._is_semicircle_mode():
+                # In full polar mode, initialize the display range to 0..2pi
+                # so users get the expected 0..360 degree domain.
                 self.min_lifetime = 0.0
-                self.max_lifetime = (
-                    2e3 / effective_frequency
-                )  # 2 periods in ns
+                self.max_lifetime = 2.0 * np.pi
                 min_slider_val = 0
                 max_slider_val = int(
                     self.max_lifetime * self.lifetime_range_factor
                 )
+                self.current_metric_data_original = np.mod(
+                    self.current_metric_data_original, 2.0 * np.pi
+                )
+                self.current_metric_data = (
+                    self.current_metric_data_original.copy()
+                )
+                for name, data in self.per_layer_metric_data_original.items():
+                    wrapped = np.mod(data, 2.0 * np.pi)
+                    self.per_layer_metric_data_original[name] = wrapped
+                    self.per_layer_metric_data[name] = wrapped.copy()
             else:
-                min_slider_val = int(
-                    self.min_lifetime * self.lifetime_range_factor
-                )
-                max_slider_val = int(
-                    self.max_lifetime * self.lifetime_range_factor
-                )
+                self.min_lifetime = np.min(valid_data)
+                self.max_lifetime = np.max(valid_data)
+
+                if (
+                    self._output_requires_frequency(output_type)
+                    and effective_frequency is not None
+                    and (
+                        not np.isfinite(self.min_lifetime)
+                        or not np.isfinite(self.max_lifetime)
+                        or self.max_lifetime > (2e3 / effective_frequency)
+                        or self.min_lifetime < 0
+                    )
+                ):
+                    self.min_lifetime = 0.0
+                    self.max_lifetime = (
+                        2e3 / effective_frequency
+                    )  # 2 periods in ns
+                    min_slider_val = 0
+                    max_slider_val = int(
+                        self.max_lifetime * self.lifetime_range_factor
+                    )
+                else:
+                    min_slider_val = int(
+                        self.min_lifetime * self.lifetime_range_factor
+                    )
+                    max_slider_val = int(
+                        self.max_lifetime * self.lifetime_range_factor
+                    )
         self.lifetime_range_slider.setRange(0, max_slider_val)
         self.lifetime_range_slider.setValue((min_slider_val, max_slider_val))
 


### PR DESCRIPTION
This pull request improves the handling and display of phase data in full polar mode within the phasor mapping tab, ensuring that phase values are correctly wrapped to the [0, 2π] range and that UI slider ranges match user expectations. It also adds comprehensive tests to verify these behaviors.

**Phase value wrapping and display improvements:**

* Ensures that when outputting "Phase" in full polar mode, phase values are wrapped to the [0, 2π] interval using `np.mod`, so negative angles or those outside this range are correctly displayed.
* When in full polar mode, initializes the phase map slider range and internal min/max values to [0, 2π], and wraps all relevant metric data arrays accordingly to maintain consistency across the UI and calculations.

**Testing enhancements:**

* Adds `test_phase_output_wraps_to_full_circle_in_full_polar_mode` to verify that negative or out-of-range phase values are wrapped to [0, 2π] in full polar mode.
* Adds `test_phase_range_defaults_to_0_2pi_in_full_polar_mode` to ensure that the phase slider range is initialized to [0, 2π] in full polar mode, matching user expectations for a full-circle phase plot.