### PR TITLE
Add write permisions in github workflow on release

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -12,6 +12,8 @@ jobs:
   build-installer:
     name: Build installer (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Installers can't be uploaded to the release due to not having write permissions. This PR solves this issue.