### PR TITLE
Enhance selection toolbar behavior to handle sender-less toggles

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -160,6 +160,90 @@ def test_biaplotter_toggle_callback_handles_missing_sender(
     mock_deactivate.assert_called_once()
 
 
+def test_biaplotter_pan_toggle_deactivates_active_selector_without_sender(
+    make_napari_viewer,
+):
+    """A sender-less pan toggle should clear the current selector tool."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    canvas = plotter.canvas_widget
+
+    with patch.object(CanvasWidget, 'sender', return_value=None):
+        canvas.selection_toolbar.buttons['LASSO'].click()
+
+    canvas.toolbar.mode = 'pan/zoom'
+
+    with patch.object(CanvasWidget, 'sender', return_value=None):
+        canvas._on_toggle_button(True)
+
+    assert canvas.active_selector is None
+    assert all(
+        not button.isChecked()
+        for button in canvas.selection_toolbar.buttons.values()
+    )
+
+
+def test_biaplotter_selector_toggle_handles_missing_sender(
+    make_napari_viewer,
+):
+    """Selector buttons should still activate when sender() is unavailable."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    canvas = plotter.canvas_widget
+
+    with patch.object(CanvasWidget, 'sender', return_value=None):
+        canvas.selection_toolbar.buttons['LASSO'].click()
+
+    assert canvas.active_selector is not None
+    assert (
+        canvas.active_selector.__class__.__name__ == 'InteractiveLassoSelector'
+    )
+
+
+def test_biaplotter_selector_toggle_is_exclusive_without_sender(
+    make_napari_viewer,
+):
+    """Switching selector tools without sender() should deactivate the previous tool."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    canvas = plotter.canvas_widget
+
+    with patch.object(CanvasWidget, 'sender', return_value=None):
+        canvas.selection_toolbar.buttons['LASSO'].click()
+        canvas.selection_toolbar.buttons['ELLIPSE'].click()
+
+    assert canvas.selection_toolbar.buttons['LASSO'].isChecked() is False
+    assert canvas.selection_toolbar.buttons['ELLIPSE'].isChecked() is True
+    assert canvas.active_selector is not None
+    assert (
+        canvas.active_selector.__class__.__name__
+        == 'InteractiveEllipseSelector'
+    )
+
+
+def test_biaplotter_zoom_toggle_deactivates_active_selector_without_sender(
+    make_napari_viewer,
+):
+    """A sender-less zoom toggle should clear the current selector tool."""
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    canvas = plotter.canvas_widget
+
+    with patch.object(CanvasWidget, 'sender', return_value=None):
+        canvas.selection_toolbar.buttons['RECTANGLE'].click()
+
+    canvas.toolbar.mode = 'zoom rect'
+
+    with patch.object(CanvasWidget, 'sender', return_value=None):
+        canvas._on_toggle_button(True)
+
+    assert canvas.active_selector is None
+    assert all(
+        not button.isChecked()
+        for button in canvas.selection_toolbar.buttons.values()
+    )
+
+
 def test_phasor_plotter_initialization_values(make_napari_viewer):
     """Test the initialization of the Phasor Plotter Widget."""
     viewer = make_napari_viewer()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -20,7 +20,7 @@ from phasorpy.phasor import phasor_center as _phasor_center
 from phasorpy.phasor import phasor_to_polar
 from qtpy import uic
 from qtpy.QtCore import QEvent, Qt, QTimer
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QCursor
 from qtpy.QtWidgets import (
     QComboBox,
     QDialog,
@@ -129,14 +129,61 @@ def _patch_biaplotter_safe_toggle_sender():
     ):
         return
 
-    original = CanvasWidget._on_toggle_button
-
     def _on_toggle_button_safe(self, checked: bool):
         sender_obj = self.sender()
         sender_name = None
+        active_button_name = None
+
+        active_selector = getattr(self, 'active_selector', None)
+        if active_selector is not None:
+            for name, selector in getattr(self, 'selectors', {}).items():
+                if selector is active_selector:
+                    active_button_name = name
+                    break
+
         if sender_obj is not None:
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
                 sender_name = sender_obj.text()
+
+        # Non-Qt pan/zoom signals do not carry a sender, but they should still
+        # deactivate any active selector before we try to infer a toolbar button.
+        if (
+            sender_name is None
+            and checked
+            and self.toolbar.mode in {'pan/zoom', 'zoom rect'}
+        ):
+            self._deactivate_and_remove_all_selectors()
+            return
+
+        if sender_name is None and hasattr(self, 'selection_toolbar'):
+            checked_selector_names = [
+                name
+                for name, button in self.selection_toolbar.buttons.items()
+                if button.isCheckable() and button.isChecked()
+            ]
+
+            if checked:
+                if len(checked_selector_names) == 1:
+                    sender_name = checked_selector_names[0]
+                elif (
+                    active_button_name is not None
+                    and active_button_name in checked_selector_names
+                ):
+                    candidates = [
+                        name
+                        for name in checked_selector_names
+                        if name != active_button_name
+                    ]
+                    if len(candidates) == 1:
+                        sender_name = candidates[0]
+            else:
+                if (
+                    len(checked_selector_names) == 1
+                    and checked_selector_names[0] != active_button_name
+                ):
+                    sender_name = checked_selector_names[0]
+                elif not checked_selector_names and active_button_name:
+                    sender_name = active_button_name
 
         # Non-Qt emitters (psygnal) can call this with sender=None.
         # Preserve expected behavior for toolbar pan/zoom toggles.
@@ -145,7 +192,38 @@ def _patch_biaplotter_safe_toggle_sender():
                 self._deactivate_and_remove_all_selectors()
             return
 
-        return original(self, checked)
+        # Reproduce the original biaplotter behavior using the resolved sender.
+        if sender_name in self.selection_toolbar.buttons:
+            if checked:
+                if self.toolbar.mode == 'zoom rect':
+                    with self.toolbar.zoom_toggled_signal.blocked():
+                        self.toolbar.zoom()
+                elif self.toolbar.mode == 'pan/zoom':
+                    with self.toolbar.pan_toggled_signal.blocked():
+                        self.toolbar.pan()
+                self._deactivate_and_remove_all_selectors(
+                    except_this_button_name=sender_name
+                )
+                self.active_selector = sender_name
+            else:
+                checked_selector_names = [
+                    name
+                    for name, button in self.selection_toolbar.buttons.items()
+                    if button.isCheckable() and button.isChecked()
+                ]
+                if (
+                    len(checked_selector_names) == 1
+                    and checked_selector_names[0] != sender_name
+                ):
+                    self._deactivate_and_remove_all_selectors(
+                        except_this_button_name=checked_selector_names[0]
+                    )
+                    self.active_selector = checked_selector_names[0]
+                else:
+                    self._remove_all_selectors()
+                    self.canvas.setCursor(QCursor(Qt.ArrowCursor))
+        elif sender_name in ['Pan', 'Zoom'] and checked:
+            self._deactivate_and_remove_all_selectors()
 
     CanvasWidget._on_toggle_button = _on_toggle_button_safe
     CanvasWidget._napari_phasors_safe_toggle_sender_patch = True


### PR DESCRIPTION
This pull request improves the robustness and correctness of the selector tool toggling logic in the plotter widget, especially when signals are emitted without a sender (which can happen in some Qt or non-Qt contexts). It introduces more reliable handling for tool activation and deactivation, and adds comprehensive tests to ensure correct behavior when sender information is missing.

**Selector tool toggle and pan/zoom logic improvements:**

* Refactored the `_on_toggle_button` logic in `CanvasWidget` to more robustly infer the intended sender (selector tool) when the sender is `None`, ensuring that selector tool activation, exclusivity, and deactivation work correctly even for non-Qt signals or toolbar actions. This includes handling cases where pan/zoom or zoom rect modes are toggled without a sender, ensuring all selectors are properly deactivated.
* Ensured that when a selector button is toggled on or off without a sender, the correct selector is activated or deactivated, and the exclusivity of selector tools is maintained.
* Updated imports to include `QCursor` for cursor management when deactivating selectors.

**Testing enhancements:**

* Added several new tests to `test_plotter.py` that verify correct behavior of selector tool toggling, pan/zoom and zoom rect tool deactivation, and exclusivity, specifically in scenarios where the sender is missing. These tests cover activating and deactivating selectors, switching between selectors, and toggling pan/zoom and zoom rect tools without sender information.