### PR TITLE
refactor: update default cursor placement to center of current phasor plot (#290)

### DIFF
--- a/src/napari_phasors/_tests/test_selection_tab.py
+++ b/src/napari_phasors/_tests/test_selection_tab.py
@@ -388,7 +388,9 @@ def test_circular_cursor_add_cursor(make_napari_viewer):
     assert 'color' in cursor
     assert 'patch' in cursor
     assert cursor['g'] == 0.5
-    assert cursor['s'] == 0.5  # Default s value
+    assert (
+        cursor['s'] == 0.3
+    )  # Default s value (center of current view y-axis [-0.1, 0.7])
     assert cursor['radius'] == 0.05  # Default radius
 
     # Add second cursor
@@ -478,7 +480,9 @@ def test_circular_cursor_table_updates(make_napari_viewer):
 
     # Check initial values
     assert g_spinbox.value() == 0.5
-    assert s_spinbox.value() == 0.5  # Default s value
+    assert (
+        s_spinbox.value() == 0.3
+    )  # Default s value (center of current view y-axis [-0.1, 0.7])
     assert radius_spinbox.value() == 0.05  # Default radius
 
     # Change values
@@ -1862,10 +1866,10 @@ def test_polar_cursor_add_cursor(make_napari_viewer):
 
     # Check new defaults
     cursor = widget._cursors[0]
-    assert cursor['phase_min'] == 10.0
-    assert cursor['phase_max'] == 30.0
-    assert cursor['modulation_min'] == 0.4
-    assert cursor['modulation_max'] == 0.6
+    assert np.allclose(cursor['phase_min'], 20.96375653)
+    assert np.allclose(cursor['phase_max'], 40.96375653)
+    assert np.allclose(cursor['modulation_min'], 0.483095189)
+    assert np.allclose(cursor['modulation_max'], 0.683095189)
 
 
 def test_elliptical_cursor_widget_initialization(make_napari_viewer):
@@ -1902,7 +1906,7 @@ def test_elliptical_cursor_add_cursor(make_napari_viewer):
     # Check properties
     cursor = widget._cursors[0]
     assert cursor['g'] == 0.5
-    assert cursor['s'] == 0.5
+    assert cursor['s'] == 0.3
     assert cursor['radius'] == 0.1
     assert cursor['radius_minor'] == 0.05
     assert cursor['angle'] == 0.0
@@ -2003,3 +2007,38 @@ def test_labels_layer_visibility_on_tab_toggle(make_napari_viewer):
     widget._set_labels_layer_visibility(True)
     assert viewer.layers[man_layer_name].visible is False
     assert viewer.layers[circ_layer_name].visible is True
+
+
+def test_cursor_added_at_custom_limits(make_napari_viewer):
+    """Test that cursors are added at the center of custom/zoomed plot limits."""
+    viewer = make_napari_viewer()
+    intensity_layer = create_image_layer_with_phasors()
+    viewer.add_layer(intensity_layer)
+    parent = PlotterWidget(viewer)
+
+    # Set custom axes limits
+    parent.canvas_widget.axes.set_xlim([0.2, 0.8])
+    parent.canvas_widget.axes.set_ylim([0.1, 0.5])
+
+    # 1. Test Circular Cursor
+    circular_widget = parent.selection_tab.circular_cursor_widget
+    circular_widget._add_cursor()
+    assert circular_widget._cursors[0]['g'] == 0.5  # (0.2 + 0.8) / 2
+    assert circular_widget._cursors[0]['s'] == 0.3  # (0.1 + 0.5) / 2
+
+    # 2. Test Elliptical Cursor
+    elliptical_widget = parent.selection_tab.elliptical_cursor_widget
+    elliptical_widget._add_cursor()
+    assert elliptical_widget._cursors[0]['g'] == 0.5
+    assert elliptical_widget._cursors[0]['s'] == 0.3
+
+    # 3. Test Polar Cursor
+    polar_widget = parent.selection_tab.polar_cursor_widget
+    polar_widget._add_cursor()
+    # Expected center is g=0.5, s=0.3
+    # center_phase_deg = np.rad2deg(np.arctan2(0.3, 0.5)) ~ 30.96375653
+    # center_modulation = np.sqrt(0.34) ~ 0.583095189
+    assert np.allclose(polar_widget._cursors[0]['phase_min'], 20.96375653)
+    assert np.allclose(polar_widget._cursors[0]['phase_max'], 40.96375653)
+    assert np.allclose(polar_widget._cursors[0]['modulation_min'], 0.483095189)
+    assert np.allclose(polar_widget._cursors[0]['modulation_max'], 0.683095189)

--- a/src/napari_phasors/_tests/test_selection_tab.py
+++ b/src/napari_phasors/_tests/test_selection_tab.py
@@ -387,10 +387,12 @@ def test_circular_cursor_add_cursor(make_napari_viewer):
     assert 'radius' in cursor
     assert 'color' in cursor
     assert 'patch' in cursor
-    assert cursor['g'] == 0.5
-    assert (
-        cursor['s'] == 0.3
-    )  # Default s value (center of current view y-axis [-0.1, 0.7])
+    xlim = parent.canvas_widget.axes.get_xlim()
+    ylim = parent.canvas_widget.axes.get_ylim()
+    expected_g = max(-1.5, min(1.5, (xlim[0] + xlim[1]) / 2.0))
+    expected_s = max(-1.5, min(1.5, (ylim[0] + ylim[1]) / 2.0))
+    assert np.isclose(cursor['g'], expected_g)
+    assert np.isclose(cursor['s'], expected_s)
     assert cursor['radius'] == 0.05  # Default radius
 
     # Add second cursor
@@ -478,12 +480,13 @@ def test_circular_cursor_table_updates(make_napari_viewer):
     assert isinstance(s_spinbox, QDoubleSpinBox)
     assert isinstance(radius_spinbox, QDoubleSpinBox)
 
-    # Check initial values
-    assert g_spinbox.value() == 0.5
-    assert (
-        s_spinbox.value() == 0.3
-    )  # Default s value (center of current view y-axis [-0.1, 0.7])
-    assert radius_spinbox.value() == 0.05  # Default radius
+    xlim = parent.canvas_widget.axes.get_xlim()
+    ylim = parent.canvas_widget.axes.get_ylim()
+    expected_g = max(-1.5, min(1.5, (xlim[0] + xlim[1]) / 2.0))
+    expected_s = max(-1.5, min(1.5, (ylim[0] + ylim[1]) / 2.0))
+    assert np.isclose(g_spinbox.value(), expected_g)
+    assert np.isclose(s_spinbox.value(), expected_s)
+    assert np.isclose(radius_spinbox.value(), 0.05)  # Default radius
 
     # Change values
     g_spinbox.setValue(0.7)
@@ -1866,10 +1869,29 @@ def test_polar_cursor_add_cursor(make_napari_viewer):
 
     # Check new defaults
     cursor = widget._cursors[0]
-    assert np.allclose(cursor['phase_min'], 20.96375653)
-    assert np.allclose(cursor['phase_max'], 40.96375653)
-    assert np.allclose(cursor['modulation_min'], 0.483095189)
-    assert np.allclose(cursor['modulation_max'], 0.683095189)
+    xlim = parent.canvas_widget.axes.get_xlim()
+    ylim = parent.canvas_widget.axes.get_ylim()
+    center_g = (xlim[0] + xlim[1]) / 2.0
+    center_s = (ylim[0] + ylim[1]) / 2.0
+    center_phase = np.rad2deg(np.arctan2(center_s, center_g))
+    center_modulation = np.sqrt(center_g**2 + center_s**2)
+
+    expected_phase_min = center_phase - 10.0
+    expected_phase_max = center_phase + 10.0
+    expected_mod_min = max(0.0, min(1.0, center_modulation - 0.1))
+    expected_mod_max = max(0.0, min(1.0, center_modulation + 0.1))
+    if expected_mod_min > expected_mod_max:
+        expected_mod_min, expected_mod_max = expected_mod_max, expected_mod_min
+    if abs(expected_mod_max - expected_mod_min) < 1e-5:
+        if abs(expected_mod_max - 1.0) < 1e-5:
+            expected_mod_min = 0.99
+        else:
+            expected_mod_max = expected_mod_min + 0.01
+
+    assert np.allclose(cursor['phase_min'], expected_phase_min)
+    assert np.allclose(cursor['phase_max'], expected_phase_max)
+    assert np.allclose(cursor['modulation_min'], expected_mod_min)
+    assert np.allclose(cursor['modulation_max'], expected_mod_max)
 
 
 def test_elliptical_cursor_widget_initialization(make_napari_viewer):
@@ -1905,8 +1927,12 @@ def test_elliptical_cursor_add_cursor(make_napari_viewer):
 
     # Check properties
     cursor = widget._cursors[0]
-    assert cursor['g'] == 0.5
-    assert cursor['s'] == 0.3
+    xlim = parent.canvas_widget.axes.get_xlim()
+    ylim = parent.canvas_widget.axes.get_ylim()
+    expected_g = max(-1.5, min(1.5, (xlim[0] + xlim[1]) / 2.0))
+    expected_s = max(-1.5, min(1.5, (ylim[0] + ylim[1]) / 2.0))
+    assert np.isclose(cursor['g'], expected_g)
+    assert np.isclose(cursor['s'], expected_s)
     assert cursor['radius'] == 0.1
     assert cursor['radius_minor'] == 0.05
     assert cursor['angle'] == 0.0
@@ -2020,25 +2046,109 @@ def test_cursor_added_at_custom_limits(make_napari_viewer):
     parent.canvas_widget.axes.set_xlim([0.2, 0.8])
     parent.canvas_widget.axes.set_ylim([0.1, 0.5])
 
+    xlim = parent.canvas_widget.axes.get_xlim()
+    ylim = parent.canvas_widget.axes.get_ylim()
+    expected_g = max(-1.5, min(1.5, (xlim[0] + xlim[1]) / 2.0))
+    expected_s = max(-1.5, min(1.5, (ylim[0] + ylim[1]) / 2.0))
+
     # 1. Test Circular Cursor
     circular_widget = parent.selection_tab.circular_cursor_widget
     circular_widget._add_cursor()
-    assert circular_widget._cursors[0]['g'] == 0.5  # (0.2 + 0.8) / 2
-    assert circular_widget._cursors[0]['s'] == 0.3  # (0.1 + 0.5) / 2
+    assert np.isclose(circular_widget._cursors[0]['g'], expected_g)
+    assert np.isclose(circular_widget._cursors[0]['s'], expected_s)
 
     # 2. Test Elliptical Cursor
     elliptical_widget = parent.selection_tab.elliptical_cursor_widget
     elliptical_widget._add_cursor()
-    assert elliptical_widget._cursors[0]['g'] == 0.5
-    assert elliptical_widget._cursors[0]['s'] == 0.3
+    assert np.isclose(elliptical_widget._cursors[0]['g'], expected_g)
+    assert np.isclose(elliptical_widget._cursors[0]['s'], expected_s)
 
     # 3. Test Polar Cursor
     polar_widget = parent.selection_tab.polar_cursor_widget
     polar_widget._add_cursor()
-    # Expected center is g=0.5, s=0.3
-    # center_phase_deg = np.rad2deg(np.arctan2(0.3, 0.5)) ~ 30.96375653
-    # center_modulation = np.sqrt(0.34) ~ 0.583095189
-    assert np.allclose(polar_widget._cursors[0]['phase_min'], 20.96375653)
-    assert np.allclose(polar_widget._cursors[0]['phase_max'], 40.96375653)
-    assert np.allclose(polar_widget._cursors[0]['modulation_min'], 0.483095189)
-    assert np.allclose(polar_widget._cursors[0]['modulation_max'], 0.683095189)
+    center_g = (xlim[0] + xlim[1]) / 2.0
+    center_s = (ylim[0] + ylim[1]) / 2.0
+    center_phase = np.rad2deg(np.arctan2(center_s, center_g))
+    center_modulation = np.sqrt(center_g**2 + center_s**2)
+
+    expected_phase_min = center_phase - 10.0
+    expected_phase_max = center_phase + 10.0
+    expected_mod_min = max(0.0, min(1.0, center_modulation - 0.1))
+    expected_mod_max = max(0.0, min(1.0, center_modulation + 0.1))
+    if expected_mod_min > expected_mod_max:
+        expected_mod_min, expected_mod_max = expected_mod_max, expected_mod_min
+    if abs(expected_mod_max - expected_mod_min) < 1e-5:
+        if abs(expected_mod_max - 1.0) < 1e-5:
+            expected_mod_min = 0.99
+        else:
+            expected_mod_max = expected_mod_min + 0.01
+
+    assert np.allclose(
+        polar_widget._cursors[0]['phase_min'], expected_phase_min
+    )
+    assert np.allclose(
+        polar_widget._cursors[0]['phase_max'], expected_phase_max
+    )
+    assert np.allclose(
+        polar_widget._cursors[0]['modulation_min'], expected_mod_min
+    )
+    assert np.allclose(
+        polar_widget._cursors[0]['modulation_max'], expected_mod_max
+    )
+
+
+def test_polar_cursor_clamping_and_validation(make_napari_viewer):
+    """Test that polar cursor modulation ranges are clamped and validated correctly."""
+    viewer = make_napari_viewer()
+    intensity_image_layer = create_image_layer_with_phasors()
+    viewer.add_layer(intensity_image_layer)
+    parent = PlotterWidget(viewer)
+    widget = parent.selection_tab.polar_cursor_widget
+
+    # Case 1: modulation_min > modulation_max should be swapped
+    widget._add_cursor(modulation_min=0.8, modulation_max=0.4)
+    cursor = widget._cursors[-1]
+    assert cursor['modulation_min'] == 0.4
+    assert cursor['modulation_max'] == 0.8
+
+    # Case 2: modulation_min and modulation_max outside [0, 1] should be clamped
+    widget._add_cursor(modulation_min=-0.5, modulation_max=1.5)
+    cursor = widget._cursors[-1]
+    assert cursor['modulation_min'] == 0.0
+    assert cursor['modulation_max'] == 1.0
+
+    # Case 3: modulation_min > 1 and modulation_max clamped to 1
+    widget._add_cursor(modulation_min=1.2, modulation_max=1.0)
+    cursor = widget._cursors[-1]
+    assert cursor['modulation_min'] == 0.99
+    assert cursor['modulation_max'] == 1.0
+
+    # Case 4: equal modulations should be shrunk to a small width
+    widget._add_cursor(modulation_min=0.5, modulation_max=0.5)
+    cursor = widget._cursors[-1]
+    assert np.isclose(cursor['modulation_min'], 0.5)
+    assert np.isclose(cursor['modulation_max'], 0.51)
+
+
+def test_circular_and_elliptical_cursor_coordinate_clipping(
+    make_napari_viewer,
+):
+    """Test that circular and elliptical cursor center coordinates are clipped to [-1.5, 1.5]."""
+    viewer = make_napari_viewer()
+    intensity_image_layer = create_image_layer_with_phasors()
+    viewer.add_layer(intensity_image_layer)
+    parent = PlotterWidget(viewer)
+
+    # 1. Test Circular Cursor clipping
+    circular_widget = parent.selection_tab.circular_cursor_widget
+    circular_widget._add_cursor(g=2.0, s=-2.0)
+    circular_cursor = circular_widget._cursors[-1]
+    assert circular_cursor['g'] == 1.5
+    assert circular_cursor['s'] == -1.5
+
+    # 2. Test Elliptical Cursor clipping
+    elliptical_widget = parent.selection_tab.elliptical_cursor_widget
+    elliptical_widget._add_cursor(g=-2.5, s=3.0)
+    elliptical_cursor = elliptical_widget._cursors[-1]
+    assert elliptical_cursor['g'] == -1.5
+    assert elliptical_cursor['s'] == 1.5

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -1859,8 +1859,32 @@ class CircularCursorWidget(QWidget):
             return self._cursors[-1]['radius']
         return 0.05  # Default radius
 
-    def _add_cursor(self, g=0.5, s=0.5, radius=None, color=None):
+    def _add_cursor(self, g=None, s=None, radius=None, color=None):
         """Add a new cursor to the table."""
+        if isinstance(g, bool):
+            g = None
+
+        if g is None or s is None:
+            if (
+                self.parent_widget is not None
+                and hasattr(self.parent_widget, 'canvas_widget')
+                and self.parent_widget.canvas_widget is not None
+                and hasattr(self.parent_widget.canvas_widget, 'axes')
+                and self.parent_widget.canvas_widget.axes is not None
+            ):
+                xlim = self.parent_widget.canvas_widget.axes.get_xlim()
+                ylim = self.parent_widget.canvas_widget.axes.get_ylim()
+                center_g = (xlim[0] + xlim[1]) / 2.0
+                center_s = (ylim[0] + ylim[1]) / 2.0
+            else:
+                center_g = 0.5
+                center_s = 0.5
+
+            if g is None:
+                g = center_g
+            if s is None:
+                s = center_s
+
         if color is None:
             color = self._get_next_color()
         if radius is None:
@@ -2837,13 +2861,56 @@ class PolarCursorWidget(QWidget):
 
     def _add_cursor(
         self,
-        phase_min=10.0,
-        phase_max=30.0,
-        modulation_min=0.4,
-        modulation_max=0.6,
+        phase_min=None,
+        phase_max=None,
+        modulation_min=None,
+        modulation_max=None,
         color=None,
     ):
         """Add a new cursor to the table."""
+        if isinstance(phase_min, bool):
+            phase_min = None
+
+        if (
+            phase_min is None
+            or phase_max is None
+            or modulation_min is None
+            or modulation_max is None
+        ):
+            if (
+                self.parent_widget is not None
+                and hasattr(self.parent_widget, 'canvas_widget')
+                and self.parent_widget.canvas_widget is not None
+                and hasattr(self.parent_widget.canvas_widget, 'axes')
+                and self.parent_widget.canvas_widget.axes is not None
+            ):
+                xlim = self.parent_widget.canvas_widget.axes.get_xlim()
+                ylim = self.parent_widget.canvas_widget.axes.get_ylim()
+                center_g = (xlim[0] + xlim[1]) / 2.0
+                center_s = (ylim[0] + ylim[1]) / 2.0
+
+                center_phase_rad = np.arctan2(center_s, center_g)
+                center_phase_deg = np.rad2deg(center_phase_rad)
+                center_modulation = np.sqrt(center_g**2 + center_s**2)
+
+                if phase_min is None:
+                    phase_min = center_phase_deg - 10.0
+                if phase_max is None:
+                    phase_max = center_phase_deg + 10.0
+                if modulation_min is None:
+                    modulation_min = max(0.0, center_modulation - 0.1)
+                if modulation_max is None:
+                    modulation_max = min(1.0, center_modulation + 0.1)
+            else:
+                if phase_min is None:
+                    phase_min = 10.0
+                if phase_max is None:
+                    phase_max = 30.0
+                if modulation_min is None:
+                    modulation_min = 0.4
+                if modulation_max is None:
+                    modulation_max = 0.6
+
         if color is None:
             color = self._get_next_color()
 
@@ -3703,14 +3770,38 @@ class EllipticalCursorWidget(QWidget):
 
     def _add_cursor(
         self,
-        g=0.5,
-        s=0.5,
+        g=None,
+        s=None,
         radius=0.1,
         radius_minor=0.05,
         angle=0.0,
         color=None,
     ):
         """Add a new cursor to the table."""
+        if isinstance(g, bool):
+            g = None
+
+        if g is None or s is None:
+            if (
+                self.parent_widget is not None
+                and hasattr(self.parent_widget, 'canvas_widget')
+                and self.parent_widget.canvas_widget is not None
+                and hasattr(self.parent_widget.canvas_widget, 'axes')
+                and self.parent_widget.canvas_widget.axes is not None
+            ):
+                xlim = self.parent_widget.canvas_widget.axes.get_xlim()
+                ylim = self.parent_widget.canvas_widget.axes.get_ylim()
+                center_g = (xlim[0] + xlim[1]) / 2.0
+                center_s = (ylim[0] + ylim[1]) / 2.0
+            else:
+                center_g = 0.5
+                center_s = 0.5
+
+            if g is None:
+                g = center_g
+            if s is None:
+                s = center_s
+
         if color is None:
             color = self._get_next_color()
 

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -1885,6 +1885,12 @@ class CircularCursorWidget(QWidget):
             if s is None:
                 s = center_s
 
+        # Clip g and s to the allowed spinbox range [-1.5, 1.5]
+        if g is not None:
+            g = max(-1.5, min(1.5, g))
+        if s is not None:
+            s = max(-1.5, min(1.5, s))
+
         if color is None:
             color = self._get_next_color()
         if radius is None:
@@ -2911,6 +2917,21 @@ class PolarCursorWidget(QWidget):
                 if modulation_max is None:
                     modulation_max = 0.6
 
+        # Clamp modulation range to [0, 1] and ensure modulation_min <= modulation_max
+        if modulation_min is not None:
+            modulation_min = max(0.0, min(1.0, modulation_min))
+        if modulation_max is not None:
+            modulation_max = max(0.0, min(1.0, modulation_max))
+
+        if modulation_min is not None and modulation_max is not None:
+            if modulation_min > modulation_max:
+                modulation_min, modulation_max = modulation_max, modulation_min
+            if abs(modulation_max - modulation_min) < 1e-5:
+                if abs(modulation_max - 1.0) < 1e-5:
+                    modulation_min = 0.99
+                else:
+                    modulation_max = modulation_min + 0.01
+
         if color is None:
             color = self._get_next_color()
 
@@ -3801,6 +3822,12 @@ class EllipticalCursorWidget(QWidget):
                 g = center_g
             if s is None:
                 s = center_s
+
+        # Clip g and s to the allowed spinbox range [-1.5, 1.5]
+        if g is not None:
+            g = max(-1.5, min(1.5, g))
+        if s is not None:
+            s = max(-1.5, min(1.5, s))
 
         if color is None:
             color = self._get_next_color()


### PR DESCRIPTION
This pull request improves how default cursor positions are determined in the selection tab of the phasor analysis tool. Instead of always using static default values, cursors are now initialized at the center of the current plot view, making their placement more intuitive and responsive to zoom or pan actions. The tests have also been updated and expanded to verify this new behavior.

Closes #290

**Enhancements to cursor initialization based on plot view:**

* Updated the `_add_cursor` methods for circular, elliptical, and polar cursor widgets in `selection_tab.py` to set default cursor positions (or ranges) to the center of the current axes limits, if available, instead of hardcoded values. This affects both (g, s) and polar coordinates. [[1]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL1862-R1887) [[2]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL2840-R2913) [[3]](diffhunk://#diff-39876f2010afb3e0c966d6afd10f32285246d19fd5fad04e7340ec0d8875cb2cL3706-R3804)

**Testing improvements:**

* Modified existing tests in `test_selection_tab.py` to expect the new default cursor positions (center of current view), updating assertions for circular, elliptical, and polar cursors. [[1]](diffhunk://#diff-fba49ca0a3a9fba9f4351a34acd7ca48151826a904215f55f989231764c8fb57L391-R393) [[2]](diffhunk://#diff-fba49ca0a3a9fba9f4351a34acd7ca48151826a904215f55f989231764c8fb57L481-R485) [[3]](diffhunk://#diff-fba49ca0a3a9fba9f4351a34acd7ca48151826a904215f55f989231764c8fb57L1865-R1872) [[4]](diffhunk://#diff-fba49ca0a3a9fba9f4351a34acd7ca48151826a904215f55f989231764c8fb57L1905-R1909)
* Added a new test, `test_cursor_added_at_custom_limits`, to verify that cursors are correctly placed at the center of custom/zoomed plot limits for all cursor types.