### PR TITLE
fix: renaming layers bug in Plotter and Histogram Widgets (#273) (#274)

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1723,6 +1723,83 @@ def test_mask_layer_rename_updates_combobox_and_assignments(
     assert plotter.mask_layer_combobox.currentText() == "mask_after_rename"
 
 
+def test_image_layer_rename_updates_combobox(make_napari_viewer):
+    """Test that renaming an image layer keeps it selected and updates the name in the checkable combobox."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+
+    plotter = PlotterWidget(viewer)
+
+    # Select the layer
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer1.name])
+    assert plotter.get_selected_layer_names() == [layer1.name]
+
+    # Rename the layer
+    old_name = layer1.name
+    new_name = "renamed_image_layer"
+    layer1.name = new_name
+
+    assert plotter.get_selected_layer_names() == [new_name]
+    assert new_name in plotter.image_layers_checkable_combobox.allItems()
+    assert old_name not in plotter.image_layers_checkable_combobox.allItems()
+
+
+def test_image_layer_rename_without_initial_phasors(make_napari_viewer):
+    """Test that renaming an image layer that starts without phasor metadata correctly tracks rename when it later gets phasors."""
+    viewer = make_napari_viewer()
+    # Create image layer without phasors
+    layer1 = Image(np.ones((10, 10)), name="raw_image")
+    viewer.add_layer(layer1)
+
+    plotter = PlotterWidget(viewer)
+
+    # It should not be in the combobox yet
+    assert (
+        "raw_image" not in plotter.image_layers_checkable_combobox.allItems()
+    )
+
+    # Rename the layer before it has phasor metadata
+    layer1.name = "renamed_raw_image"
+
+    # Set phasor metadata to simulate calibration/calculation
+    layer1.metadata = {
+        "G": np.ones((10, 10)),
+        "S": np.ones((10, 10)),
+        "G_original": np.ones((10, 10)),
+        "S_original": np.ones((10, 10)),
+        "harmonics": [1],
+    }
+
+    # Trigger reset_layer_choices (e.g. simulation of tab change or manual refresh)
+    plotter.reset_layer_choices()
+
+    # It should now be in the combobox with the renamed name
+    assert (
+        "renamed_raw_image"
+        in plotter.image_layers_checkable_combobox.allItems()
+    )
+
+    # If we select it
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        ["renamed_raw_image"]
+    )
+
+    # Rename it again (while it has phasor metadata and is selected)
+    layer1.name = "final_image_name"
+
+    # It should keep being selected and update the name in the combobox
+    assert plotter.get_selected_layer_names() == ["final_image_name"]
+    assert (
+        "final_image_name"
+        in plotter.image_layers_checkable_combobox.allItems()
+    )
+    assert (
+        "renamed_raw_image"
+        not in plotter.image_layers_checkable_combobox.allItems()
+    )
+
+
 def test_mask_ui_switches_to_button_when_multiple_layers_selected(
     make_napari_viewer,
 ):

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -256,3 +256,35 @@ def test_histogram_widget_respects_range_slider_limits(qtbot):
     xlim = widget.ax.get_xlim()
     assert xlim[0] == 2.0
     assert xlim[1] == 3.0
+
+
+def test_histogram_widget_rename_dataset(qtbot):
+    """HistogramWidget should update internal tracking dicts when a dataset is renamed."""
+    widget = HistogramWidget(bins=10)
+    qtbot.addWidget(widget)
+
+    datasets = {
+        "Layer A": np.array([1, 2, 3], dtype=float),
+    }
+    widget.update_multi_data(datasets)
+
+    # Simulate user changing some settings for the layer
+    widget._layer_colors["Layer A"] = (1.0, 0.0, 0.0)
+    widget._group_assignments["Layer A"] = 2
+
+    # Rename the dataset
+    widget.rename_dataset("Layer A", "Layer B")
+
+    assert "Layer A" not in widget._datasets
+    assert "Layer B" in widget._datasets
+
+    assert "Layer A" not in widget._counts_per_dataset
+    assert "Layer B" in widget._counts_per_dataset
+
+    assert "Layer A" not in widget._layer_colors
+    assert "Layer B" in widget._layer_colors
+    assert widget._layer_colors["Layer B"] == (1.0, 0.0, 0.0)
+
+    assert "Layer A" not in widget._group_assignments
+    assert "Layer B" in widget._group_assignments
+    assert widget._group_assignments["Layer B"] == 2

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2242,6 +2242,25 @@ class HistogramWidget(QWidget):
         self.show()
         self.dataChanged.emit()
 
+    def rename_dataset(self, old_name: str, new_name: str) -> None:
+        """Handle renaming of a dataset to preserve colors and groupings."""
+        if old_name in self._datasets:
+            self._datasets[new_name] = self._datasets.pop(old_name)
+        if old_name in self._counts_per_dataset:
+            self._counts_per_dataset[new_name] = self._counts_per_dataset.pop(
+                old_name
+            )
+        if old_name in self._layer_colors:
+            self._layer_colors[new_name] = self._layer_colors.pop(old_name)
+        if old_name in self._group_assignments:
+            self._group_assignments[new_name] = self._group_assignments.pop(
+                old_name
+            )
+
+        if self._datasets:
+            self._render()
+            self.fig.canvas.draw_idle()
+
     def update_colormap(
         self,
         colormap_colors: np.ndarray = None,

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2260,6 +2260,7 @@ class HistogramWidget(QWidget):
         if self._datasets:
             self._render()
             self.fig.canvas.draw_idle()
+            self.dataChanged.emit()
 
     def update_colormap(
         self,

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -3897,6 +3897,19 @@ class ComponentsWidget(QWidget):
         except Exception as e:  # noqa: BLE001
             show_error(f"Analysis failed: {str(e)}")
 
+    def rename_layer(self, old_name: str, new_name: str):
+        """Rename derived layers when base layer is renamed."""
+        from napari.layers import Image
+
+        for layer in self.viewer.layers:
+            if not isinstance(layer, Image):
+                continue
+            name = layer.name
+            for sep in (" fractions: ", " fraction: "):
+                if name.endswith(sep + old_name):
+                    comp_part = name[: -len(sep + old_name)]
+                    layer.name = f"{comp_part}{sep}{new_name}"
+
     def _get_fraction_layers_for_component(self, component_name):
         """Get all fraction layers in the viewer for a given component name.
 

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -3899,8 +3899,6 @@ class ComponentsWidget(QWidget):
 
     def rename_layer(self, old_name: str, new_name: str):
         """Rename derived layers when base layer is renamed."""
-        from napari.layers import Image
-
         for layer in self.viewer.layers:
             if not isinstance(layer, Image):
                 continue

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -1498,6 +1498,14 @@ class FretWidget(QWidget):
                 self.fret_colormap = self.fret_layer.colormap.colors
                 self.colormap_contrast_limits = self.fret_layer.contrast_limits
 
+    def rename_layer(self, old_name: str, new_name: str):
+        """Rename derived layers when base layer is renamed."""
+        fret_layer_name = f"FRET efficiency: {old_name}"
+        if fret_layer_name in self.viewer.layers:
+            self.viewer.layers[fret_layer_name].name = (
+                f"FRET efficiency: {new_name}"
+            )
+
     def _update_fret_histogram(self):
         """Update the FRET efficiency histogram from all selected FRET layers."""
         if not self.fret_layers:

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -1502,9 +1502,12 @@ class FretWidget(QWidget):
         """Rename derived layers when base layer is renamed."""
         fret_layer_name = f"FRET efficiency: {old_name}"
         if fret_layer_name in self.viewer.layers:
-            self.viewer.layers[fret_layer_name].name = (
-                f"FRET efficiency: {new_name}"
-            )
+            new_fret_layer_name = f"FRET efficiency: {new_name}"
+            self.viewer.layers[fret_layer_name].name = new_fret_layer_name
+            if hasattr(self, 'histogram_widget'):
+                self.histogram_widget.rename_dataset(
+                    fret_layer_name, new_fret_layer_name
+                )
 
     def _update_fret_histogram(self):
         """Update the FRET efficiency histogram from all selected FRET layers."""

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -1438,6 +1438,33 @@ class PhasorMappingWidget(QWidget):
         else:
             self.histogram_widget.update_data(self.current_metric_data)
 
+    def rename_layer(self, old_name: str, new_name: str):
+        """Update internal dictionaries and rename derived layers when a layer is renamed."""
+        for dict_attr in [
+            'per_layer_metric_data_original',
+            'per_layer_metric_data',
+            'per_layer_lifetime_data_original',
+            'per_layer_lifetime_data',
+        ]:
+            if hasattr(self, dict_attr):
+                dict_obj = getattr(self, dict_attr)
+                if dict_obj is not None and old_name in dict_obj:
+                    dict_obj[new_name] = dict_obj.pop(old_name)
+
+        # Rename derived layers
+        for output_type in [
+            "Phase",
+            "Modulation",
+            "Apparent Phase Lifetime",
+            "Apparent Modulation Lifetime",
+            "Normal Lifetime",
+        ]:
+            layer_name = f"{output_type}: {old_name}"
+            if layer_name in self.viewer.layers:
+                self.viewer.layers[layer_name].name = (
+                    f"{output_type}: {new_name}"
+                )
+
     def create_output_layers(self):
         """Create or update output layers for all selected layers."""
         selected_layers = self.parent_widget.get_selected_layers()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -5200,6 +5200,18 @@ class PlotterWidget(QWidget):
                     renamed_images.get(name, name)
                     for name in previously_selected
                 ]
+                self._mask_assignments = {
+                    renamed_images.get(
+                        image_layer_name, image_layer_name
+                    ): mask_name
+                    for image_layer_name, mask_name in self._mask_assignments.items()
+                }
+                self._mask_invert_assignments = {
+                    renamed_images.get(
+                        image_layer_name, image_layer_name
+                    ): invert
+                    for image_layer_name, invert in self._mask_invert_assignments.items()
+                }
                 self._notify_tabs_of_renamed_layers(renamed_images)
             self._image_layers_by_id = image_layers_by_id
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -5091,6 +5091,57 @@ class PlotterWidget(QWidget):
                 self.selection_tab.manual_selection_changed
             )
 
