### PR TITLE
Fix: Ignore warning from biaplotter for log color indices below 1

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -1007,6 +1007,31 @@ def test_phasor_plotter_log_scale_checkbox(make_napari_viewer):
     assert log_scale_checkbox.isChecked() == initial_log_state
 
 
+def test_density_plot_log_scale_warning_suppression(make_napari_viewer):
+    """Test that warnings related to log normalization and non-positive ylim are suppressed in HISTOGRAM2D mode."""
+    viewer = make_napari_viewer()
+    intensity_image_layer = create_image_layer_with_phasors()
+    viewer.add_layer(intensity_image_layer)
+    plotter = PlotterWidget(viewer)
+
+    # Enable Density Plot mode and log scale
+    plotter.plot_type = 'HISTOGRAM2D'
+    plotter.histogram_log_scale = True
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        # Trigger plot update while log scale is active
+        plotter.plot()
+
+        # Verify that none of the suppressed warnings were raised
+        for w in caught_warnings:
+            msg = str(w.message)
+            if (
+                "Log normalization applied" in msg
+                or "non-positive ylim" in msg
+            ):
+                pytest.fail(f"Warning was not suppressed: {msg}")
+
+
 def test_phasor_plotter_white_background_checkbox(make_napari_viewer):
     """Test white background checkbox functionality."""
     viewer = make_napari_viewer()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -6572,81 +6572,104 @@ class PlotterWidget(QWidget):
 
     def _update_histogram_plot(self, x_data, y_data, selection_id_data=None):
         """Update the histogram plot with new data."""
-        plot_data = np.column_stack((x_data, y_data))
-        histogram_artist = self.canvas_widget.artists['HISTOGRAM2D']
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Log normalization applied to color indices*",
+                category=UserWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="Attempt to set non-positive ylim on a log-scaled axis will be ignored*",
+                category=UserWarning,
+            )
+            plot_data = np.column_stack((x_data, y_data))
+            histogram_artist = self.canvas_widget.artists['HISTOGRAM2D']
 
-        histogram_artist.data = plot_data
-        histogram_artist.cmin = 1
+            histogram_artist.data = plot_data
+            histogram_artist.cmin = 1
 
-        if self._last_histogram_bins != self.histogram_bins:
-            histogram_artist.bins = self.histogram_bins
-            self._last_histogram_bins = self.histogram_bins
+            if self._last_histogram_bins != self.histogram_bins:
+                histogram_artist.bins = self.histogram_bins
+                self._last_histogram_bins = self.histogram_bins
 
-        histogram_is_solid = self._histogram_style == 'solid'
-        if histogram_is_solid:
-            cache_key = f"solid:{tuple(self._histogram_color)}"
-        else:
-            cache_key = self.histogram_colormap
-
-        if self._last_histogram_colormap != cache_key:
+            histogram_is_solid = self._histogram_style == 'solid'
             if histogram_is_solid:
