### PR TITLE
Fix: Ensure filters are preserved during calibration and uncalibration (#275)

### DIFF
--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -491,3 +491,135 @@ def test_calibration_preserves_filters(make_napari_viewer):
     assert sample_layer.metadata["settings"]["threshold"] == 0.1
     assert sample_layer.metadata["settings"]["threshold_upper"] == 0.9
     assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"
+
+
+def test_calibration_preserves_wavelet_sigma_filter(make_napari_viewer):
+    """Test that wavelet filters with sigma parameter are preserved during calibration/uncalibration."""
+    from napari_phasors._utils import apply_filter_and_threshold
+
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    # Add uncalibrated layer
+    sample_layer = create_image_layer_with_phasors()
+    sample_layer.name = "sample_layer"
+    viewer.add_layer(sample_layer)
+
+    # Apply wavelet filter with sigma to the layer
+    apply_filter_and_threshold(
+        sample_layer,
+        threshold=0.05,
+        threshold_method="Otsu",
+        filter_method="wavelet",
+        sigma=2.5,
+        levels=2,
+    )
+
+    # Verify filter settings are stored
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert sample_layer.metadata["settings"]["filter"]["sigma"] == 2.5
+    assert sample_layer.metadata["settings"]["filter"]["levels"] == 2
+    assert sample_layer.metadata["settings"]["threshold"] == 0.05
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Otsu"
+
+    # Set up calibration
+    widget.calibration_widget.calibration_layer_combobox.setCurrentText(
+        "sample_layer"
+    )
+    widget.calibration_widget.frequency_input.setText("80")
+    widget.calibration_widget.lifetime_line_edit_widget.setText("2.0")
+
+    # Calibrate the layer
+    widget.calibration_widget.calibrate_push_button.click()
+
+    # Verify calibration happened
+    assert sample_layer.metadata["settings"]["calibrated"] is True
+
+    # Verify wavelet filter settings are still present after calibration
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert sample_layer.metadata["settings"]["filter"]["sigma"] == 2.5
+    assert sample_layer.metadata["settings"]["filter"]["levels"] == 2
+    assert sample_layer.metadata["settings"]["threshold"] == 0.05
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Otsu"
+
+    # Now uncalibrate the layer
+    widget.calibration_widget.calibrate_push_button.click()
+
+    # Verify uncalibration happened
+    assert sample_layer.metadata["settings"]["calibrated"] is False
+
+    # Verify wavelet filter settings are still preserved after uncalibration
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert sample_layer.metadata["settings"]["filter"]["sigma"] == 2.5
+    assert sample_layer.metadata["settings"]["filter"]["levels"] == 2
+    assert sample_layer.metadata["settings"]["threshold"] == 0.05
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Otsu"
+
+
+def test_calibration_preserves_wavelet_levels_filter(make_napari_viewer):
+    """Test that wavelet filters with different levels parameter are preserved during calibration/uncalibration."""
+    from napari_phasors._utils import apply_filter_and_threshold
+
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    # Add uncalibrated layer
+    sample_layer = create_image_layer_with_phasors()
+    sample_layer.name = "sample_layer"
+    viewer.add_layer(sample_layer)
+
+    # Apply wavelet filter with different levels parameter
+    apply_filter_and_threshold(
+        sample_layer,
+        threshold=0.02,
+        threshold_upper=0.95,
+        threshold_method="Manual",
+        filter_method="wavelet",
+        sigma=1.5,
+        levels=4,
+    )
+
+    # Verify filter settings are stored with levels=4
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert sample_layer.metadata["settings"]["filter"]["sigma"] == 1.5
+    assert sample_layer.metadata["settings"]["filter"]["levels"] == 4
+    assert sample_layer.metadata["settings"]["threshold"] == 0.02
+    assert sample_layer.metadata["settings"]["threshold_upper"] == 0.95
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"
+
+    # Set up calibration
+    widget.calibration_widget.calibration_layer_combobox.setCurrentText(
+        "sample_layer"
+    )
+    widget.calibration_widget.frequency_input.setText("80")
+    widget.calibration_widget.lifetime_line_edit_widget.setText("2.0")
+
+    # Calibrate the layer
+    widget.calibration_widget.calibrate_push_button.click()
+
+    # Verify calibration happened
+    assert sample_layer.metadata["settings"]["calibrated"] is True
+
+    # Verify wavelet filter settings with levels are preserved after calibration
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert sample_layer.metadata["settings"]["filter"]["sigma"] == 1.5
+    assert sample_layer.metadata["settings"]["filter"]["levels"] == 4
+    assert sample_layer.metadata["settings"]["threshold"] == 0.02
+    assert sample_layer.metadata["settings"]["threshold_upper"] == 0.95
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"
+
+    # Now uncalibrate the layer
+    widget.calibration_widget.calibrate_push_button.click()
+
+    # Verify uncalibration happened
+    assert sample_layer.metadata["settings"]["calibrated"] is False
+
+    # Verify wavelet filter settings with levels are preserved after uncalibration
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "wavelet"
+    assert sample_layer.metadata["settings"]["filter"]["sigma"] == 1.5
+    assert sample_layer.metadata["settings"]["filter"]["levels"] == 4
+    assert sample_layer.metadata["settings"]["threshold"] == 0.02
+    assert sample_layer.metadata["settings"]["threshold_upper"] == 0.95
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"

--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -423,3 +423,71 @@ def test_on_image_layer_changed_with_frequency(make_napari_viewer):
 
     parent._sync_frequency_inputs_from_metadata()
     assert widget.calibration_widget.frequency_input.text() == "80.0"
+
+
+def test_calibration_preserves_filters(make_napari_viewer):
+    """Test that filters and thresholds are preserved during calibration/uncalibration."""
+    from napari_phasors._utils import apply_filter_and_threshold
+
+    viewer = make_napari_viewer()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    # Add uncalibrated layer
+    sample_layer = create_image_layer_with_phasors()
+    sample_layer.name = "sample_layer"
+    viewer.add_layer(sample_layer)
+
+    # Apply median filter with threshold to the layer
+    apply_filter_and_threshold(
+        sample_layer,
+        threshold=0.1,
+        threshold_upper=0.9,
+        threshold_method="Manual",
+        filter_method="median",
+        size=3,
+        repeat=1,
+    )
+
+    # Verify filter settings are stored
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "median"
+    assert sample_layer.metadata["settings"]["filter"]["size"] == 3
+    assert sample_layer.metadata["settings"]["filter"]["repeat"] == 1
+    assert sample_layer.metadata["settings"]["threshold"] == 0.1
+    assert sample_layer.metadata["settings"]["threshold_upper"] == 0.9
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"
+
+    # Set up calibration
+    widget.calibration_widget.calibration_layer_combobox.setCurrentText(
+        "sample_layer"
+    )
+    widget.calibration_widget.frequency_input.setText("80")
+    widget.calibration_widget.lifetime_line_edit_widget.setText("2.0")
+
+    # Calibrate the layer
+    widget.calibration_widget.calibrate_push_button.click()
+
+    # Verify calibration happened
+    assert sample_layer.metadata["settings"]["calibrated"] is True
+
+    # Verify filter settings are still present after calibration
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "median"
+    assert sample_layer.metadata["settings"]["filter"]["size"] == 3
+    assert sample_layer.metadata["settings"]["filter"]["repeat"] == 1
+    assert sample_layer.metadata["settings"]["threshold"] == 0.1
+    assert sample_layer.metadata["settings"]["threshold_upper"] == 0.9
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"
+
+    # Now uncalibrate the layer
+    widget.calibration_widget.calibrate_push_button.click()
+
+    # Verify uncalibration happened
+    assert sample_layer.metadata["settings"]["calibrated"] is False
+
+    # Verify threshold and filter settings are still preserved after uncalibration
+    assert sample_layer.metadata["settings"]["filter"]["method"] == "median"
+    assert sample_layer.metadata["settings"]["filter"]["size"] == 3
+    assert sample_layer.metadata["settings"]["filter"]["repeat"] == 1
+    assert sample_layer.metadata["settings"]["threshold"] == 0.1
+    assert sample_layer.metadata["settings"]["threshold_upper"] == 0.9
+    assert sample_layer.metadata["settings"]["threshold_method"] == "Manual"

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -381,39 +381,25 @@ class CalibrationWidget(QWidget):
     def _apply_existing_filters_and_thresholds(self, sample_layer):
         """Apply existing filter and threshold settings if they exist."""
         settings = sample_layer.metadata.get("settings", {})
-
         filter_settings = settings.get("filter", {})
-        filter_method = filter_settings.get("method")
-        filter_size = filter_settings.get("size")
-        filter_repeat = filter_settings.get("repeat")
-        sigma = filter_settings.get("sigma")
-        levels = filter_settings.get("levels")
 
-        threshold = settings.get("threshold")
-        threshold_upper = settings.get("threshold_upper")
-        threshold_method = settings.get("threshold_method")
+        # Build kwargs dict with only non-None values
+        kwargs = {}
+        for key, value in [
+            ("filter_method", filter_settings.get("method")),
+            ("size", filter_settings.get("size")),
+            ("repeat", filter_settings.get("repeat")),
+            ("sigma", filter_settings.get("sigma")),
+            ("levels", filter_settings.get("levels")),
+            ("threshold", settings.get("threshold")),
+            ("threshold_upper", settings.get("threshold_upper")),
+            ("threshold_method", settings.get("threshold_method")),
+        ]:
+            if value is not None:
+                kwargs[key] = value
 
-        if (
-            filter_method is not None
-            or filter_size is not None
-            or filter_repeat is not None
-            or sigma is not None
-            or levels is not None
-            or threshold is not None
-            or threshold_upper is not None
-            or threshold_method is not None
-        ):
-            apply_filter_and_threshold(
-                sample_layer,
-                threshold=threshold,
-                threshold_upper=threshold_upper,
-                threshold_method=threshold_method,
-                filter_method=filter_method,
-                size=filter_size,
-                repeat=filter_repeat,
-                sigma=sigma,
-                levels=levels,
-            )
+        if kwargs:
+            apply_filter_and_threshold(sample_layer, **kwargs)
 
     def _apply_phasor_transformation(self, sample_name, phi_zero, mod_zero):
         """Apply phasor transformation with given correction parameters."""

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -383,21 +383,36 @@ class CalibrationWidget(QWidget):
         settings = sample_layer.metadata.get("settings", {})
 
         filter_settings = settings.get("filter", {})
+        filter_method = filter_settings.get("method")
         filter_size = filter_settings.get("size")
         filter_repeat = filter_settings.get("repeat")
+        sigma = filter_settings.get("sigma")
+        levels = filter_settings.get("levels")
 
         threshold = settings.get("threshold")
+        threshold_upper = settings.get("threshold_upper")
+        threshold_method = settings.get("threshold_method")
 
         if (
-            filter_size is not None
+            filter_method is not None
+            or filter_size is not None
             or filter_repeat is not None
+            or sigma is not None
+            or levels is not None
             or threshold is not None
+            or threshold_upper is not None
+            or threshold_method is not None
         ):
             apply_filter_and_threshold(
                 sample_layer,
                 threshold=threshold,
+                threshold_upper=threshold_upper,
+                threshold_method=threshold_method,
+                filter_method=filter_method,
                 size=filter_size,
                 repeat=filter_repeat,
+                sigma=sigma,
+                levels=levels,
             )
 
     def _apply_phasor_transformation(self, sample_name, phi_zero, mod_zero):


### PR DESCRIPTION
This pull request adds a fix to ensure that filter and threshold settings on image layers are preserved during calibration and uncalibration. The main focus is on improving robustness and correctness when handling layer metadata related to filtering and thresholding.

Fixes #275 

**Testing improvements:**

* Added a new test, `test_calibration_preserves_filters`, to verify that filter and threshold settings (including method, size, repeat, threshold values, and method) are retained after calibration and uncalibration actions on image layers.

**Calibration logic enhancements:**

* Updated `_apply_existing_filters_and_thresholds` in `calibration_tab.py` to support and pass additional filter (`method`, `sigma`, `levels`) and threshold (`threshold_upper`, `threshold_method`) parameters from the layer's metadata to the `apply_filter_and_threshold` function, ensuring all relevant settings are reapplied as needed.