### PR TITLE
Fix center of mass calculation in StatisticsTableWidget

### DIFF
--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -158,6 +158,23 @@ def test_statistics_table_widget_populates_rows(qtbot):
     assert row_names == {"Layer A", "Layer B"}
 
 
+def test_statistics_table_widget_handles_empty_histogram_bins(qtbot):
+    """StatisticsTableWidget should not crash when histogram counts are zero."""
+    table = StatisticsTableWidget()
+    qtbot.addWidget(table)
+
+    datasets = {"Layer A": np.array([10.0, 11.0, 12.0])}
+    bin_edges = np.array([0.0, 1.0, 2.0])
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+
+    table.update_statistics(
+        datasets, bin_centers=bin_centers, bin_edges=bin_edges
+    )
+
+    assert table.rowCount() == 1
+    assert table.item(0, 1).text() == "nan"
+
+
 def test_statistics_dock_widget_updates_for_single_and_grouped_data(qtbot):
     """StatisticsDockWidget should toggle sections by histogram mode/data."""
     histogram_widget = HistogramWidget(bins=12)

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2893,8 +2893,6 @@ class StatisticsTableWidget(QTableWidget):
                 if bin_centers is not None and bin_edges is not None:
                     counts, _ = np.histogram(valid, bins=bin_edges)
                     com_val = np.average(bin_centers, weights=counts)
-                    print(bin_centers.shape)
-                    print(counts.shape)
                 else:
                     com_val = mean_val
             else:

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2892,12 +2892,9 @@ class StatisticsTableWidget(QTableWidget):
 
                 if bin_centers is not None and bin_edges is not None:
                     counts, _ = np.histogram(valid, bins=bin_edges)
-                    total = counts.sum()
-                    com_val = (
-                        float(np.sum(bin_centers * counts) / total)
-                        if total > 0
-                        else float("nan")
-                    )
+                    com_val = np.average(bin_centers, weights=counts)
+                    print(bin_centers.shape)
+                    print(counts.shape)
                 else:
                     com_val = mean_val
             else:

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2892,7 +2892,10 @@ class StatisticsTableWidget(QTableWidget):
 
                 if bin_centers is not None and bin_edges is not None:
                     counts, _ = np.histogram(valid, bins=bin_edges)
-                    com_val = np.average(bin_centers, weights=counts)
+                    if counts.sum() > 0:
+                        com_val = np.average(bin_centers, weights=counts)
+                    else:
+                        com_val = float("nan")
                 else:
                     com_val = mean_val
             else:


### PR DESCRIPTION
This pull request updates the calculation of the center of mass value in the `update_statistics` method to use a more concise and numerically stable approach. The key change is replacing a manual weighted sum and division by the total count with `np.average` using the histogram counts as weights.

**Statistics calculation improvements:**

* Simplified the calculation of `com_val` by replacing the manual weighted sum and division with `np.average(bin_centers, weights=counts)` for better readability and numerical stability.