-                selected_histogram_colormap = self._make_solid_contour_cmap(
-                    "histogram_solid",
-                    self._histogram_color,
+                cache_key = f"solid:{tuple(self._histogram_color)}"
+            else:
+                cache_key = self.histogram_colormap
+
+            if self._last_histogram_colormap != cache_key:
+                if histogram_is_solid:
+                    selected_histogram_colormap = (
+                        self._make_solid_contour_cmap(
+                            "histogram_solid",
+                            self._histogram_color,
+                        )
+                    )
+                else:
+                    selected_histogram_colormap = colormaps.ALL_COLORMAPS[
+                        self.histogram_colormap
+                    ]
+                    selected_histogram_colormap = (
+                        LinearSegmentedColormap.from_list(
+                            self.histogram_colormap,
+                            selected_histogram_colormap.colors,
+                        )
+                    )
+                histogram_artist.histogram_colormap = (
+                    selected_histogram_colormap
+                )
+                self._last_histogram_colormap = cache_key
+                self._last_histogram_colormap_object = (
+                    selected_histogram_colormap
                 )
             else:
-                selected_histogram_colormap = colormaps.ALL_COLORMAPS[
-                    self.histogram_colormap
-                ]
                 selected_histogram_colormap = (
-                    LinearSegmentedColormap.from_list(
-                        self.histogram_colormap,
-                        selected_histogram_colormap.colors,
+                    self._last_histogram_colormap_object
+                )
+
+            if histogram_artist.histogram is not None:
+                current_norm = "log" if self.histogram_log_scale else "linear"
+                if self._last_histogram_norm != current_norm:
+                    histogram_artist.histogram_color_normalization_method = (
+                        current_norm
                     )
-                )
-            histogram_artist.histogram_colormap = selected_histogram_colormap
-            self._last_histogram_colormap = cache_key
-            self._last_histogram_colormap_object = selected_histogram_colormap
-        else:
-            selected_histogram_colormap = self._last_histogram_colormap_object
+                    self._last_histogram_norm = current_norm
 
-        if histogram_artist.histogram is not None:
-            current_norm = "log" if self.histogram_log_scale else "linear"
-            if self._last_histogram_norm != current_norm:
-                histogram_artist.histogram_color_normalization_method = (
-                    current_norm
-                )
-                self._last_histogram_norm = current_norm
+            target_color_indices = (
+                selection_id_data if selection_id_data is not None else 0
+            )
 
-        target_color_indices = (
-            selection_id_data if selection_id_data is not None else 0
-        )
+            indices_changed = False
+            if isinstance(target_color_indices, np.ndarray):
+                if (
+                    self._last_histogram_color_indices is None
+                    or not isinstance(
+                        self._last_histogram_color_indices, np.ndarray
+                    )
+                    or not np.array_equal(
+                        self._last_histogram_color_indices,
+                        target_color_indices,
+                    )
+                ):
+                    indices_changed = True
+            else:
+                if (
+                    self._last_histogram_color_indices is None
+                    or isinstance(
+                        self._last_histogram_color_indices, np.ndarray
+                    )
+                    or self._last_histogram_color_indices
+                    != target_color_indices
+                ):
+                    indices_changed = True
 
-        indices_changed = False
-        if isinstance(target_color_indices, np.ndarray):
-            if (
-                self._last_histogram_color_indices is None
-                or not isinstance(
-                    self._last_histogram_color_indices, np.ndarray
-                )
-                or not np.array_equal(
-                    self._last_histogram_color_indices, target_color_indices
-                )
-            ):
-                indices_changed = True
-        else:
-            if (
-                self._last_histogram_color_indices is None
-                or isinstance(self._last_histogram_color_indices, np.ndarray)
-                or self._last_histogram_color_indices != target_color_indices
-            ):
-                indices_changed = True
+            if indices_changed:
+                histogram_artist.color_indices = target_color_indices
+                self._last_histogram_color_indices = target_color_indices
 
-        if indices_changed:
-            histogram_artist.color_indices = target_color_indices
-            self._last_histogram_color_indices = target_color_indices
-
-        self._update_colorbar(selected_histogram_colormap)
+            self._update_colorbar(selected_histogram_colormap)
 
     def _clear_contour_plot(self):
         """Clear all contour collections from the plot."""


### PR DESCRIPTION
This PR proposes to suppress the UserWarning from biaplotter/matplotlib when the log scale toggle is on in Density Plot mode.

Closes #297 

Wrapped the entire body of the `_update_histogram_plot` function in a `warnings.catch_warnings()` context block, ignoring both "Log normalization applied to color indices*" and "Attempt to set non-positive `ylim` on a log-scaled axis will be ignored*" warning messages. This ensures that no matter what action triggers a plot refresh (such as changing bins, layer selections, colormaps, or cursor selections), these specific warnings will not clutter the terminal or UI.

Added the unit test `test_density_plot_log_scale_warning_suppression`. This test sets `plotter.plot_type` to 'HISTOGRAM2D', turns on `plotter.histogram_log_scale`, triggers a plot update, and checks that none of the warning messages regarding log normalization or non-positive ylim are raised.