### PR TITLE
Fix grouped contour rendering and solid color gradient coloring.

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -851,13 +851,13 @@ def test_make_solid_contour_cmap():
     # The method _make_solid_contour_cmap doesn't use instance state.
     # We'll just call it on an uninitialized instance or dummy instance.
     class DummyPlotter:
-        _normalize_rgb = PlotterWidget._normalize_rgb
+        _normalize_rgb = staticmethod(PlotterWidget._normalize_rgb)
         _make_solid_contour_cmap = PlotterWidget._make_solid_contour_cmap
 
     dummy = DummyPlotter()
 
     target_color = (1.0, 0.0, 0.0)  # Red
-    cmap = dummy._make_solid_contour_cmap(dummy, "test_cmap", target_color)
+    cmap = dummy._make_solid_contour_cmap("test_cmap", target_color)
 
     # Low color should be 50% white blended with red
     # low_color = np.clip([1, 0, 0] + (1 - [1, 0, 0]) * 0.5, 0, 1) = [1, 0.5, 0.5]

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -807,6 +807,66 @@ def test_contour_plot_creates_and_cleans_collections(make_napari_viewer):
     plotter.deleteLater()
 
 
+def test_contour_plot_grouped_mode(make_napari_viewer):
+    """Test that grouped mode creates one contour collection per group."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    layer2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+    viewer.add_layer(layer2)
+    plotter = PlotterWidget(viewer)
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [layer1.name, layer2.name]
+    )
+    plotter._process_layer_selection_change()
+
+    # Configure grouped mode
+    plotter.plot_type = 'CONTOUR'
+    plotter._contour_display_mode = "Grouped"
+    plotter._contour_group_assignments = {layer1.name: 1, layer2.name: 1}
+    plotter._contour_group_names = {1: "Group 1"}
+
+    plotter.plot()
+
+    # Should only create one contour collection for the entire group
+    assert len(plotter._contour_collections) == 1
+
+    artists = [
+        artist
+        for artist in plotter.canvas_widget.axes.collections
+        if artist.get_label() == 'contour_plot_element'
+    ]
+    assert len(artists) > 0
+
+    plotter.deleteLater()
+
+
+def test_make_solid_contour_cmap():
+    """Test that the solid contour colormap blends the target color with 50% white."""
+    # We don't need a full widget, just the method
+    from napari_phasors.plotter import PlotterWidget
+
+    # Create an instance without initializing a viewer (or use a mock)
+    # The method _make_solid_contour_cmap doesn't use instance state.
+    # We'll just call it on an uninitialized instance or dummy instance.
+    class DummyPlotter:
+        _normalize_rgb = PlotterWidget._normalize_rgb
+        _make_solid_contour_cmap = PlotterWidget._make_solid_contour_cmap
+
+    dummy = DummyPlotter()
+
+    target_color = (1.0, 0.0, 0.0)  # Red
+    cmap = dummy._make_solid_contour_cmap(dummy, "test_cmap", target_color)
+
+    # Low color should be 50% white blended with red
+    # low_color = np.clip([1, 0, 0] + (1 - [1, 0, 0]) * 0.5, 0, 1) = [1, 0.5, 0.5]
+    np.testing.assert_allclose(cmap(0.0)[:3], (1.0, 0.5, 0.5))
+
+    # High color should be the target color
+    np.testing.assert_allclose(cmap(1.0)[:3], target_color)
+
+
 def test_add_layer_without_phasor_features_does_not_trigger_plot_or_combobox(
     make_napari_viewer,
 ):

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -6759,18 +6759,16 @@ class PlotterWidget(QWidget):
         return tuple(arr[:3])
 
     def _make_solid_contour_cmap(self, name, target_color):
-        """Create a subtle ramp for solid contour style.
+        """Create a gradient ramp for solid contour style.
 
-        Uses an off-white start so the lowest contour is still visible on
-        white backgrounds while preserving the selected hue progression.
+        Blends the target color with white for the lower end to preserve
+        hue while providing a good visible range of the gradient.
         """
         target = np.asarray(self._normalize_rgb(target_color), dtype=float)
 
-        # Slightly below white with a tiny tint toward the target color.
-        # This keeps low levels visible on white backgrounds.
-        low_gray = 0.92
-        tint = 0.08
-        low_color = np.clip((1.0 - tint) * low_gray + tint * target, 0.0, 1.0)
+        # Start from a lighter version of the color (e.g., 50% mixed with white)
+        # to prevent too many white/gray contours at low levels.
+        low_color = np.clip(target + (1.0 - target) * 0.5, 0.0, 1.0)
 
         return LinearSegmentedColormap.from_list(
             name,
@@ -7015,35 +7013,36 @@ class PlotterWidget(QWidget):
                     )
                 )
 
-            for member_idx, (_layer_name, gx, gy) in enumerate(
-                grouped_data[gid]
-            ):
-                h, xedges, yedges = self._compute_contour_histogram(
-                    gx, gy, bins, range_xlim, range_ylim
-                )
-                if style_mode == "colormap":
-                    cs = ax.contour(
-                        xedges,
-                        yedges,
-                        h.T,
-                        levels=levels,
-                        linewidths=linewidths,
-                        cmap=style_cmap,
-                        norm='log' if use_log_norm else None,
-                    )
-                else:
-                    cs = ax.contour(
-                        xedges,
-                        yedges,
-                        h.T,
-                        levels=levels,
-                        linewidths=linewidths,
-                        cmap=solid_cmap,
-                        norm='log' if use_log_norm else None,
-                    )
+            gx_all = np.concatenate([gx for _, gx, _ in grouped_data[gid]])
+            gy_all = np.concatenate([gy for _, _, gy in grouped_data[gid]])
 
-                _tag_contour_set(cs, group_label if member_idx == 0 else None)
-                self._contour_collections.append(cs)
+            h, xedges, yedges = self._compute_contour_histogram(
+                gx_all, gy_all, bins, range_xlim, range_ylim
+            )
+
+            if style_mode == "colormap":
+                cs = ax.contour(
+                    xedges,
+                    yedges,
+                    h.T,
+                    levels=levels,
+                    linewidths=linewidths,
+                    cmap=style_cmap,
+                    norm='log' if use_log_norm else None,
+                )
+            else:
+                cs = ax.contour(
+                    xedges,
+                    yedges,
+                    h.T,
+                    levels=levels,
+                    linewidths=linewidths,
+                    cmap=solid_cmap,
+                    norm='log' if use_log_norm else None,
+                )
+
+            _tag_contour_set(cs, group_label)
+            self._contour_collections.append(cs)
 
             legend_labels.append(group_label)
 


### PR DESCRIPTION
This PR proposes a fix to grouped contour mode in the phasor plot. 

Fixes #295 

**Fixed the grouped mode contour calculation:** Previously, the grouped mode plotted separate contours for each layer within a group using the same color, leading to overlapping contours, multiple sets of boundaries, and incorrect bin detail. I've updated the logic to concatenate all data points within a group (`gx_all` and `gy_all`) and calculate the histogram over the combined group data, so it creates one set of cohesive contour lines that accurately represent the entire group.

**Improved the solid contour colormap:** To fix the washed-out gradient and eliminate the excess white/gray contour lines, I've adjusted the color blending algorithm `in _make_solid_contour_cmap`. It now starts the gradient using a 50% blend of the target color with white (instead of an almost purely gray baseline), ensuring the hue stays consistent while providing a much smoother visible range across the lowest contours without turning gray.