+    def _notify_tabs_of_renamed_layers(self, renamed_images: dict):
+        """Notify all tabs and histogram widgets that image layers were renamed."""
+        for old_name, new_name in renamed_images.items():
+            # Notify Phasor Mapping Tab
+            if hasattr(self, 'phasor_mapping_tab') and self.phasor_mapping_tab:
+                if hasattr(self.phasor_mapping_tab, 'rename_layer'):
+                    self.phasor_mapping_tab.rename_layer(old_name, new_name)
+                if hasattr(
+                    self.phasor_mapping_tab, 'histogram_widget'
+                ) and hasattr(
+                    self.phasor_mapping_tab.histogram_widget, 'rename_dataset'
+                ):
+                    self.phasor_mapping_tab.histogram_widget.rename_dataset(
+                        old_name, new_name
+                    )
+
+            # Notify Components Tab
+            if hasattr(self, 'components_tab') and self.components_tab:
+                if hasattr(self.components_tab, 'rename_layer'):
+                    self.components_tab.rename_layer(old_name, new_name)
+                if hasattr(
+                    self.components_tab, 'histogram_widget'
+                ) and hasattr(
+                    self.components_tab.histogram_widget, 'rename_dataset'
+                ):
+                    self.components_tab.histogram_widget.rename_dataset(
+                        old_name, new_name
+                    )
+
+            # Notify FRET Tab
+            if hasattr(self, 'fret_tab') and self.fret_tab:
+                if hasattr(self.fret_tab, 'rename_layer'):
+                    self.fret_tab.rename_layer(old_name, new_name)
+                if hasattr(self.fret_tab, 'histogram_widget') and hasattr(
+                    self.fret_tab.histogram_widget, 'rename_dataset'
+                ):
+                    self.fret_tab.histogram_widget.rename_dataset(
+                        old_name, new_name
+                    )
+
+            # Notify Filter Tab
+            if (
+                hasattr(self, 'filter_tab')
+                and self.filter_tab
+                and hasattr(self.filter_tab, 'histogram_widget')
+                and hasattr(self.filter_tab.histogram_widget, 'rename_dataset')
+            ):
+                self.filter_tab.histogram_widget.rename_dataset(
+                    old_name, new_name
+                )
+
     def reset_layer_choices(self):
         """Reset the image layer checkable combobox choices."""
         if getattr(self, '_resetting_layer_choices', False):
