### PR TITLE
Add support for exporting labels layers and export masked OME-TIF (#261) (#264)

### DIFF
--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1391,21 +1391,21 @@ def test_writer_widget_mask_checkbox(make_napari_viewer, tmp_path):
     widget.export_layer_combobox.selectAll()
 
     # Verify checkbox is hidden
-    assert widget.mask_checkbox.isVisible() is False
+    assert widget.mask_checkbox.isHidden() is True
 
     # 2. Add a mask to the metadata and trigger metadata event
     layer.metadata["mask"] = np.ones((10, 10))
     layer.events.metadata()
 
     # Verify checkbox is visible
-    assert widget.mask_checkbox.isVisible() is True
+    assert widget.mask_checkbox.isHidden() is False
 
     # 3. Remove the mask and trigger metadata event
     del layer.metadata["mask"]
     layer.events.metadata()
 
     # Verify checkbox is hidden again
-    assert widget.mask_checkbox.isVisible() is False
+    assert widget.mask_checkbox.isHidden() is True
 
     # 4. Check saving calls write_ome_tiff with correct export_masked parameter
     # Restore mask

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1325,3 +1325,53 @@ def test_writer_widget_csv_coordinates_consistency_2d(
     # Check (1,1) -> 40
     val_11 = df[(df['y'] == 1) & (df['x'] == 1)]['value'].values[0]
     assert val_11 == 40
+
+
+def test_writer_widget_excludes_labels_layer(make_napari_viewer):
+    """Test that WriterWidget excludes Labels layers from populate combobox."""
+    viewer = make_napari_viewer()
+    viewer.add_image(np.random.random((10, 10)), name="my_image")
+    viewer.add_labels(np.zeros((10, 10), dtype=int), name="my_labels")
+
+    widget = WriterWidget(viewer)
+
+    items = [
+        widget.export_layer_combobox.itemText(i)
+        for i in range(widget.export_layer_combobox.count())
+    ]
+    assert "my_image" in items
+    assert "my_labels" not in items
+
+
+def test_export_labels_layer_as_colored_image(make_napari_viewer, tmp_path):
+    """Test that Labels layers are exported as colored images without colorbar."""
+    from PIL import Image as PILImage
+
+    from napari_phasors._writer import export_layer_as_image
+
+    viewer = make_napari_viewer()
+
+    # Create a labels layer with distinct labels
+    labels_data = np.zeros((10, 10), dtype=np.int32)
+    labels_data[2:5, 2:5] = 1
+    labels_data[6:9, 6:9] = 2
+    labels_layer = viewer.add_labels(labels_data, name="test_labels")
+
+    # Export labels layer as image
+    export_path = str(tmp_path / "test_labels_export.png")
+    export_layer_as_image(export_path, labels_layer, include_colorbar=True)
+
+    assert os.path.exists(export_path)
+
+    # Open and verify the image has color representation (not black and white)
+    img = PILImage.open(export_path)
+    img_data = np.array(img)
+
+    assert img_data.ndim == 3
+    assert img_data.shape[-1] in (3, 4)
+
+    # Check that it's colored (not grayscale where R=G=B for all pixels)
+    is_colored = np.any(img_data[..., 0] != img_data[..., 1]) or np.any(
+        img_data[..., 1] != img_data[..., 2]
+    )
+    assert is_colored, "Exported labels image is grayscale or black and white!"

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1375,3 +1375,56 @@ def test_export_labels_layer_as_colored_image(make_napari_viewer, tmp_path):
         img_data[..., 1] != img_data[..., 2]
     )
     assert is_colored, "Exported labels image is grayscale or black and white!"
+
+
+def test_writer_widget_mask_checkbox(make_napari_viewer, tmp_path):
+    """Test that WriterWidget mask checkbox behaves dynamically based on layer mask presence."""
+    viewer = make_napari_viewer()
+
+    # 1. Create a layer without phasor/mask data
+    data = np.random.random((10, 10))
+    layer = viewer.add_image(data, name="test_image")
+
+    widget = WriterWidget(viewer)
+
+    # Select layer
+    widget.export_layer_combobox.selectAll()
+
+    # Verify checkbox is hidden
+    assert widget.mask_checkbox.isVisible() is False
+
+    # 2. Add a mask to the metadata and trigger metadata event
+    layer.metadata["mask"] = np.ones((10, 10))
+    layer.events.metadata()
+
+    # Verify checkbox is visible
+    assert widget.mask_checkbox.isVisible() is True
+
+    # 3. Remove the mask and trigger metadata event
+    del layer.metadata["mask"]
+    layer.events.metadata()
+
+    # Verify checkbox is hidden again
+    assert widget.mask_checkbox.isVisible() is False
+
+    # 4. Check saving calls write_ome_tiff with correct export_masked parameter
+    # Restore mask
+    layer.metadata["mask"] = np.ones((10, 10))
+    layer.events.metadata()
+    widget.mask_checkbox.setChecked(True)
+
+    with patch("napari_phasors._widget.write_ome_tiff") as mock_write:
+        widget._save_file(
+            str(tmp_path / "output.ome.tif"),
+            "Phasor as OME-TIFF (*.ome.tif)",
+            selected_layers=["test_image"],
+            export_masked=True,
+        )
+        mock_write.assert_called_once_with(
+            str(tmp_path / "output.ome.tif"),
+            layer,
+            export_masked=True,
+        )
+
+    # Clean up
+    widget.close()

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -362,3 +362,68 @@ def test_write_ometif_does_not_save_z_spacing_for_2d_layer(tmp_path):
         description = json.loads(tif.pages[0].description)
         settings = json.loads(description["napari_phasors_settings"])
         assert "z_spacing_um" not in settings
+
+
+def test_write_ometif_masked(tmp_path):
+    """Test that write_ome_tiff with export_masked=True applies the mask."""
+    time_constants = [0.1, 1, 10]
+    raw_flim_data = make_raw_flim_data(time_constants=time_constants)
+    harmonic = [1, 2, 3]
+    intensity_image_layer = make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=harmonic
+    )
+
+    mask = np.ones((2, 5), dtype=int)
+    mask[0, 0] = 0
+    intensity_image_layer.metadata["mask"] = mask
+    intensity_image_layer.metadata["mask_invert"] = False
+
+    # 1. Export with export_masked=True
+    filepath_masked = os.path.join(tmp_path, "test_masked.ome.tif")
+    write_ome_tiff(
+        filepath_masked,
+        [
+            (
+                intensity_image_layer.data,
+                {"metadata": intensity_image_layer.metadata},
+            )
+        ],
+        export_masked=True,
+    )
+
+    assert os.path.exists(filepath_masked)
+
+    # Read back and verify G, S, and mean have NaN at [0,0]
+    reader = napari_get_reader(filepath_masked, harmonics=harmonic)
+    layer_data_list = reader(filepath_masked)
+    metadata_masked = layer_data_list[0][1]["metadata"]
+    mean_masked = layer_data_list[0][0]
+
+    assert np.isnan(mean_masked[0, 0])
+    assert np.isnan(metadata_masked["G"][:, 0, 0]).all()
+    assert np.isnan(metadata_masked["S"][:, 0, 0]).all()
+
+    # The rest should not be NaN
+    assert not np.isnan(mean_masked[0, 1:]).any()
+    assert not np.isnan(metadata_masked["G"][:, 0, 1:]).any()
+
+    # 2. Export with export_masked=False
+    filepath_unmasked = os.path.join(tmp_path, "test_unmasked.ome.tif")
+    write_ome_tiff(
+        filepath_unmasked,
+        [
+            (
+                intensity_image_layer.data,
+                {"metadata": intensity_image_layer.metadata},
+            )
+        ],
+        export_masked=False,
+    )
+
+    reader_unmasked = napari_get_reader(filepath_unmasked, harmonics=harmonic)
+    layer_data_list_unmasked = reader_unmasked(filepath_unmasked)
+    metadata_unmasked = layer_data_list_unmasked[0][1]["metadata"]
+    mean_unmasked = layer_data_list_unmasked[0][0]
+
+    assert not np.isnan(mean_unmasked[0, 0])
+    assert not np.isnan(metadata_unmasked["G"][:, 0, 0]).any()

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -143,6 +143,21 @@ def test_write_ometif(tmp_path):
     assert os.path.exists(
         os.path.join(tmp_path, "test_file_extension.ome.tif")
     )
