### PR TITLE
feat: Axis selection option in the Custom Import widget (#277)

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -228,6 +228,60 @@ def napari_get_reader(
         return None
 
 
+def _clamp_harmonics(
+    harmonics: Union[int, Sequence[int], None], n_samples: int
+):
+    """Clamp or convert the requested harmonics to what's valid for n_samples.
+
+    The maximum usable harmonic is `n_samples // 2`. If `harmonics` is None,
+    it defaults to `[1, 2]`. If the requested harmonics exceed the maximum,
+    they are clamped down. If no valid harmonics remain, a ValueError is
+    raised.
+    """
+    max_h = n_samples // 2
+    if max_h < 1:
+        raise ValueError(
+            f"Not enough samples ({n_samples}) to compute phasor harmonics; need at least 2 samples."
+        )
+
+    # Default harmonics
+    if harmonics is None:
+        harmonics = [1, 2]
+
+    # 'all' means 1..max_h
+    if harmonics == "all":
+        return list(range(1, max_h + 1))
+
+    # Single int -> list
+    if isinstance(harmonics, int):
+        h = min(harmonics, max_h)
+        return [h]
+
+    # Iterable of ints
+    out = []
+    for h in harmonics:
+        try:
+            hi = int(h)
+        except (TypeError, ValueError):
+            continue
+        if hi <= 0:
+            continue
+        out.append(min(hi, max_h))
+
+    # Remove duplicates while preserving order
+    seen = set()
+    res = []
+    for v in out:
+        if v not in seen:
+            seen.add(v)
+            res.append(v)
+
+    if not res:
+        # fallback to harmonic 1 when possible
+        return [1]
+    return res
+
+
 def ambiguous_file_reader(
     path: str,
     reader_options: dict | None = None,
@@ -283,30 +337,32 @@ def raw_file_reader(
         in 'metadata' contain phasor coordinates as columns 'G' and 'S'.
 
     """
-    # Set default harmonics if None is passed
-    if harmonics is None:
-        harmonics = [1, 2]
     filename, file_extension = _get_filename_extension(path)
+
+    # Read SDT multi-file special case
     if file_extension == ".sdt":
-        # Try reading .sdt with increasing 'index' numbers to collect all files as channels
         i = 0
-        raw_data = []
+        raw_list = []
         while True:
             try:
                 _data = extension_mapping["raw"][".sdt"](path, {"index": i})
-                raw_data.append(_data)
+                raw_list.append(_data)
                 i += 1
             except IndexError:
                 break
-        # Stack list of xarrays in a new axis "C" (shapes must match)
-        for _data in raw_data:
+        for _d in raw_list:
             assert (
-                _data.shape == raw_data[0].shape
+                _d.shape == raw_list[0].shape
             ), "Shapes from files in .sdt do not match!"
-        raw_data = xr.concat(raw_data, dim="C")
+        raw_data = xr.concat(raw_list, dim="C")
     else:
+        # Remove widget-level option 'phasor_axis' before calling IO
+        filtered_reader_options = (
+            reader_options.copy() if reader_options else {}
+        )
+        filtered_reader_options.pop('phasor_axis', None)
         raw_data = extension_mapping["raw"][file_extension](
-            path, reader_options
+            path, filtered_reader_options
         )
 
     settings = {}
@@ -322,12 +378,19 @@ def raw_file_reader(
     has_dims = hasattr(raw_data, 'dims')
     raw_dims = tuple(raw_data.dims) if has_dims else ()
 
-    # Determine the number of steps for the progress bar
+    # Set default harmonics if None is passed
+    if harmonics is None:
+        harmonics = [1, 2]
+
+    # Determine progress bar steps: per-channel if iter_axis present, else per-harmonic
     if iter_axis is not None and iter_axis in raw_dims:
-        iter_axis_index = raw_dims.index(iter_axis)
-        n_steps = raw_data.shape[iter_axis_index]
+        try:
+            iter_axis_index = raw_dims.index(iter_axis)
+            n_steps = int(raw_data.shape[iter_axis_index])
+        except (ValueError, IndexError, TypeError):
+            n_steps = 1
     else:
-        n_steps = len(harmonics) if isinstance(harmonics, list) else 1
+        n_steps = len(harmonics) if isinstance(harmonics, (list, tuple)) else 1
 
     pbr = show_activity_progress(
         desc=f"Reading {filename}...", total=n_steps + 1
@@ -336,7 +399,17 @@ def raw_file_reader(
     try:
         if iter_axis is None or iter_axis not in raw_dims:
             # Handle files without iteration axis or when keepdims=False squeezed it out
-            if file_extension in [".tif", ".tiff"]:
+            # Allow explicit override of histogram axis via reader options
+            axis_override = None
+            if reader_options and 'phasor_axis' in reader_options:
+                try:
+                    axis_override = int(reader_options.get('phasor_axis'))
+                except (TypeError, ValueError):
+                    axis_override = None
+
+            if axis_override is not None:
+                axis = axis_override
+            elif file_extension in [".tif", ".tiff"]:
                 axis = 0
             elif has_dims and "H" in raw_dims:
                 axis = raw_dims.index("H")
@@ -363,16 +436,27 @@ def raw_file_reader(
             if file_extension not in [".lsm", ".tif", ".tiff"]:
                 settings['channel'] = 0
 
+            # Determine number of histogram samples along selected axis
+            try:
+                n_samples = raw_data.shape[axis]
+            except (IndexError, TypeError, AttributeError):
+                try:
+                    n_samples = raw_data.values.shape[axis]
+                except (IndexError, TypeError, AttributeError):
+                    n_samples = 0
+
+            try:
+                harmonics_to_use = _clamp_harmonics(harmonics, int(n_samples))
+            except (ValueError, TypeError) as e:
+                show_error(str(e))
+                return []
+
             pbr.set_description("Computing phasor transform...")
             mean_intensity_image, G_image, S_image = phasor_from_signal(
-                raw_data, axis=axis, harmonic=harmonics
+                raw_data, axis=axis, harmonic=harmonics_to_use
             )
             pbr.update(n_steps)
-            channel_suffix = (
-                " Intensity Image"
-                if iter_axis is None
-                else " Intensity Image: Channel 0"
-            )
+            channel_suffix = " Intensity Image"
             add_kwargs = {
                 "name": f"{filename}{channel_suffix}",
                 "metadata": {
@@ -387,7 +471,7 @@ def raw_file_reader(
                     "S": S_image,
                     "G_original": G_image.copy(),
                     "S_original": S_image.copy(),
-                    "harmonics": harmonics,
+                    "harmonics": harmonics_to_use,
                 },
             }
             layers.append((mean_intensity_image, add_kwargs))
@@ -408,7 +492,11 @@ def raw_file_reader(
                 pbr.set_description(f"Channel {channel_pos + 1}/{n_channels}")
                 pbr.update(1)
                 channel_data = raw_data.isel({iter_axis: channel_pos})
-                histogram_axis = channel_data.dims.index("H")
+                histogram_axis = (
+                    channel_data.dims.index("H")
+                    if "H" in channel_data.dims
+                    else 0
+                )
 
                 # Calculate summed signal over spatial dimensions for this channel
                 axes_to_sum = tuple(
@@ -431,15 +519,30 @@ def raw_file_reader(
                 except (TypeError, ValueError):
                     channel_settings['channel'] = channel_label
 
+                # Determine samples for this histogram axis and clamp harmonics
+                try:
+                    n_samples = channel_data.shape[histogram_axis]
+                except (IndexError, TypeError, AttributeError):
+                    try:
+                        n_samples = channel_data.values.shape[histogram_axis]
+                    except (IndexError, TypeError, AttributeError):
+                        n_samples = 0
+
+                try:
+                    harmonics_to_use = _clamp_harmonics(
+                        harmonics, int(n_samples)
+                    )
+                except (ValueError, TypeError) as e:
+                    show_error(str(e))
+                    return []
+
                 mean_intensity_image, G_image, S_image = phasor_from_signal(
                     channel_data,
                     axis=histogram_axis,
-                    harmonic=harmonics,
+                    harmonic=harmonics_to_use,
                 )
                 add_kwargs = {
-                    "name": (
-                        f"{filename} Intensity Image: Channel {channel_label}"
-                    ),
+                    "name": f"{filename} Intensity Image: Channel {channel_label}",
                     "metadata": {
                         "original_mean": mean_intensity_image,
                         "settings": channel_settings,
@@ -452,12 +555,13 @@ def raw_file_reader(
                         "S": S_image,
                         "G_original": G_image.copy(),
                         "S_original": S_image.copy(),
-                        "harmonics": harmonics,
+                        "harmonics": harmonics_to_use,
                     },
                 }
                 layers.append((mean_intensity_image, add_kwargs))
     finally:
         pbr.close()
+
     # Set colormaps if multichannel image
     if len(layers) == 2:
         # add colormaps MAGENTA_GREEN
@@ -669,12 +773,18 @@ def processed_file_reader(
     if harmonics is None:
         harmonics = 'all'
     filename, file_extension = _get_filename_extension(path)
+
+    # Prepare reader options: remove widget-only keys and ensure harmonic present
+    filtered_reader_options = reader_options.copy() if reader_options else {}
+    filtered_reader_options.pop('phasor_axis', None)
+    if 'harmonic' not in filtered_reader_options:
+        filtered_reader_options['harmonic'] = harmonics
+
     pbr = show_activity_progress(desc=f"Loading {filename}...", total=3)
     try:
-        reader_options = reader_options or {"harmonic": harmonics}
         mean_intensity_image, real, imag, attrs = extension_mapping[
             "processed"
-        ][file_extension](path, reader_options)
+        ][file_extension](path, filtered_reader_options)
         pbr.update(1)
         if "description" in attrs:
             # HTML-unescape the description to handle tifffile HTML encoding

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -277,8 +277,10 @@ def _clamp_harmonics(
             res.append(v)
 
     if not res:
-        # fallback to harmonic 1 when possible
-        return [1]
+        raise ValueError(
+            f"No valid harmonics remain for {n_samples} samples. "
+            f"Requested harmonics: {harmonics}."
+        )
     return res
 
 
@@ -370,11 +372,6 @@ def raw_file_reader(
             ), "Shapes from files in .sdt do not match!"
         raw_data = xr.concat(raw_list, dim="C")
     else:
-        # Remove widget-level option 'phasor_axis' before calling IO
-        filtered_reader_options = (
-            reader_options.copy() if reader_options else {}
-        )
-        filtered_reader_options.pop('phasor_axis', None)
         raw_data = extension_mapping["raw"][file_extension](
             path, filtered_reader_options
         )
@@ -409,19 +406,10 @@ def raw_file_reader(
     try:
         if iter_axis is None or iter_axis not in raw_dims:
             # Handle files without iteration axis or when keepdims=False squeezed it out
-            # Allow explicit override of histogram axis via reader options
-            axis_override = None
-            if reader_options and 'phasor_axis' in reader_options:
-                try:
-                    axis_override = int(reader_options.get('phasor_axis'))
-                except (TypeError, ValueError):
-                    axis_override = None
-
             if axis_override is not None:
                 axis = axis_override
             elif file_extension in [".tif", ".tiff"]:
-                # Use explicit override from reader_options (set by widget), otherwise default to 0
-                axis = axis_override if axis_override is not None else 0
+                axis = 0
             elif has_dims and "H" in raw_dims:
                 axis = raw_dims.index("H")
             elif has_dims and "C" in raw_dims:

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -337,6 +337,20 @@ def raw_file_reader(
         in 'metadata' contain phasor coordinates as columns 'G' and 'S'.
 
     """
+    # Set default harmonics if None is passed
+    if harmonics is None:
+        harmonics = [1, 2]
+
+    # Extract phasor_axis from reader_options (widget-level parameter)
+    # This should not be passed to IO functions
+    axis_override = None
+    filtered_reader_options = reader_options.copy() if reader_options else {}
+    if 'phasor_axis' in filtered_reader_options:
+        try:
+            axis_override = int(filtered_reader_options.pop('phasor_axis'))
+        except (KeyError, ValueError, TypeError):
+            filtered_reader_options.pop('phasor_axis', None)
+
     filename, file_extension = _get_filename_extension(path)
 
     # Read SDT multi-file special case
@@ -378,10 +392,6 @@ def raw_file_reader(
     has_dims = hasattr(raw_data, 'dims')
     raw_dims = tuple(raw_data.dims) if has_dims else ()
 
-    # Set default harmonics if None is passed
-    if harmonics is None:
-        harmonics = [1, 2]
-
     # Determine progress bar steps: per-channel if iter_axis present, else per-harmonic
     if iter_axis is not None and iter_axis in raw_dims:
         try:
@@ -410,7 +420,8 @@ def raw_file_reader(
             if axis_override is not None:
                 axis = axis_override
             elif file_extension in [".tif", ".tiff"]:
-                axis = 0
+                # Use explicit override from reader_options (set by widget), otherwise default to 0
+                axis = axis_override if axis_override is not None else 0
             elif has_dims and "H" in raw_dims:
                 axis = raw_dims.index("H")
             elif has_dims and "C" in raw_dims:
@@ -492,11 +503,15 @@ def raw_file_reader(
                 pbr.set_description(f"Channel {channel_pos + 1}/{n_channels}")
                 pbr.update(1)
                 channel_data = raw_data.isel({iter_axis: channel_pos})
-                histogram_axis = (
-                    channel_data.dims.index("H")
-                    if "H" in channel_data.dims
-                    else 0
-                )
+                # Allow override of histogram axis via reader options
+                if axis_override is not None:
+                    histogram_axis = axis_override
+                else:
+                    histogram_axis = (
+                        channel_data.dims.index("H")
+                        if "H" in channel_data.dims
+                        else 0
+                    )
 
                 # Calculate summed signal over spatial dimensions for this channel
                 axes_to_sum = tuple(

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -32,9 +32,7 @@ def test_reader_ptu():
     )
     assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
-    assert (
-        layer_data_tuple[1]["name"] == "test_file Intensity Image: Channel 0"
-    )
+    assert layer_data_tuple[1]["name"] == "test_file Intensity Image"
     metadata = layer_data_tuple[1]["metadata"]
     assert "G" in metadata
     assert "S" in metadata
@@ -355,8 +353,10 @@ def test_reader_tiff_extension():
     assert callable(reader)
 
 
-def test_raw_reader_tiff_ignores_widget_axis_option(monkeypatch):
-    """TIFF raw loading should ignore widget-only axis options passed via reader_options."""
+def test_raw_reader_tiff_does_not_forward_widget_axis_option_to_imread(
+    monkeypatch,
+):
+    """TIFF raw loading should not forward widget-only options (e.g. `phasor_axis`) into the IO/read layer."""
 
     def fake_imread(path):
         return np.arange(24, dtype=np.float32).reshape(2, 3, 4)
@@ -646,6 +646,37 @@ def test_ambiguous_file_reader_raises_combined_error(monkeypatch):
     assert "processed_file_reader error" in message
     assert "raw exploded" in message
     assert "processed exploded" in message
+
+
+def test_clamp_harmonics():
+    from napari_phasors._reader import _clamp_harmonics
+
+    # None defaults to [1, 2]
+    assert _clamp_harmonics(None, 4) == [1, 2]
+    # 'all' returns all up to n_samples // 2
+    assert _clamp_harmonics("all", 6) == [1, 2, 3]
+    # Integer clamps to max_h
+    assert _clamp_harmonics(3, 4) == [2]
+    # List of valid harmonics
+    assert _clamp_harmonics([1, 2], 6) == [1, 2]
+    # Clamping down excessive harmonics
+    assert _clamp_harmonics([1, 4], 4) == [1, 2]
+    # Handling duplicates and sorting
+    assert _clamp_harmonics([2, 1, 2], 6) == [2, 1]
+
+    # ValueError raised when no valid harmonics remain
+    with pytest.raises(ValueError, match="No valid harmonics remain"):
+        _clamp_harmonics([], 4)
+
+    with pytest.raises(ValueError, match="No valid harmonics remain"):
+        _clamp_harmonics([-1, -2], 4)
+
+    with pytest.raises(ValueError, match="No valid harmonics remain"):
+        _clamp_harmonics(["invalid"], 4)
+
+    # ValueError raised when not enough samples
+    with pytest.raises(ValueError, match="Not enough samples"):
+        _clamp_harmonics([1], 1)
 
 
 # TODO: Add tests for .tif files

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -355,6 +355,35 @@ def test_reader_tiff_extension():
     assert callable(reader)
 
 
+def test_raw_reader_tiff_ignores_widget_axis_option(monkeypatch):
+    """TIFF raw loading should ignore widget-only axis options passed via reader_options."""
+
+    def fake_imread(path):
+        return np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+
+    def fake_phasor_from_signal(signal, axis, harmonic):
+        mean_image = np.zeros((2, 4), dtype=np.float32)
+        g_image = np.zeros((2, 2, 4), dtype=np.float32)
+        s_image = np.zeros((2, 2, 4), dtype=np.float32)
+        return mean_image, g_image, s_image
+
+    monkeypatch.setattr(reader_module.tifffile, "imread", fake_imread)
+    monkeypatch.setattr(
+        reader_module,
+        "phasor_from_signal",
+        fake_phasor_from_signal,
+    )
+
+    layers = reader_module.raw_file_reader(
+        "example.tif",
+        reader_options={"phasor_axis": 1},
+    )
+
+    assert len(layers) == 1
+    assert layers[0][0].shape == (2, 4)
+    assert layers[0][1]["metadata"]["harmonics"] == [1]
+
+
 def test_reader_multi_file_raw_dispatches_to_stack_reader(monkeypatch):
     """Test that a list of raw files is handled via raw_file_stack_reader."""
     paths = ["slice_01.lsm", "slice_02.lsm", "slice_03.lsm"]

--- a/src/napari_phasors/_tests/test_sample_data.py
+++ b/src/napari_phasors/_tests/test_sample_data.py
@@ -19,10 +19,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     )
     assert layer_data_tuple[0].shape == (256, 256)
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
-    assert (
-        layer_data_tuple[1]["name"]
-        == "Convallaria_$EI0S Intensity Image: Channel 0"
-    )
+    assert layer_data_tuple[1]["name"] == "Convallaria_$EI0S Intensity Image"
     metadata = layer_data_tuple[1]["metadata"]
     assert "G" in metadata
     assert "S" in metadata
@@ -47,7 +44,7 @@ def test_convallaria_FLIM_sample_data(make_napari_viewer):
     assert "name" in layer_data_tuple[1] and "metadata" in layer_data_tuple[1]
     assert (
         layer_data_tuple[1]["name"]
-        == "Calibration_Rhodamine110_$EI0S Intensity Image: Channel 0"
+        == "Calibration_Rhodamine110_$EI0S Intensity Image"
     )
     metadata = layer_data_tuple[1]["metadata"]
     assert "G" in metadata

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 from phasorpy.datasets import fetch
 from phasorpy.io import (
     phasor_from_ometiff,
@@ -444,6 +445,40 @@ def test_phasor_transform_lsm_widget(make_napari_viewer):
     assert viewer.layers[1].data.shape == (512, 512)
     assert viewer.layers[1].metadata["G"].shape == (1, 512, 512)
     assert list(viewer.layers[1].metadata["harmonics"]) == [2]
+
+
+def test_lsm_widget_axis_selection_updates_signal_plot(
+    make_napari_viewer, monkeypatch
+):
+    """Changing the axis combobox should update the selected axis and refresh the preview plot."""
+    viewer = make_napari_viewer()
+    fake_signal = xr.DataArray(
+        np.arange(24, dtype=np.float32).reshape(2, 3, 4),
+        dims=("Z", "Y", "H"),
+    )
+
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+    monkeypatch.setattr(
+        widget, "_get_preview_signal_data", lambda: fake_signal
+    )
+    widget._update_axis_options()
+    widget._update_signal_plot()
+
+    assert widget.axis_combo is not None
+    assert widget.axis_combo.currentText() == "Auto"
+    assert widget.reader_options.get("phasor_axis") is None
+    assert widget.axis_combo.count() == 4
+
+    initial_plot = widget.ax.get_lines()[0].get_ydata().copy()
+
+    widget.axis_combo.setCurrentIndex(2)
+
+    assert widget.reader_options["phasor_axis"] == 1
+    updated_plot = widget.ax.get_lines()[0].get_ydata()
+    expected_plot = fake_signal.values.sum(axis=(0, 2))
+
+    np.testing.assert_array_equal(updated_plot, expected_plot)
+    assert not np.array_equal(initial_plot, updated_plot)
 
 
 def test_phasor_transform_czi_widget(make_napari_viewer):

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -481,6 +481,42 @@ def test_lsm_widget_axis_selection_updates_signal_plot(
     assert not np.array_equal(initial_plot, updated_plot)
 
 
+def test_tiff_widget_axis_selection_updates_signal_plot(
+    make_napari_viewer, monkeypatch
+):
+    """Changing the axis combobox for a TIFF file should update the selected axis and refresh the preview plot."""
+    viewer = make_napari_viewer()
+    fake_signal = xr.DataArray(
+        np.arange(24, dtype=np.float32).reshape(2, 3, 4),
+        dims=("Z", "Y", "H"),
+    )
+
+    # LsmWidget handles both LSM and TIFF files; passing a TIFF extension (like "example.tif")
+    # will set self._is_lsm = False.
+    widget = LsmWidget(viewer, path="example.tif")
+    monkeypatch.setattr(
+        widget, "_get_preview_signal_data", lambda: fake_signal
+    )
+    widget._update_axis_options()
+    widget._update_signal_plot()
+
+    assert widget.axis_combo is not None
+    assert widget.axis_combo.currentText() == "Auto"
+    assert widget.reader_options.get("phasor_axis") is None
+    assert widget.axis_combo.count() == 4
+
+    initial_plot = widget.ax.get_lines()[0].get_ydata().copy()
+
+    widget.axis_combo.setCurrentIndex(2)
+
+    assert widget.reader_options["phasor_axis"] == 1
+    updated_plot = widget.ax.get_lines()[0].get_ydata()
+    expected_plot = fake_signal.values.sum(axis=(0, 2))
+
+    np.testing.assert_array_equal(updated_plot, expected_plot)
+    assert not np.array_equal(initial_plot, updated_plot)
+
+
 def test_phasor_transform_czi_widget(make_napari_viewer):
     """Test CziWidget from PhasorTransform widget."""
     viewer = make_napari_viewer()

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -266,7 +266,7 @@ def test_phasor_transform_fbd_widget(make_napari_viewer):
     # Click button of phasor transform and check layers
     widget.btn.click()
     assert len(viewer.layers) == 1
-    assert viewer.layers[0].name == "test_file$EI0S Intensity Image: Channel 0"
+    assert viewer.layers[0].name == "test_file$EI0S Intensity Image"
     assert viewer.layers[0].data.shape == (256, 256)
     # Check phasor data in metadata
     assert "G" in viewer.layers[0].metadata

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -427,9 +427,6 @@ class AdvancedOptionsWidget(QWidget):
         # Axis selection for phasor calculation (updated from preview)
         self._axis_widget()
 
-        # Axis selection for phasor calculation (updated from preview)
-        self._axis_widget()
-
     def _add_shape_preview_widget(self):
         """Add a label showing estimated output shape for current options."""
         self.shape_preview_label = QLabel("Estimated output shape: N/A")

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -424,6 +424,9 @@ class AdvancedOptionsWidget(QWidget):
 
         self.mainLayout.addWidget(self.canvas)
 
+        # Axis selection for phasor calculation (updated from preview)
+        self._axis_widget()
+
     def _add_shape_preview_widget(self):
         """Add a label showing estimated output shape for current options."""
         self.shape_preview_label = QLabel("Estimated output shape: N/A")
@@ -435,6 +438,92 @@ class AdvancedOptionsWidget(QWidget):
                 )
                 return
         self.mainLayout.addWidget(self.shape_preview_label)
+
+    def _axis_widget(self):
+        """Add axis selection combobox to choose which axis to compute phasor along."""
+        axis_layout = QHBoxLayout()
+        axis_layout.addWidget(QLabel("Phasor axis: "))
+
+        self.axis_combo = QComboBox()
+        self.axis_combo.addItem("Auto")
+        self.axis_combo.currentIndexChanged.connect(self._on_axis_changed)
+        axis_layout.addWidget(self.axis_combo)
+        axis_layout.addStretch()
+        self.mainLayout.addLayout(axis_layout)
+
+    def _update_axis_options(self):
+        """Refresh axis options based on preview signal shape and dims."""
+        if not hasattr(self, 'axis_combo'):
+            return
+
+        preview = self._get_preview_signal_data()
+        # Determine shape and labels
+        if preview is None:
+            shape = ()
+            labels = []
+        else:
+            if hasattr(preview, 'dims'):
+                labels = [str(d).upper() for d in preview.dims]
+                shape = tuple(preview.shape)
+            else:
+                arr = np.asarray(preview)
+                shape = arr.shape
+                labels = _default_axis_labels(len(shape))
+
+        # Build items: prefer dimension name, show size
+        items = ["Auto"]
+        for i, s in enumerate(shape):
+            name = labels[i] if i < len(labels) else f"Axis {i}"
+            items.append(f"{name} (size={s})")
+
+        # Preserve previous selection text if possible
+        prev_text = (
+            self.axis_combo.currentText()
+            if self.axis_combo.count() > 0
+            else None
+        )
+
+        self.axis_combo.blockSignals(True)
+        self.axis_combo.clear()
+        for it in items:
+            self.axis_combo.addItem(it)
+        self.axis_combo.blockSignals(False)
+
+        # Restore selection if still available
+        if prev_text and prev_text in items:
+            self.axis_combo.setCurrentText(prev_text)
+        else:
+            # default to Auto
+            self.axis_combo.setCurrentIndex(0)
+
+        # Update reader_options with current selection
+        self._apply_axis_selection_to_options()
+
+    def _on_axis_changed(self, index):
+        self._apply_axis_selection_to_options()
+        self._update_shape_preview()
+        # Update signal plot if available to reflect new axis selection
+        if hasattr(self, '_update_signal_plot'):
+            self._update_signal_plot()
+
+    def _apply_axis_selection_to_options(self):
+        """Store selected axis index into `self.reader_options['phasor_axis']`.
+
+        Use `None` for Auto.
+        """
+        if not hasattr(self, 'axis_combo'):
+            return
+        txt = self.axis_combo.currentText()
+        if not txt or txt == "Auto":
+            self.reader_options.pop('phasor_axis', None)
+            return
+        # extract axis index from format "NAME (size=...)" -> find first occurrence of '(' and infer index via position
+        # We assume items are in order, so index = combo index - 1
+        idx = self.axis_combo.currentIndex() - 1
+        if idx >= 0:
+            self.reader_options['phasor_axis'] = idx
+        else:
+            self.reader_options.pop('phasor_axis', None)
 
     def _update_shape_preview(self):
         """Update estimated output shape when reader options change."""
@@ -600,6 +689,7 @@ class AdvancedOptionsWidget(QWidget):
                     title = 'Signal Preview'
 
             self._update_harmonic_slider()
+            self._update_axis_options()
 
             self.ax.set_xlabel('Time / Histogram Bin')
             self.ax.set_ylabel('Total Signal (sum over pixels)')
@@ -1475,6 +1565,10 @@ class LsmWidget(AdvancedOptionsWidget):
 
         self._harmonic_widget()
 
+        # Add axis selection widget before the transform button
+        self._axis_widget()
+        self._update_axis_options()
+
         self.btn = QPushButton("Phasor Transform")
         self.btn.clicked.connect(
             lambda: self._on_click(
@@ -1502,6 +1596,34 @@ class LsmWidget(AdvancedOptionsWidget):
                 f"Error reading {'LSM' if self._is_lsm else 'TIFF'} signal: {str(e)}"
             )
             return None
+
+    def _collapse_signal_for_plot(self, signal):
+        """Collapse signal to 1-D for plotting, respecting selected axis.
+
+        This override ensures the signal plot uses the user-selected axis
+        from the axis combobox.
+        """
+        array = np.asarray(signal)
+        if array.ndim == 0:
+            return np.array([float(array)])
+        if array.ndim == 1:
+            return array
+
+        # Get selected axis from reader_options, default to auto-detection
+        selected_axis = self.reader_options.get('phasor_axis', None)
+
+        if selected_axis is not None:
+            # Use user-selected axis
+            signal_axis = selected_axis
+        else:
+            # Use auto-detection
+            axis_labels = None
+            if hasattr(signal, "dims"):
+                axis_labels = tuple(signal.dims)
+            signal_axis = self._choose_signal_axis(array.shape, axis_labels)
+
+        axes_to_sum = tuple(i for i in range(array.ndim) if i != signal_axis)
+        return np.sum(array, axis=axes_to_sum)
 
     def _update_signal_plot(self):
         """Update the signal plot for LSM/TIFF files (spectral data)."""

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -427,6 +427,9 @@ class AdvancedOptionsWidget(QWidget):
         # Axis selection for phasor calculation (updated from preview)
         self._axis_widget()
 
+        # Axis selection for phasor calculation (updated from preview)
+        self._axis_widget()
+
     def _add_shape_preview_widget(self):
         """Add a label showing estimated output shape for current options."""
         self.shape_preview_label = QLabel("Estimated output shape: N/A")


### PR DESCRIPTION
This pull request introduces significant improvements to axis selection and harmonics handling for phasor transforms in the `napari_phasors` plugin. The main changes add explicit support for user selection of the histogram axis (phasor axis) via the UI, ensure that harmonics are always valid for the selected axis, and make the widget and reader logic more robust and testable. Additionally, new tests have been added to verify correct behavior for axis selection and harmonics clamping.

Closes #277 

**Axis selection improvements:**

* Added an axis selection combobox (`phasor_axis`) to the widget UI, allowing users to choose which axis to compute the phasor transform along. The selection is stored in `reader_options` and updates the preview plot and output shape accordingly. (`src/napari_phasors/_widget.py`, [[1]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR427-R432) [[2]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR445-R530) [[3]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR1571-R1574)
* The selected axis is passed as a widget-only parameter (`phasor_axis`) and is stripped from `reader_options` before calling IO/read functions, ensuring separation of UI and backend logic. (`src/napari_phasors/_reader.py`, [[1]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R343-R379) [[2]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598L339-R424) [[3]](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R791-R802)

**Harmonics handling and validation:**

* Introduced `_clamp_harmonics` to ensure requested harmonics are valid for the number of histogram samples, with sensible defaults and error handling. Harmonics are now always clamped to the maximum valid value for the axis. (`src/napari_phasors/_reader.py`, [src/napari_phasors/_reader.pyR231-R284](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R231-R284), F63cc561L447R447, F63cc561L534R534, F63cc561L482R482, F63cc561L570R570)
* The harmonics actually used for the transform are stored in the layer metadata, not just the requested values. (`src/napari_phasors/_reader.py`, F63cc561L482R482, F63cc561L570R570)

**Testing and robustness:**

* Added tests for axis selection in both the widget and the raw reader, verifying that axis selection updates the preview plot and that widget-only axis options are ignored by the TIFF raw reader backend. (`src/napari_phasors/_tests/test_widget.py`, [[1]](diffhunk://#diff-a918119f4b439f5937b77c15179af7e000ad425fec46a2f13d0821657e4f8f0eR450-R519); `src/napari_phasors/_tests/test_reader.py`, [[2]](diffhunk://#diff-3daf1b61a9205179efcf379c8c1ea5be8e83fed84b074cc759bf63843cb7fb09R358-R386)
* Improved error handling and default behaviors when axis or harmonics selection is invalid or missing. (`src/napari_phasors/_reader.py`, [src/napari_phasors/_reader.pyR231-R284](diffhunk://#diff-15fce1bd85aa01df992a23b480e7d29c2407a4a6249ac549832c81e8989d2598R231-R284), F63cc561L447R447, F63cc561L534R534)

These changes make axis and harmonics selection more explicit, robust, and user-friendly, while ensuring correct backend behavior and better test coverage.