@@ -5120,6 +5171,11 @@ class PlotterWidget(QWidget):
                 and "G_original" in layer.metadata
                 and "S_original" in layer.metadata
             ]
+            image_layers_by_id = {
+                id(layer): layer.name
+                for layer in self.viewer.layers
+                if isinstance(layer, Image)
+            }
             mask_layer_names = [
                 layer.name
                 for layer in self.viewer.layers
@@ -5131,6 +5187,22 @@ class PlotterWidget(QWidget):
                 if isinstance(layer, (Labels, Shapes))
             }
 
+            # If image layers were renamed, update selections and notify tabs
+            old_image_layers_by_id = getattr(self, '_image_layers_by_id', {})
+            renamed_images = {
+                old_name: new_name
+                for layer_id, new_name in image_layers_by_id.items()
+                if layer_id in old_image_layers_by_id
+                and (old_name := old_image_layers_by_id[layer_id]) != new_name
+            }
+            if renamed_images:
+                previously_selected = [
+                    renamed_images.get(name, name)
+                    for name in previously_selected
+                ]
+                self._notify_tabs_of_renamed_layers(renamed_images)
+            self._image_layers_by_id = image_layers_by_id
+
             # If mask layers were renamed, keep combobox and assignments synced
             # by matching layer object identity across updates.
             old_mask_layers_by_id = getattr(self, '_mask_layers_by_id', {})