+    write_ome_tiff(
+        os.path.join(tmp_path, "test_file_extension.ome.tiff"),
+        [
+            (
+                intensity_image_layer.data,
+                {"metadata": intensity_image_layer.metadata},
+            )
+        ],
+    )
+    assert os.path.exists(
+        os.path.join(tmp_path, "test_file_extension.ome.tiff")
+    )
+    assert not os.path.exists(
+        os.path.join(tmp_path, "test_file_extension.ome.tiff.ome.tif")
+    )
     reader = napari_get_reader(
         os.path.join(tmp_path, "test_file.ome.tif"), harmonics=harmonic
     )
@@ -427,3 +442,112 @@ def test_write_ometif_masked(tmp_path):
 
     assert not np.isnan(mean_unmasked[0, 0])
     assert not np.isnan(metadata_unmasked["G"][:, 0, 0]).any()
+
+
+def test_write_ometif_masked_phasor_same_ndim(tmp_path):
+    """Test write_ome_tiff with export_masked=True, has_phasor_data=True, and G.ndim == mask.ndim."""
+    from unittest.mock import patch
+
+    mean = np.ones((2, 5))
+    G = np.ones((2, 5))
+    S = np.ones((2, 5))
+    mask = np.ones((2, 5), dtype=int)
+    mask[0, 0] = 0  # invalid
+
+    metadata = {
+        "original_mean": mean,
+        "G_original": G,
+        "S_original": S,
+        "harmonics": [1],
+        "mask": mask,
+        "mask_invert": False,
+    }
+
+    filepath = os.path.join(tmp_path, "test_same_ndim.ome.tif")
+
+    with patch(
+        "napari_phasors._writer.phasor_to_ometiff"
+    ) as mock_phasor_to_ometiff:
+        write_ome_tiff(
+            filepath,
+            [(mean, {"metadata": metadata})],
+            export_masked=True,
+        )
+
+        mock_phasor_to_ometiff.assert_called_once()
+        args, kwargs = mock_phasor_to_ometiff.call_args
+
+        called_mean = args[1]
+        called_G = args[2]
+        called_S = args[3]
+
+        assert np.isnan(called_mean[0, 0])
+        assert np.isnan(called_G[0, 0])
+        assert np.isnan(called_S[0, 0])
+
+        assert not np.isnan(called_mean[0, 1:]).any()
+        assert not np.isnan(called_G[0, 1:]).any()
+        assert not np.isnan(called_S[0, 1:]).any()
+
+
+def test_write_ometif_masked_non_phasor(tmp_path):
+    """Test write_ome_tiff with export_masked=True for non-phasor layers."""
+    from unittest.mock import patch
+
+    from napari.layers import Image
+
+    # Case 1: data.ndim > mask_invalid.ndim
+    data_3d = np.ones((3, 2, 5))
+    mask_2d = np.ones((2, 5), dtype=int)
+    mask_2d[0, 0] = 0  # invalid
+
+    layer_3d = Image(data_3d, name="layer_3d")
+    layer_3d.metadata = {
+        "mask": mask_2d,
+        "mask_invert": False,
+    }
+
+    filepath_3d = os.path.join(tmp_path, "test_non_phasor_3d.ome.tif")
+
+    with patch("tifffile.imwrite") as mock_imwrite:
+        write_ome_tiff(
+            filepath_3d,
+            layer_3d,
+            export_masked=True,
+        )
+
+        mock_imwrite.assert_called_once()
+        args, kwargs = mock_imwrite.call_args
+        written_data = args[1]
+
+        assert written_data.shape == (3, 2, 5)
+        assert np.isnan(written_data[:, 0, 0]).all()
+        assert not np.isnan(written_data[:, 0, 1:]).any()
+
+    # Case 2: data.ndim == mask_invalid.ndim with mask_invert = True
+    data_2d = np.ones((2, 5))
+    mask_2d_invert = np.zeros((2, 5), dtype=int)
+    mask_2d_invert[0, 0] = 1  # invalid when invert=True
+
+    layer_2d = Image(data_2d, name="layer_2d")
+    layer_2d.metadata = {
+        "mask": mask_2d_invert,
+        "mask_invert": True,
+    }
+
+    filepath_2d = os.path.join(tmp_path, "test_non_phasor_2d.ome.tif")
+
+    with patch("tifffile.imwrite") as mock_imwrite:
+        write_ome_tiff(
+            filepath_2d,
+            layer_2d,
+            export_masked=True,
+        )
+
+        mock_imwrite.assert_called_once()
+        args, kwargs = mock_imwrite.call_args
+        written_data = args[1]
+
+        assert written_data.shape == (2, 5)
+        assert np.isnan(written_data[0, 0])
+        assert not np.isnan(written_data[0, 1:]).any()

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2285,6 +2285,15 @@ class WriterWidget(QWidget):
         self.colorbar_checkbox.setChecked(True)
         self.main_layout.addWidget(self.colorbar_checkbox)
 