@@ -5140,6 +5212,7 @@ class PlotterWidget(QWidget):
                 if layer_id in old_mask_layers_by_id
                 and old_mask_layers_by_id[layer_id] != new_name
             }
+            self._mask_layers_by_id = mask_layers_by_id
 
             if mask_layer_combobox_current_text in renamed_masks:
                 mask_layer_combobox_current_text = renamed_masks[
@@ -5222,26 +5295,29 @@ class PlotterWidget(QWidget):
             # quadratic. We also drop ids of layers that have been
             # removed so the set doesn't grow unbounded.
             current_layer_ids = {
-                id(self.viewer.layers[name])
-                for name in layer_names + mask_layer_names
+                id(layer)
+                for layer in self.viewer.layers
+                if isinstance(layer, (Image, Labels, Shapes))
             }
             self._connected_layer_ids.intersection_update(current_layer_ids)
 
-            for layer_name in layer_names + mask_layer_names:
-                layer = self.viewer.layers[layer_name]
+            for layer in self.viewer.layers:
                 layer_id = id(layer)
                 if layer_id in self._connected_layer_ids:
                     continue
                 if isinstance(layer, Image):
                     layer.events.name.connect(self.reset_layer_choices)
-                if isinstance(layer, (Shapes, Labels)):
+                    self._connected_layer_ids.add(layer_id)
+                elif isinstance(layer, (Shapes, Labels)):
                     layer.events.name.connect(self.reset_layer_choices)
-                if isinstance(layer, Shapes):
-                    layer.events.data.connect(self._on_mask_data_changed)
-                if isinstance(layer, Labels):
-                    layer.events.paint.connect(self._on_mask_data_changed)
-                    layer.events.set_data.connect(self._on_mask_data_changed)
-                self._connected_layer_ids.add(layer_id)
+                    if isinstance(layer, Shapes):
+                        layer.events.data.connect(self._on_mask_data_changed)
+                    elif isinstance(layer, Labels):
+                        layer.events.paint.connect(self._on_mask_data_changed)
+                        layer.events.set_data.connect(
+                            self._on_mask_data_changed
+                        )
+                    self._connected_layer_ids.add(layer_id)
 
             self._mask_layers_by_id = mask_layers_by_id
 


### PR DESCRIPTION
This pull request adds robust support for layer renaming throughout the napari-phasors plugin, ensuring that renaming image layers (and related datasets) keeps all user selections, derived layers, and internal state consistent across tabs and widgets. The changes include new tests, utility methods, and updates to synchronize layer names in all relevant UI components and data structures.

Fixes #273 
Fixes #274

**Layer renaming support and synchronization:**

* Added new tests in `test_plotter.py` to ensure that renaming image layers updates the checkable combobox and maintains selection, including cases where phasor metadata is added after renaming.
* Implemented logic in `PlotterWidget.reset_layer_choices` to detect renamed image layers, update selected items, and notify all tabs and histogram widgets of the change. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R5094-R5144) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R5190-R5205)
* Added a `_notify_tabs_of_renamed_layers` method in `plotter.py` to propagate renames to Phasor Mapping, Components, FRET, and Filter tabs and their histogram widgets.

**Tab and widget updates for renaming:**

* Added `rename_layer` methods to `phasor_mapping_tab.py`, `components_tab.py`, and `fret_tab.py` to update internal dictionaries and rename derived layers when a base layer is renamed. [[1]](diffhunk://#diff-0026ef05339fb07a2141f342360f557f4be44831336997b6a302d05cc8629c79R1441-R1467) [[2]](diffhunk://#diff-ac4cac72bd494410a0f94b46d2da459ae6e75afbb54ff6aab5fb1753d226d3dcR3900-R3912) [[3]](diffhunk://#diff-5e26c33e175d2b0f7be20a900bea40091b4ee755b3a8e7f69b62ad4521034af9R1501-R1508)
* Added a `rename_dataset` method to `HistogramWidget` (in `_utils.py`), ensuring that all internal tracking dictionaries (datasets, colors, group assignments, counts) are updated when a dataset is renamed.
* Added a test for `HistogramWidget.rename_dataset` to verify correct updates to internal state.

**Internal and event handling improvements:**

* Modified `reset_layer_choices` in `plotter.py` to track and update image and mask layer names by object identity, ensuring correct handling of renames and event connections. [[1]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R5174-R5178) [[2]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662R5215) [[3]](diffhunk://#diff-1ceee67ad2fccc5b38e4ae495c80a0b614dafdce38f61c56e445807fe2e0c662L5225-R5319)

These changes together ensure seamless user experience when renaming layers, with all UI elements and analysis results staying in sync.