+        self.mask_checkbox = QCheckBox("Export masked OME-TIFF")
+        self.mask_checkbox.setChecked(True)
+        self.mask_checkbox.hide()
+        self.main_layout.addWidget(self.mask_checkbox)
+
+        self.export_layer_combobox.selectionChanged.connect(
+            self._update_mask_checkbox_visibility
+        )
+
         self.search_button = QPushButton("Select Export Location and Name")
         self.search_button.clicked.connect(self._open_file_dialog)
         self.main_layout.addWidget(self.search_button)
@@ -2343,9 +2352,29 @@ class WriterWidget(QWidget):
 
         if file_path:
             include_colorbar = self.colorbar_checkbox.isChecked()
-            self._save_file(
-                file_path, selected_filter, include_colorbar, selected_layers
+            export_masked = (
+                self.mask_checkbox.isVisible()
+                and self.mask_checkbox.isChecked()
             )
+            self._save_file(
+                file_path,
+                selected_filter,
+                include_colorbar,
+                selected_layers,
+                export_masked=export_masked,
+            )
+
+    def _update_mask_checkbox_visibility(self):
+        """Show/hide the mask checkbox based on whether any selected layer has a mask."""
+        selected_layers = self.export_layer_combobox.checkedItems()
+        any_masked = False
+        for name in selected_layers:
+            if name in self.viewer.layers:
+                layer = self.viewer.layers[name]
+                if 'mask' in getattr(layer, 'metadata', {}):
+                    any_masked = True
+                    break
+        self.mask_checkbox.setVisible(any_masked)
 
     def _populate_combobox(self):
         """Populate combobox with image layers."""
@@ -2358,6 +2387,26 @@ class WriterWidget(QWidget):
         # Update display to show placeholder if no items are checked
         self.export_layer_combobox._update_display_text()
 
+        # Connect to metadata changes for newly populated layers
+        if not hasattr(self, '_connected_metadata_layers'):
+            self._connected_metadata_layers = set()
+
+        for layer in list(self._connected_metadata_layers):
+            with suppress(Exception):
+                layer.events.metadata.disconnect(
+                    self._update_mask_checkbox_visibility
+                )
+        self._connected_metadata_layers.clear()
+
+        for layer in image_layers:
+            with suppress(Exception):
+                layer.events.metadata.connect(
+                    self._update_mask_checkbox_visibility
+                )
+                self._connected_metadata_layers.add(layer)
+
+        self._update_mask_checkbox_visibility()
+
     def closeEvent(self, event):
         """Disconnect viewer signals before the widget is destroyed."""
         with suppress(TypeError, ValueError, AttributeError):
@@ -2368,6 +2417,13 @@ class WriterWidget(QWidget):
             self.viewer.layers.events.removed.disconnect(
                 self._populate_combobox
             )
+        if hasattr(self, '_connected_metadata_layers'):
+            for layer in list(self._connected_metadata_layers):
+                with suppress(Exception):
+                    layer.events.metadata.disconnect(
+                        self._update_mask_checkbox_visibility
+                    )
+            self._connected_metadata_layers.clear()
 
         event.accept()
         super().closeEvent(event)
@@ -2378,6 +2434,7 @@ class WriterWidget(QWidget):
         selected_filter,
         include_colorbar=False,
         selected_layers=None,
+        export_masked=False,
     ):
         """Callback whenever the export location and name are specified."""
         if selected_layers is None:
@@ -2436,7 +2493,9 @@ class WriterWidget(QWidget):
 
             try:
                 if selected_filter == "Phasor as OME-TIFF (*.ome.tif)":
-                    write_ome_tiff(final_path, export_layer)
+                    write_ome_tiff(
+                        final_path, export_layer, export_masked=export_masked
+                    )
                 elif selected_filter == "Layer data as CSV (*.csv)":
                     export_layer_as_csv(final_path, export_layer)
                 elif selected_filter in [
@@ -2470,7 +2529,11 @@ class WriterWidget(QWidget):
                     layer_file_path = os.path.join(directory, filename)
 
                     if selected_filter == "Phasor as OME-TIFF (*.ome.tif)":
-                        write_ome_tiff(layer_file_path, export_layer)
+                        write_ome_tiff(
+                            layer_file_path,
+                            export_layer,
+                            export_masked=export_masked,
+                        )
                     elif selected_filter == "Layer data as CSV (*.csv)":
                         export_layer_as_csv(layer_file_path, export_layer)
                     elif selected_filter in [

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from napari.layers import Image, Labels
+from napari.layers import Image
 from napari.utils.notifications import show_error, show_info
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator, QIntValidator
@@ -2351,9 +2351,7 @@ class WriterWidget(QWidget):
         """Populate combobox with image layers."""
         self.export_layer_combobox.clear()
         image_layers = [
-            layer
-            for layer in self.viewer.layers
-            if isinstance(layer, (Image, Labels))
+            layer for layer in self.viewer.layers if isinstance(layer, Image)
         ]
         for layer in image_layers:
             self.export_layer_combobox.addItem(layer.name)

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2364,7 +2364,7 @@ class WriterWidget(QWidget):
                 export_masked=export_masked,
             )
 
-    def _update_mask_checkbox_visibility(self):
+    def _update_mask_checkbox_visibility(self, event=None):
         """Show/hide the mask checkbox based on whether any selected layer has a mask."""
         selected_layers = self.export_layer_combobox.checkedItems()
         any_masked = False

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from napari.layers import Image
+from napari.layers import Image, Labels
 from napari.utils.notifications import show_error, show_info
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator, QIntValidator
@@ -2351,7 +2351,9 @@ class WriterWidget(QWidget):
         """Populate combobox with image layers."""
         self.export_layer_combobox.clear()
         image_layers = [
-            layer for layer in self.viewer.layers if isinstance(layer, Image)
+            layer
+            for layer in self.viewer.layers
+            if isinstance(layer, (Image, Labels))
         ]
         for layer in image_layers:
             self.export_layer_combobox.addItem(layer.name)

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -110,7 +110,7 @@ def write_ome_tiff(
     image_layer: Any,
     export_masked: bool = False,
 ) -> list[str]:
-    """Save image layer with phasor coordinates as 'OME-TIFF'.
+    """Save layer with phasor coordinates as 'OME-TIFF'.
 
     For layers with phasor metadata, saves mean intensity and phasor coordinates.
     For layers without phasor metadata, saves the raw layer data as OME-TIFF.
@@ -119,12 +119,13 @@ def write_ome_tiff(
     ----------
     path : str
         A string path indicating where to save the image file.
-    image_layer : napari.layers.Image
-        Napari image layer or a list with the mean intensity image as the
-        first element and as second element a dict with `metadata` as key.
-        The value associated to 'metadata' must be a dict containing
-        `G_original`, `S_original`, and `harmonics` keys with NumPy arrays
-        for phasor data, or just raw image data for non-phasor layers.
+    image_layer : napari.layers.Layer or tuple or list
+        Napari layer-like object (such as Image or Labels) or a list/tuple
+        representing a napari writer layer-data tuple (with the layer data as
+        the first element and a dict with `metadata` as the second element).
+        The metadata must contain `G_original`, `S_original`, and `harmonics`
+        keys with NumPy arrays for phasor data, or just raw layer data for
+        non-phasor layers.
 
     Returns
     -------
@@ -148,7 +149,9 @@ def write_ome_tiff(
         and "harmonics" in metadata
     )
 
-    if not path.endswith(".ome.tif"):
+    if not (
+        path.lower().endswith(".ome.tif") or path.lower().endswith(".ome.tiff")
+    ):
         path += ".ome.tif"
 
     dims = None

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -105,7 +105,11 @@ def _extract_z_spacing_um(
     return value if value > 0 else None
 
 
-def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
+def write_ome_tiff(
+    path: str,
+    image_layer: Any,
+    export_masked: bool = False,
+) -> list[str]:
     """Save image layer with phasor coordinates as 'OME-TIFF'.
 
     For layers with phasor metadata, saves mean intensity and phasor coordinates.
@@ -198,6 +202,22 @@ def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
             G = metadata["G_original"]
             S = metadata["S_original"]
             harmonics = metadata["harmonics"]
+
+            if export_masked and "mask" in metadata:
+                mask_data = metadata["mask"]
+                invert = metadata.get("mask_invert", False)
+                mask_invalid = mask_data > 0 if invert else mask_data <= 0
+
+                mean = np.where(mask_invalid, np.nan, mean.copy())
+
+                if G.ndim > mask_invalid.ndim:
+                    mask_invalid_expanded = mask_invalid[np.newaxis, ...]
+                    G = np.where(mask_invalid_expanded, np.nan, G.copy())
+                    S = np.where(mask_invalid_expanded, np.nan, S.copy())
+                else:
+                    G = np.where(mask_invalid, np.nan, G.copy())
+                    S = np.where(mask_invalid, np.nan, S.copy())
+
             if "settings" in metadata:
                 settings = metadata["settings"].copy()
             else:
@@ -264,6 +284,22 @@ def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
 
             if dims:
                 metadata_dict['axes'] = dims
+
+            if export_masked and "mask" in metadata:
+                mask_data = metadata["mask"]
+                invert = metadata.get("mask_invert", False)
+                mask_invalid = mask_data > 0 if invert else mask_data <= 0
+
+                if data.ndim > mask_invalid.ndim:
+                    expanded_shape = [1] * (
+                        data.ndim - mask_invalid.ndim
+                    ) + list(mask_invalid.shape)
+                    mask_invalid_expanded = mask_invalid.reshape(
+                        expanded_shape
+                    )
+                    data = np.where(mask_invalid_expanded, np.nan, data.copy())
+                else:
+                    data = np.where(mask_invalid, np.nan, data.copy())
 
             tifffile.imwrite(
                 path,

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -331,8 +331,16 @@ def export_layer_as_image(
         data_2d = data
 
     if is_labels:
-        cmap = 'nipy_spectral'
-        clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
+        include_colorbar = False
+        if colormap is not None and hasattr(colormap, 'map'):
+            try:
+                data_2d = colormap.map(data_2d)
+            except Exception:  # noqa: BLE001
+                cmap = 'nipy_spectral'
+                clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
+        else:
+            cmap = 'nipy_spectral'
+            clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
     else:
         napari_cmap = colormap
         if hasattr(napari_cmap, "colors"):
@@ -352,7 +360,7 @@ def export_layer_as_image(
         )
 
     # Calculate aspect ratio from data shape
-    height, width = data_2d.shape
+    height, width = data_2d.shape[:2]
     aspect_ratio = width / height
 
     base_height = 8
@@ -373,14 +381,16 @@ def export_layer_as_image(
             figsize=(base_width, base_height), facecolor="black"
         )
 
-    im = ax.imshow(
-        data_2d,
-        cmap=cmap,
-        vmin=clim[0],
-        vmax=clim[1],
-        interpolation="nearest",
-        aspect="auto",
-    )
+    imshow_kwargs = {
+        "interpolation": "nearest",
+        "aspect": "auto",
+    }
+    if data_2d.ndim == 2:
+        imshow_kwargs["cmap"] = cmap
+        imshow_kwargs["vmin"] = clim[0]
+        imshow_kwargs["vmax"] = clim[1]
+
+    im = ax.imshow(data_2d, **imshow_kwargs)
     ax.axis("off")
 
     if include_colorbar:

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.colors import LinearSegmentedColormap
-from napari.layers import Image
+from napari.layers import Labels
 from phasorpy.io import phasor_to_ometiff
 
 from ._utils import show_activity_progress
@@ -127,11 +127,11 @@ def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
     A list containing the string path to the saved file.
     """
     # Extract metadata depending on input type
-    if isinstance(image_layer, Image):
+    if hasattr(image_layer, 'data') and hasattr(image_layer, 'metadata'):
         metadata = image_layer.metadata
         data = image_layer.data
     else:
-        metadata = image_layer[0][1]["metadata"]
+        metadata = image_layer[0][1].get("metadata", {})
         data = image_layer[0][0]
 
     z_spacing_um = _extract_z_spacing_um(image_layer, data, metadata)
@@ -148,7 +148,7 @@ def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
         path += ".ome.tif"
 
     dims = None
-    if isinstance(image_layer, Image):
+    if hasattr(image_layer, 'axis_labels'):
         labels = getattr(image_layer, 'axis_labels', None)
         if labels is not None and len(labels) == data.ndim:
             dims = "".join(str(label).upper()[0] for label in labels)
@@ -171,7 +171,7 @@ def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
         metadata_dict['PhysicalSizeZ'] = z_spacing_um
         metadata_dict['PhysicalSizeZUnit'] = 'µm'
 
-    if isinstance(image_layer, Image):
+    if hasattr(image_layer, 'scale'):
         scale = getattr(image_layer, 'scale', None)
         if scale is not None:
             y_idx, x_idx = -2, -1
@@ -278,11 +278,11 @@ def write_ome_tiff(path: str, image_layer: Any) -> list[str]:
 
 def export_layer_as_image(
     path: str,
-    image_layer: Image,
+    image_layer: Any,
     include_colorbar: bool = True,
     current_step: Sequence[int] | None = None,
-) -> None:
-    """Export an image layer as an image file using its colormap and contrast limits.
+) -> list[str]:
+    """Export an image or labels layer as an image file using its colormap and contrast limits.
 
     The function extracts a 2D slice from the provided ``image_layer`` and saves it
     using Matplotlib, preserving the napari colormap and contrast limits. For
@@ -294,8 +294,8 @@ def export_layer_as_image(
     path : str
         Output file path. The extension determines the image format (e.g. ``.png``,
         ``.jpg``, ``.tif``).
-    image_layer : napari.layers.Image
-        Image layer to export.
+    image_layer : Any
+        Image or Labels layer to export, or layer data tuple from napari writer.
     include_colorbar : bool, optional
         If ``True``, include a colorbar in the exported figure. Default is ``True``.
     current_step : sequence of int, optional
@@ -304,7 +304,17 @@ def export_layer_as_image(
         provided and the data is multi-dimensional, the first index (0) is used
         for each non-spatial dimension.
     """
-    data = image_layer.data
+    if hasattr(image_layer, 'data'):
+        data = image_layer.data
+        is_labels = isinstance(image_layer, Labels)
+        colormap = getattr(image_layer, 'colormap', None)
+        contrast_limits = getattr(image_layer, 'contrast_limits', None)
+    else:
+        data = image_layer[0][0]
+        attributes = image_layer[0][1]
+        is_labels = image_layer[0][2] == 'labels'
+        colormap = attributes.get('colormap', None)
+        contrast_limits = attributes.get('contrast_limits', None)
 
     if data.ndim > 2:
         if current_step is not None:
@@ -320,18 +330,26 @@ def export_layer_as_image(
     else:
         data_2d = data
 
-    napari_cmap = image_layer.colormap
-    if hasattr(napari_cmap, "colors"):
-        cmap = LinearSegmentedColormap.from_list(
-            napari_cmap.name, napari_cmap.colors
-        )
+    if is_labels:
+        cmap = 'nipy_spectral'
+        clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
     else:
-        try:
-            cmap = plt.get_cmap(napari_cmap.name)
-        except (AttributeError, ValueError):
-            cmap = plt.get_cmap("gray")
-
-    clim = image_layer.contrast_limits
+        napari_cmap = colormap
+        if hasattr(napari_cmap, "colors"):
+            cmap = LinearSegmentedColormap.from_list(
+                napari_cmap.name, napari_cmap.colors
+            )
+        else:
+            try:
+                name = getattr(napari_cmap, "name", napari_cmap) or "gray"
+                cmap = plt.get_cmap(name)
+            except (AttributeError, ValueError, TypeError):
+                cmap = plt.get_cmap("gray")
+        clim = (
+            contrast_limits
+            if contrast_limits is not None
+            else [data_2d.min(), data_2d.max()]
+        )
 
     # Calculate aspect ratio from data shape
     height, width = data_2d.shape
@@ -390,9 +408,10 @@ def export_layer_as_image(
         facecolor=fig.get_facecolor(),
     )
     plt.close(fig)
+    return [path]
 
 
-def export_layer_as_csv(path: str, image_layer: Image) -> None:
+def export_layer_as_csv(path: str, image_layer: Any) -> list[str]:
     """Export layer data or phasor features as a CSV file.
 
     The function has two behaviors depending on whether the layer has
@@ -407,21 +426,26 @@ def export_layer_as_csv(path: str, image_layer: Image) -> None:
     ----------
     path : str
         Output CSV file path.
-    image_layer : napari.layers.Image
-        Image layer whose data or phasor features will be exported.
+    image_layer : Any
+        Image or Labels layer to export, or layer data tuple from napari writer.
     """
+    if hasattr(image_layer, 'data'):
+        data = image_layer.data
+        metadata = getattr(image_layer, 'metadata', {})
+    else:
+        data = image_layer[0][0]
+        metadata = image_layer[0][1].get("metadata", {})
+
     has_phasor_data = (
-        "G" in image_layer.metadata
-        and "S" in image_layer.metadata
-        and "harmonics" in image_layer.metadata
+        "G" in metadata and "S" in metadata and "harmonics" in metadata
     )
 
     if has_phasor_data:
-        G = image_layer.metadata["G"]
-        S = image_layer.metadata["S"]
-        G_original = image_layer.metadata.get("G_original", G)
-        S_original = image_layer.metadata.get("S_original", S)
-        harmonics = np.atleast_1d(image_layer.metadata["harmonics"])
+        G = metadata["G"]
+        S = metadata["S"]
+        G_original = metadata.get("G_original", G)
+        S_original = metadata.get("S_original", S)
+        harmonics = np.atleast_1d(metadata["harmonics"])
 
         # Get spatial shape (last 2 dimensions)
         spatial_shape = G.shape[-2:]
@@ -461,7 +485,6 @@ def export_layer_as_csv(path: str, image_layer: Image) -> None:
         df = pd.DataFrame(rows)
         df.to_csv(path, index=False)
     else:
-        data = image_layer.data
         if data.ndim == 2:
             rows, cols = data.shape
             y_coords, x_coords = np.meshgrid(
@@ -481,3 +504,4 @@ def export_layer_as_csv(path: str, image_layer: Image) -> None:
             df = pd.DataFrame(df_dict)
 
         df.to_csv(path, index=False)
+    return [path]

--- a/src/napari_phasors/napari.yaml
+++ b/src/napari_phasors/napari.yaml
@@ -24,6 +24,12 @@ contributions:
     - id: napari-phasors.write_ome_tiff
       python_name: napari_phasors:write_ome_tiff
       title: Write OME-TIFF
+    - id: napari-phasors.export_layer_as_csv
+      python_name: napari_phasors._writer:export_layer_as_csv
+      title: Export Layer to CSV
+    - id: napari-phasors.export_layer_as_image
+      python_name: napari_phasors._writer:export_layer_as_image
+      title: Export Layer as Image
     - id: napari-phasors.PhasorTransform
       python_name: napari_phasors:PhasorTransform
       title: Phasor Custom Import
@@ -38,7 +44,15 @@ contributions:
     - command: napari-phasors.write_ome_tiff
       display_name: Export Phasor to OME-TIFF
       layer_types: ['image*','labels*']
-      filename_extensions: []
+      filename_extensions: ['.ome.tif']
+    - command: napari-phasors.export_layer_as_csv
+      display_name: Export Layer to CSV
+      layer_types: ['image*','labels*']
+      filename_extensions: ['.csv']
+    - command: napari-phasors.export_layer_as_image
+      display_name: Export Layer as Image
+      layer_types: ['image*','labels*']
+      filename_extensions: ['.png', '.jpg', '.jpeg', '.tif']
   sample_data:
     - command: napari-phasors.convallaria_FLIM_sample_data
       display_name: Convallaria FLIM


### PR DESCRIPTION
This pull request introduces support for exporting masked OME-TIFF files and improves the handling of labels and mask metadata in the export workflow. It adds a dynamic mask export option to the `WriterWidget`, ensures that masks are applied correctly during export, and updates the image export logic to handle both image and labels layers robustly. Comprehensive tests are also added for these new features.

Closes #261
Closes #264 

**Enhancements to Masked Export Functionality:**

* Added an `Export masked OME-TIFF` checkbox to the `WriterWidget`, which appears dynamically when the selected layer(s) contain mask metadata. The widget listens for metadata changes and updates the checkbox visibility accordingly. [[1]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR2288-R2296) [[2]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR2355-R2378) [[3]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR2390-R2409) [[4]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR2420-R2426)
* Modified the `_save_file` method and related export logic to pass an `export_masked` parameter to `write_ome_tiff`, enabling or disabling mask application as specified by the user. [[1]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cR2437) [[2]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cL2439-R2498) [[3]](diffhunk://#diff-13f809147c91d8d3d9c4d428005d196bfd8e5ab1ac966310e544c69c61820e5cL2473-R2536)

**Improvements to OME-TIFF Export Logic:**

* Updated `write_ome_tiff` to apply mask data to exported images and associated metadata when `export_masked=True`, setting masked pixels to NaN as appropriate. The function now robustly checks for layer attributes instead of relying on specific types. [[1]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L108-R112) [[2]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L130-R138) [[3]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L151-R155) [[4]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L174-R178) [[5]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231R205-R220) [[6]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231R288-R303)

**Support for Labels Layers and Image Export:**

* Enhanced `export_layer_as_image` to support both image and labels layers, including proper handling of colormaps and colorbar inclusion. Labels layers are exported as colored images without a colorbar. [[1]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L18-R18) [[2]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L281-R321) [[3]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L297-R334) [[4]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231R343-R353) [[5]](diffhunk://#diff-d8dbdba894033a62ba0b89cb40e635e71abdd67be07074f23956fb4860c2e231L323-R399)

**Testing Improvements:**

* Added tests to verify that:
  - The `WriterWidget` excludes labels layers from the export combobox.
  - Labels layers are exported as colored images.
  - The mask checkbox behaves dynamically based on mask metadata.
  - Exported OME-TIFF files correctly apply or ignore masks as specified. [[1]](diffhunk://#diff-a918119f4b439f5937b77c15179af7e000ad425fec46a2f13d0821657e4f8f0eR1328-R1430) [[2]](diffhunk://#diff-ad49a3273b98a5607cea616004162fa43af9690da7112a0da0d9d21bd902559dR365-R429)

These changes improve the flexibility and usability of the export workflow, especially for users working with masked data and labels layers.