### PR TITLE
Fix: Properly handle exporting multiple selected layers from the napari menu

### DIFF
--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -551,3 +551,49 @@ def test_write_ometif_masked_non_phasor(tmp_path):
         assert written_data.shape == (2, 5)
         assert np.isnan(written_data[0, 0])
         assert not np.isnan(written_data[0, 1:]).any()
+
+
+def test_export_layer_as_image_tuple_colormap(tmp_path):
+    """Test export_layer_as_image with a layer data tuple containing a dict colormap."""
+    from PIL import Image as PILImage
+
+    from napari_phasors._writer import export_layer_as_image
+
+    # Use a gradient data array to ensure we span the colormap
+    data = np.linspace(0, 1, 100).reshape((10, 10))
+
+    # A custom colormap dict with different red and blue endpoints
+    colormap_dict = {
+        "name": "custom_red_blue",
+        "colors": [
+            [1.0, 0.0, 0.0, 1.0],  # Red at 0
+            [0.0, 0.0, 1.0, 1.0],  # Blue at 1
+        ],
+    }
+
+    layer_tuple = (
+        data,
+        {
+            "name": "test_image",
+            "colormap": colormap_dict,
+            "contrast_limits": [0.0, 1.0],
+            "metadata": {},
+        },
+        "image",
+    )
+
+    export_path = os.path.join(tmp_path, "test_image_export.png")
+    export_layer_as_image(export_path, layer_tuple, include_colorbar=False)
+
+    assert os.path.exists(export_path)
+
+    # Open and verify the image has color representation (not black and white)
+    img = PILImage.open(export_path)
+    img_data = np.array(img)
+
+    assert img_data.ndim == 3
+    assert img_data.shape[-1] in (3, 4)
+
+    # Verify that the image is colored (R != B, since some parts are red, some blue)
+    is_colored = np.any(img_data[..., 0] != img_data[..., 2])
+    assert is_colored, "Exported image is grayscale!"

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -105,6 +105,58 @@ def _extract_z_spacing_um(
     return value if value > 0 else None
 
 
+def _get_export_path(
+    path: str,
+    layer_name: str,
+    layers_to_export: list[Any],
+    layer_names: list[str],
+) -> str:
+    """Determine the file path for a layer, preventing overwrites during multi-layer exports."""
+    import os
+
+    import napari
+
+    directory = os.path.dirname(path)
+    full_basename = os.path.basename(path)
+
+    # Determine extension and base name
+    if full_basename.lower().endswith(".ome.tif"):
+        base_name = full_basename[:-8]
+        ext = ".ome.tif"
+    elif full_basename.lower().endswith(".ome.tiff"):
+        base_name = full_basename[:-9]
+        ext = ".ome.tiff"
+    else:
+        base_name, ext = os.path.splitext(full_basename)
+
+    # Try to detect if we are saving multiple selected layers via the napari GUI
+    viewer = napari.current_viewer()
+    is_multi_save = False
+    viewer_layer_names = []
+    if viewer is not None:
+        selected_layers = list(viewer.layers.selection)
+        if len(selected_layers) > 1:
+            is_multi_save = True
+            viewer_layer_names = [layer.name for layer in selected_layers]
+
+    if len(layers_to_export) > 1:
+        user_provided_name = base_name not in layer_names
+        if user_provided_name:
+            filename = f"{base_name}_{layer_name}{ext}"
+        else:
+            filename = f"{layer_name}{ext}"
+    elif is_multi_save and layer_name in viewer_layer_names:
+        user_provided_name = base_name not in viewer_layer_names
+        if user_provided_name:
+            filename = f"{base_name}_{layer_name}{ext}"
+        else:
+            filename = f"{layer_name}{ext}"
+    else:
+        filename = f"{base_name}{ext}"
+
+    return os.path.join(directory, filename)
+
+
 def write_ome_tiff(
     path: str,
     image_layer: Any,
@@ -132,187 +184,216 @@ def write_ome_tiff(
     A list containing the string path to the saved file.
     """
     # Extract metadata depending on input type
-    if hasattr(image_layer, 'data') and hasattr(image_layer, 'metadata'):
-        metadata = image_layer.metadata
-        data = image_layer.data
+
+    if isinstance(image_layer, list) and not hasattr(image_layer, 'data'):
+        layers_to_export = image_layer
     else:
-        metadata = image_layer[0][1].get("metadata", {})
-        data = image_layer[0][0]
+        layers_to_export = [image_layer]
 
-    z_spacing_um = _extract_z_spacing_um(image_layer, data, metadata)
-
-    # Check if layer has phasor data
-    has_phasor_data = (
-        "original_mean" in metadata
-        and "G_original" in metadata
-        and "S_original" in metadata
-        and "harmonics" in metadata
-    )
-
-    if not (
-        path.lower().endswith(".ome.tif") or path.lower().endswith(".ome.tiff")
-    ):
-        path += ".ome.tif"
-
-    dims = None
-    if hasattr(image_layer, 'axis_labels'):
-        labels = getattr(image_layer, 'axis_labels', None)
-        if labels is not None and len(labels) == data.ndim:
-            dims = "".join(str(label).upper()[0] for label in labels)
-            if not dims.endswith(("YX", "YXS")):
-                dims = None
-
-    if not dims:
-        if data.ndim == 2:
-            dims = "YX"
-        elif data.ndim == 3:
-            dims = "ZYX"
-        elif data.ndim == 4:
-            dims = "TZYX"
+    layer_names = []
+    for idx, current_layer in enumerate(layers_to_export):
+        if hasattr(current_layer, 'data') and hasattr(
+            current_layer, 'metadata'
+        ):
+            layer_names.append(getattr(current_layer, 'name', f"layer_{idx}"))
         else:
-            dims = "TZCYX"[-data.ndim :] if data.ndim <= 5 else None
+            attributes = (
+                current_layer[1]
+                if isinstance(current_layer, (list, tuple))
+                and len(current_layer) > 1
+                else {}
+            )
+            layer_names.append(
+                attributes.get("name", f"layer_{idx}")
+                if isinstance(attributes, dict)
+                else f"layer_{idx}"
+            )
 
-    metadata_dict = {}
+    saved_paths = []
+    for i, current_layer in enumerate(layers_to_export):
+        if hasattr(current_layer, 'data') and hasattr(
+            current_layer, 'metadata'
+        ):
+            metadata = current_layer.metadata
+            data = current_layer.data
+            layer_name = getattr(current_layer, 'name', f"layer_{i}")
+        else:
+            metadata = current_layer[1].get("metadata", {})
+            data = current_layer[0]
+            layer_name = current_layer[1].get("name", f"layer_{i}")
 
-    if z_spacing_um is not None:
-        metadata_dict['PhysicalSizeZ'] = z_spacing_um
-        metadata_dict['PhysicalSizeZUnit'] = 'µm'
+        current_path = _get_export_path(
+            path, layer_name, layers_to_export, layer_names
+        )
 
-    if hasattr(image_layer, 'scale'):
-        scale = getattr(image_layer, 'scale', None)
-        if scale is not None:
-            y_idx, x_idx = -2, -1
-            labels = getattr(image_layer, 'axis_labels', None)
-            if labels is not None:
-                for i, label in enumerate(labels):
-                    if str(label).lower() == 'y':
-                        y_idx = i
-                    if str(label).lower() == 'x':
-                        x_idx = i
+        z_spacing_um = _extract_z_spacing_um(current_layer, data, metadata)
 
-            if len(scale) > abs(y_idx) and scale[y_idx] > 0:
-                metadata_dict['PhysicalSizeY'] = float(scale[y_idx])
-                metadata_dict['PhysicalSizeYUnit'] = 'µm'
-            if len(scale) > abs(x_idx) and scale[x_idx] > 0:
-                metadata_dict['PhysicalSizeX'] = float(scale[x_idx])
-                metadata_dict['PhysicalSizeXUnit'] = 'µm'
+        # Check if layer has phasor data
+        has_phasor_data = (
+            "original_mean" in metadata
+            and "G_original" in metadata
+            and "S_original" in metadata
+            and "harmonics" in metadata
+        )
 
-    pbr = show_activity_progress(desc="Saving OME-TIFF...", total=2)
-    try:
-        if has_phasor_data:
-            # Export with phasor data
-            mean = metadata["original_mean"]
-            G = metadata["G_original"]
-            S = metadata["S_original"]
-            harmonics = metadata["harmonics"]
+        dims = None
+        if hasattr(current_layer, 'axis_labels'):
+            labels = getattr(current_layer, 'axis_labels', None)
+            if labels is not None and len(labels) == data.ndim:
+                dims = "".join(str(label).upper()[0] for label in labels)
+                if not dims.endswith(("YX", "YXS")):
+                    dims = None
 
-            if export_masked and "mask" in metadata:
-                mask_data = metadata["mask"]
-                invert = metadata.get("mask_invert", False)
-                mask_invalid = mask_data > 0 if invert else mask_data <= 0
-
-                mean = np.where(mask_invalid, np.nan, mean.copy())
-
-                if G.ndim > mask_invalid.ndim:
-                    mask_invalid_expanded = mask_invalid[np.newaxis, ...]
-                    G = np.where(mask_invalid_expanded, np.nan, G.copy())
-                    S = np.where(mask_invalid_expanded, np.nan, S.copy())
-                else:
-                    G = np.where(mask_invalid, np.nan, G.copy())
-                    S = np.where(mask_invalid, np.nan, S.copy())
-
-            if "settings" in metadata:
-                settings = metadata["settings"].copy()
+        if not dims:
+            if data.ndim == 2:
+                dims = "YX"
+            elif data.ndim == 3:
+                dims = "ZYX"
+            elif data.ndim == 4:
+                dims = "TZYX"
             else:
-                settings = {}
-            if "summed_signal" in metadata:
-                summed = metadata["summed_signal"]
-                settings["summed_signal"] = (
-                    summed.tolist() if hasattr(summed, 'tolist') else summed
-                )
-            if z_spacing_um is not None:
-                settings["z_spacing_um"] = z_spacing_um
+                dims = "TZCYX"[-data.ndim :] if data.ndim <= 5 else None
 
-            # Convert NumPy arrays in selections to lists for JSON serialization
-            if "selections" in settings:
-                # Make a copy of selections dict to avoid mutating the layer's metadata
-                settings["selections"] = settings["selections"].copy()
-                if "manual_selections" in settings["selections"]:
-                    # Note: The following code is commented out to avoid saving large selection maps.
-                    # manual_selections = {}
-                    # for sel_id, sel_array in settings["selections"]["manual_selections"].items():
-                    #     manual_selections[sel_id] = (
-                    #         sel_array.tolist() if hasattr(sel_array, 'tolist') else sel_array
-                    #     )
-                    # settings["selections"]["manual_selections"] = manual_selections
-                    del settings["selections"]["manual_selections"]
+        metadata_dict = {}
 
-            settings["version"] = str(
-                importlib.metadata.version('napari-phasors')
-            )
-            settings = _convert_numpy_types(settings)
-            description = json.dumps(
-                {"napari_phasors_settings": json.dumps(settings)}
-            )
-            pbr.set_description("Writing phasor data...")
-            pbr.update(1)
-            phasor_to_ometiff(
-                path,
-                mean,
-                G,
-                S,
-                harmonic=harmonics,
-                description=description,
-                dims=dims,
-                metadata=metadata_dict,
-            )
-        else:
-            # Export without phasor data - just save the raw image data
-            import tifffile
+        if z_spacing_um is not None:
+            metadata_dict['PhysicalSizeZ'] = z_spacing_um
+            metadata_dict['PhysicalSizeZUnit'] = 'µm'
 
-            # Prepare basic metadata
-            settings = {}
-            if "settings" in metadata:
-                settings = metadata["settings"].copy()
-            if z_spacing_um is not None:
-                settings["z_spacing_um"] = z_spacing_um
+        if hasattr(current_layer, 'scale'):
+            scale = getattr(current_layer, 'scale', None)
+            if scale is not None:
+                y_idx, x_idx = -2, -1
+                labels = getattr(current_layer, 'axis_labels', None)
+                if labels is not None:
+                    for i_label, label in enumerate(labels):
+                        if str(label).lower() == 'y':
+                            y_idx = i_label
+                        if str(label).lower() == 'x':
+                            x_idx = i_label
 
-            settings["version"] = str(
-                importlib.metadata.version('napari-phasors')
-            )
-            settings = _convert_numpy_types(settings)
-            description = json.dumps(
-                {"napari_phasors_settings": json.dumps(settings)}
-            )
+                if len(scale) > abs(y_idx) and scale[y_idx] > 0:
+                    metadata_dict['PhysicalSizeY'] = float(scale[y_idx])
+                    metadata_dict['PhysicalSizeYUnit'] = 'µm'
+                if len(scale) > abs(x_idx) and scale[x_idx] > 0:
+                    metadata_dict['PhysicalSizeX'] = float(scale[x_idx])
+                    metadata_dict['PhysicalSizeXUnit'] = 'µm'
 
-            if dims:
-                metadata_dict['axes'] = dims
+        pbr = show_activity_progress(
+            desc=f"Saving OME-TIFF {layer_name}...", total=2
+        )
+        try:
+            if has_phasor_data:
+                # Export with phasor data
+                mean = metadata["original_mean"]
+                G = metadata["G_original"]
+                S = metadata["S_original"]
+                harmonics = metadata["harmonics"]
 
-            if export_masked and "mask" in metadata:
-                mask_data = metadata["mask"]
-                invert = metadata.get("mask_invert", False)
-                mask_invalid = mask_data > 0 if invert else mask_data <= 0
+                if export_masked and "mask" in metadata:
+                    mask_data = metadata["mask"]
+                    invert = metadata.get("mask_invert", False)
+                    mask_invalid = mask_data > 0 if invert else mask_data <= 0
 
-                if data.ndim > mask_invalid.ndim:
-                    expanded_shape = [1] * (
-                        data.ndim - mask_invalid.ndim
-                    ) + list(mask_invalid.shape)
-                    mask_invalid_expanded = mask_invalid.reshape(
-                        expanded_shape
-                    )
-                    data = np.where(mask_invalid_expanded, np.nan, data.copy())
+                    mean = np.where(mask_invalid, np.nan, mean.copy())
+
+                    if G.ndim > mask_invalid.ndim:
+                        mask_invalid_expanded = mask_invalid[np.newaxis, ...]
+                        G = np.where(mask_invalid_expanded, np.nan, G.copy())
+                        S = np.where(mask_invalid_expanded, np.nan, S.copy())
+                    else:
+                        G = np.where(mask_invalid, np.nan, G.copy())
+                        S = np.where(mask_invalid, np.nan, S.copy())
+
+                if "settings" in metadata:
+                    settings = metadata["settings"].copy()
                 else:
-                    data = np.where(mask_invalid, np.nan, data.copy())
+                    settings = {}
+                if "summed_signal" in metadata:
+                    summed = metadata["summed_signal"]
+                    settings["summed_signal"] = (
+                        summed.tolist()
+                        if hasattr(summed, 'tolist')
+                        else summed
+                    )
+                if z_spacing_um is not None:
+                    settings["z_spacing_um"] = z_spacing_um
 
-            tifffile.imwrite(
-                path,
-                data,
-                metadata=metadata_dict if metadata_dict else None,
-                description=description,
-            )
-    finally:
-        pbr.close()
-    return [path]
+                # Convert NumPy arrays in selections to lists for JSON serialization
+                if "selections" in settings:
+                    settings["selections"] = settings["selections"].copy()
+                    if "manual_selections" in settings["selections"]:
+                        del settings["selections"]["manual_selections"]
+
+                settings["version"] = str(
+                    importlib.metadata.version('napari-phasors')
+                )
+                settings = _convert_numpy_types(settings)
+                description = json.dumps(
+                    {"napari_phasors_settings": json.dumps(settings)}
+                )
+                pbr.set_description("Writing phasor data...")
+                pbr.update(1)
+                phasor_to_ometiff(
+                    current_path,
+                    mean,
+                    G,
+                    S,
+                    harmonic=harmonics,
+                    description=description,
+                    dims=dims,
+                    metadata=metadata_dict,
+                )
+            else:
+                # Export without phasor data - just save the raw image data
+                import tifffile
+
+                # Prepare basic metadata
+                settings = {}
+                if "settings" in metadata:
+                    settings = metadata["settings"].copy()
+                if z_spacing_um is not None:
+                    settings["z_spacing_um"] = z_spacing_um
+
+                settings["version"] = str(
+                    importlib.metadata.version('napari-phasors')
+                )
+                settings = _convert_numpy_types(settings)
+                description = json.dumps(
+                    {"napari_phasors_settings": json.dumps(settings)}
+                )
+
+                if dims:
+                    metadata_dict['axes'] = dims
+
+                if export_masked and "mask" in metadata:
+                    mask_data = metadata["mask"]
+                    invert = metadata.get("mask_invert", False)
+                    mask_invalid = mask_data > 0 if invert else mask_data <= 0
+
+                    if data.ndim > mask_invalid.ndim:
+                        expanded_shape = [1] * (
+                            data.ndim - mask_invalid.ndim
+                        ) + list(mask_invalid.shape)
+                        mask_invalid_expanded = mask_invalid.reshape(
+                            expanded_shape
+                        )
+                        data = np.where(
+                            mask_invalid_expanded, np.nan, data.copy()
+                        )
+                    else:
+                        data = np.where(mask_invalid, np.nan, data.copy())
+
+                tifffile.imwrite(
+                    current_path,
+                    data,
+                    metadata=metadata_dict if metadata_dict else None,
+                    description=description,
+                )
+            saved_paths.append(current_path)
+        finally:
+            pbr.close()
+    return saved_paths
 
 
 def export_layer_as_image(
@@ -343,121 +424,184 @@ def export_layer_as_image(
         provided and the data is multi-dimensional, the first index (0) is used
         for each non-spatial dimension.
     """
-    if hasattr(image_layer, 'data'):
-        data = image_layer.data
-        is_labels = isinstance(image_layer, Labels)
-        colormap = getattr(image_layer, 'colormap', None)
-        contrast_limits = getattr(image_layer, 'contrast_limits', None)
-    else:
-        data = image_layer[0][0]
-        attributes = image_layer[0][1]
-        is_labels = image_layer[0][2] == 'labels'
-        colormap = attributes.get('colormap', None)
-        contrast_limits = attributes.get('contrast_limits', None)
 
-    if data.ndim > 2:
-        if current_step is not None:
-            step = list(current_step)
-            indices = [
-                step[i] if i < len(step) else 0 for i in range(data.ndim - 2)
-            ]
+    if isinstance(image_layer, list) and not hasattr(image_layer, 'data'):
+        layers_to_export = image_layer
+    else:
+        layers_to_export = [image_layer]
+
+    layer_names = []
+    for idx, current_layer in enumerate(layers_to_export):
+        if hasattr(current_layer, 'data'):
+            layer_names.append(getattr(current_layer, 'name', f"layer_{idx}"))
         else:
-            indices = [0] * (data.ndim - 2)
+            attributes = (
+                current_layer[1]
+                if isinstance(current_layer, (list, tuple))
+                and len(current_layer) > 1
+                else {}
+            )
+            layer_names.append(
+                attributes.get("name", f"layer_{idx}")
+                if isinstance(attributes, dict)
+                else f"layer_{idx}"
+            )
 
-        slice_indices = tuple(indices) + (slice(None), slice(None))
-        data_2d = data[slice_indices]
-    else:
-        data_2d = data
+    saved_paths = []
 
-    if is_labels:
-        include_colorbar = False
-        if colormap is not None and hasattr(colormap, 'map'):
-            try:
-                data_2d = colormap.map(data_2d)
-            except Exception:  # noqa: BLE001
+    for i, current_layer in enumerate(layers_to_export):
+        if hasattr(current_layer, 'data'):
+            data = current_layer.data
+            is_labels = isinstance(current_layer, Labels)
+            colormap = getattr(current_layer, 'colormap', None)
+            contrast_limits = getattr(current_layer, 'contrast_limits', None)
+            layer_name = getattr(current_layer, 'name', f"layer_{i}")
+        else:
+            data = (
+                current_layer[0][0]
+                if isinstance(current_layer[0], tuple)
+                else current_layer[0]
+            )
+            attributes = current_layer[1] if len(current_layer) > 1 else {}
+            is_labels = (
+                current_layer[2] == 'labels'
+                if len(current_layer) > 2
+                else False
+            )
+            colormap = attributes.get('colormap', None)
+            contrast_limits = attributes.get('contrast_limits', None)
+            layer_name = attributes.get('name', f"layer_{i}")
+
+        current_path = _get_export_path(
+            path, layer_name, layers_to_export, layer_names
+        )
+
+        if data.ndim > 2:
+            if current_step is not None:
+                step = list(current_step)
+                indices = [
+                    step[idx] if idx < len(step) else 0
+                    for idx in range(data.ndim - 2)
+                ]
+            else:
+                indices = [0] * (data.ndim - 2)
+
+            slice_indices = tuple(indices) + (slice(None), slice(None))
+            data_2d = data[slice_indices]
+        else:
+            data_2d = data
+
+        if is_labels:
+            layer_include_colorbar = False
+            if colormap is not None and hasattr(colormap, 'map'):
+                try:
+                    data_2d = colormap.map(data_2d)
+                except Exception:  # noqa: BLE001
+                    cmap = 'nipy_spectral'
+                    clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
+            else:
                 cmap = 'nipy_spectral'
                 clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
         else:
-            cmap = 'nipy_spectral'
-            clim = [0, data_2d.max() if data_2d.max() > 0 else 1]
-    else:
-        napari_cmap = colormap
-        if hasattr(napari_cmap, "colors"):
-            cmap = LinearSegmentedColormap.from_list(
-                napari_cmap.name, napari_cmap.colors
+            layer_include_colorbar = include_colorbar
+            napari_cmap = colormap
+            if isinstance(napari_cmap, dict):
+                cmap_name = napari_cmap.get("name", "gray")
+                cmap_colors = napari_cmap.get("colors", None)
+                if cmap_colors is not None:
+                    try:
+                        cmap = LinearSegmentedColormap.from_list(
+                            cmap_name, cmap_colors
+                        )
+                    except Exception:  # noqa: BLE001
+                        try:
+                            cmap = plt.get_cmap(cmap_name)
+                        except Exception:  # noqa: BLE001
+                            cmap = plt.get_cmap("gray")
+                else:
+                    try:
+                        cmap = plt.get_cmap(cmap_name)
+                    except Exception:  # noqa: BLE001
+                        cmap = plt.get_cmap("gray")
+            elif hasattr(napari_cmap, "colors"):
+                cmap_name = getattr(napari_cmap, "name", "custom") or "custom"
+                cmap = LinearSegmentedColormap.from_list(
+                    cmap_name, napari_cmap.colors
+                )
+            else:
+                try:
+                    name = getattr(napari_cmap, "name", napari_cmap) or "gray"
+                    cmap = plt.get_cmap(name)
+                except (AttributeError, ValueError, TypeError):
+                    cmap = plt.get_cmap("gray")
+            clim = (
+                contrast_limits
+                if contrast_limits is not None
+                else [data_2d.min(), data_2d.max()]
+            )
+
+        # Calculate aspect ratio from data shape
+        height, width = data_2d.shape[:2]
+        aspect_ratio = width / height
+
+        base_height = 8
+        base_width = base_height * aspect_ratio
+
+        if layer_include_colorbar:
+            colorbar_width = 0.5  # Width for colorbar in inches
+            total_width = base_width + colorbar_width
+            fig, (ax, cax) = plt.subplots(
+                1,
+                2,
+                figsize=(total_width, base_height),
+                gridspec_kw={"width_ratios": [base_width, colorbar_width]},
+                facecolor="black",
             )
         else:
-            try:
-                name = getattr(napari_cmap, "name", napari_cmap) or "gray"
-                cmap = plt.get_cmap(name)
-            except (AttributeError, ValueError, TypeError):
-                cmap = plt.get_cmap("gray")
-        clim = (
-            contrast_limits
-            if contrast_limits is not None
-            else [data_2d.min(), data_2d.max()]
-        )
-
-    # Calculate aspect ratio from data shape
-    height, width = data_2d.shape[:2]
-    aspect_ratio = width / height
-
-    base_height = 8
-    base_width = base_height * aspect_ratio
-
-    if include_colorbar:
-        colorbar_width = 0.5  # Width for colorbar in inches
-        total_width = base_width + colorbar_width
-        fig, (ax, cax) = plt.subplots(
-            1,
-            2,
-            figsize=(total_width, base_height),
-            gridspec_kw={"width_ratios": [base_width, colorbar_width]},
-            facecolor="black",
-        )
-    else:
-        fig, ax = plt.subplots(
-            figsize=(base_width, base_height), facecolor="black"
-        )
-
-    imshow_kwargs = {
-        "interpolation": "nearest",
-        "aspect": "auto",
-    }
-    if data_2d.ndim == 2:
-        imshow_kwargs["cmap"] = cmap
-        imshow_kwargs["vmin"] = clim[0]
-        imshow_kwargs["vmax"] = clim[1]
-
-    im = ax.imshow(data_2d, **imshow_kwargs)
-    ax.axis("off")
-
-    if include_colorbar:
-        cbar = plt.colorbar(im, cax=cax)
-        cbar.ax.tick_params(colors="white")
-
-    plt.tight_layout(pad=0)
-
-    dpi = 300
-
-    # For JPEG, set facecolor to white since it doesn't support transparency
-    if path.endswith((".jpg", ".jpeg")):
-        fig.patch.set_facecolor("white")
-        if include_colorbar:
-            cax.set_ylabel(
-                "Intensity", rotation=270, labelpad=15, color="black"
+            fig, ax = plt.subplots(
+                figsize=(base_width, base_height), facecolor="black"
             )
-            cbar.ax.tick_params(colors="black")
 
-    plt.savefig(
-        path,
-        dpi=dpi,
-        bbox_inches="tight",
-        pad_inches=0.1,
-        facecolor=fig.get_facecolor(),
-    )
-    plt.close(fig)
-    return [path]
+        imshow_kwargs = {
+            "interpolation": "nearest",
+            "aspect": "auto",
+        }
+        if data_2d.ndim == 2:
+            imshow_kwargs["cmap"] = cmap
+            imshow_kwargs["vmin"] = clim[0]
+            imshow_kwargs["vmax"] = clim[1]
+
+        im = ax.imshow(data_2d, **imshow_kwargs)
+        ax.axis("off")
+
+        if layer_include_colorbar:
+            cbar = plt.colorbar(im, cax=cax)
+            cbar.ax.tick_params(colors="white")
+
+        plt.tight_layout(pad=0)
+
+        dpi = 300
+
+        # For JPEG, set facecolor to white since it doesn't support transparency
+        if current_path.endswith((".jpg", ".jpeg")):
+            fig.patch.set_facecolor("white")
+            if layer_include_colorbar:
+                cax.set_ylabel(
+                    "Intensity", rotation=270, labelpad=15, color="black"
+                )
+                cbar.ax.tick_params(colors="black")
+
+        plt.savefig(
+            current_path,
+            dpi=dpi,
+            bbox_inches="tight",
+            pad_inches=0.1,
+            facecolor=fig.get_facecolor(),
+        )
+        plt.close(fig)
+        saved_paths.append(current_path)
+
+    return saved_paths
 
 
 def export_layer_as_csv(path: str, image_layer: Any) -> list[str]:
@@ -478,79 +622,116 @@ def export_layer_as_csv(path: str, image_layer: Any) -> list[str]:
     image_layer : Any
         Image or Labels layer to export, or layer data tuple from napari writer.
     """
-    if hasattr(image_layer, 'data'):
-        data = image_layer.data
-        metadata = getattr(image_layer, 'metadata', {})
+
+    if isinstance(image_layer, list) and not hasattr(image_layer, 'data'):
+        layers_to_export = image_layer
     else:
-        data = image_layer[0][0]
-        metadata = image_layer[0][1].get("metadata", {})
+        layers_to_export = [image_layer]
 
-    has_phasor_data = (
-        "G" in metadata and "S" in metadata and "harmonics" in metadata
-    )
-
-    if has_phasor_data:
-        G = metadata["G"]
-        S = metadata["S"]
-        G_original = metadata.get("G_original", G)
-        S_original = metadata.get("S_original", S)
-        harmonics = np.atleast_1d(metadata["harmonics"])
-
-        # Get spatial shape (last 2 dimensions)
-        spatial_shape = G.shape[-2:]
-        n_pixels = np.prod(spatial_shape)
-
-        # Create coordinate arrays
-        coords = np.unravel_index(np.arange(n_pixels), spatial_shape)
-
-        # Build dataframe with phasor data
-        rows = []
-        for h_idx, harmonic in enumerate(harmonics):
-            # Handle both 2D (single harmonic) and 3D (multiple harmonics) cases
-            if G.ndim == 3:
-                g_flat = G[h_idx].ravel()
-                s_flat = S[h_idx].ravel()
-                g_orig_flat = G_original[h_idx].ravel()
-                s_orig_flat = S_original[h_idx].ravel()
-            else:
-                g_flat = G.ravel()
-                s_flat = S.ravel()
-                g_orig_flat = G_original.ravel()
-                s_orig_flat = S_original.ravel()
-
-            for px_idx in range(n_pixels):
-                if not (np.isnan(g_flat[px_idx]) and np.isnan(s_flat[px_idx])):
-                    row = {
-                        'harmonic': harmonic,
-                        'G': g_flat[px_idx],
-                        'S': s_flat[px_idx],
-                        'G_original': g_orig_flat[px_idx],
-                        'S_original': s_orig_flat[px_idx],
-                    }
-                    for dim, coord in enumerate(coords):
-                        row[f'dim_{dim}'] = coord[px_idx]
-                    rows.append(row)
-
-        df = pd.DataFrame(rows)
-        df.to_csv(path, index=False)
-    else:
-        if data.ndim == 2:
-            rows, cols = data.shape
-            y_coords, x_coords = np.meshgrid(
-                range(rows), range(cols), indexing="ij"
-            )
-            df = pd.DataFrame(
-                {
-                    "y": y_coords.ravel(),
-                    "x": x_coords.ravel(),
-                    "value": data.ravel(),
-                }
-            )
+    layer_names = []
+    for idx, current_layer in enumerate(layers_to_export):
+        if hasattr(current_layer, 'data'):
+            layer_names.append(getattr(current_layer, 'name', f"layer_{idx}"))
         else:
-            coords = np.unravel_index(np.arange(data.size), data.shape)
-            df_dict = {f"dim_{i}": coord for i, coord in enumerate(coords)}
-            df_dict["value"] = data.ravel()
-            df = pd.DataFrame(df_dict)
+            attributes = (
+                current_layer[1]
+                if isinstance(current_layer, (list, tuple))
+                and len(current_layer) > 1
+                else {}
+            )
+            layer_names.append(
+                attributes.get("name", f"layer_{idx}")
+                if isinstance(attributes, dict)
+                else f"layer_{idx}"
+            )
 
-        df.to_csv(path, index=False)
-    return [path]
+    saved_paths = []
+
+    for i, current_layer in enumerate(layers_to_export):
+        if hasattr(current_layer, 'data'):
+            data = current_layer.data
+            metadata = getattr(current_layer, 'metadata', {})
+            layer_name = getattr(current_layer, 'name', f"layer_{i}")
+        else:
+            data = current_layer[0]
+            metadata = current_layer[1].get("metadata", {})
+            layer_name = current_layer[1].get("name", f"layer_{i}")
+
+        current_path = _get_export_path(
+            path, layer_name, layers_to_export, layer_names
+        )
+
+        has_phasor_data = (
+            "G" in metadata and "S" in metadata and "harmonics" in metadata
+        )
+
+        if has_phasor_data:
+            G = metadata["G"]
+            S = metadata["S"]
+            G_original = metadata.get("G_original", G)
+            S_original = metadata.get("S_original", S)
+            harmonics = np.atleast_1d(metadata["harmonics"])
+
+            # Get spatial shape (last 2 dimensions)
+            spatial_shape = G.shape[-2:]
+            n_pixels = np.prod(spatial_shape)
+
+            # Create coordinate arrays
+            coords = np.unravel_index(np.arange(n_pixels), spatial_shape)
+
+            # Build dataframe with phasor data
+            rows = []
+            for h_idx, harmonic in enumerate(harmonics):
+                # Handle both 2D (single harmonic) and 3D (multiple harmonics) cases
+                if G.ndim == 3:
+                    g_flat = G[h_idx].ravel()
+                    s_flat = S[h_idx].ravel()
+                    g_orig_flat = G_original[h_idx].ravel()
+                    s_orig_flat = S_original[h_idx].ravel()
+                else:
+                    g_flat = G.ravel()
+                    s_flat = S.ravel()
+                    g_orig_flat = G_original.ravel()
+                    s_orig_flat = S_original.ravel()
+
+                for px_idx in range(n_pixels):
+                    if not (
+                        np.isnan(g_flat[px_idx]) and np.isnan(s_flat[px_idx])
+                    ):
+                        row = {
+                            'harmonic': harmonic,
+                            'G': g_flat[px_idx],
+                            'S': s_flat[px_idx],
+                            'G_original': g_orig_flat[px_idx],
+                            'S_original': s_orig_flat[px_idx],
+                        }
+                        for dim, coord in enumerate(coords):
+                            row[f'dim_{dim}'] = coord[px_idx]
+                        rows.append(row)
+
+            df = pd.DataFrame(rows)
+            df.to_csv(current_path, index=False)
+        else:
+            if data.ndim == 2:
+                rows, cols = data.shape
+                y_coords, x_coords = np.meshgrid(
+                    range(rows), range(cols), indexing="ij"
+                )
+                df = pd.DataFrame(
+                    {
+                        "y": y_coords.ravel(),
+                        "x": x_coords.ravel(),
+                        "value": data.ravel(),
+                    }
+                )
+            else:
+                coords = np.unravel_index(np.arange(data.size), data.shape)
+                df_dict = {
+                    f"dim_{i}": coord for i_dim, coord in enumerate(coords)
+                }
+                df_dict["value"] = data.ravel()
+                df = pd.DataFrame(df_dict)
+
+            df.to_csv(current_path, index=False)
+        saved_paths.append(current_path)
+    return saved_paths

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import json
+import os
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Union
 
@@ -110,10 +111,9 @@ def _get_export_path(
     layer_name: str,
     layers_to_export: list[Any],
     layer_names: list[str],
+    default_ext: str = "",
 ) -> str:
     """Determine the file path for a layer, preventing overwrites during multi-layer exports."""
-    import os
-
     import napari
 
     directory = os.path.dirname(path)
@@ -128,6 +128,8 @@ def _get_export_path(
         ext = ".ome.tiff"
     else:
         base_name, ext = os.path.splitext(full_basename)
+        if not ext and default_ext:
+            ext = default_ext
 
     # Try to detect if we are saving multiple selected layers via the napari GUI
     viewer = napari.current_viewer()
@@ -223,7 +225,11 @@ def write_ome_tiff(
             layer_name = current_layer[1].get("name", f"layer_{i}")
 
         current_path = _get_export_path(
-            path, layer_name, layers_to_export, layer_names
+            path,
+            layer_name,
+            layers_to_export,
+            layer_names,
+            default_ext=".ome.tif",
         )
 
         z_spacing_um = _extract_z_spacing_um(current_layer, data, metadata)
@@ -472,8 +478,14 @@ def export_layer_as_image(
             contrast_limits = attributes.get('contrast_limits', None)
             layer_name = attributes.get('name', f"layer_{i}")
 
+        _, ext = os.path.splitext(path)
+        ext_fallback = ext if ext else ".png"
         current_path = _get_export_path(
-            path, layer_name, layers_to_export, layer_names
+            path,
+            layer_name,
+            layers_to_export,
+            layer_names,
+            default_ext=ext_fallback,
         )
 
         if data.ndim > 2:
@@ -658,7 +670,11 @@ def export_layer_as_csv(path: str, image_layer: Any) -> list[str]:
             layer_name = current_layer[1].get("name", f"layer_{i}")
 
         current_path = _get_export_path(
-            path, layer_name, layers_to_export, layer_names
+            path,
+            layer_name,
+            layers_to_export,
+            layer_names,
+            default_ext=".csv",
         )
 
         has_phasor_data = (
@@ -727,7 +743,7 @@ def export_layer_as_csv(path: str, image_layer: Any) -> list[str]:
             else:
                 coords = np.unravel_index(np.arange(data.size), data.shape)
                 df_dict = {
-                    f"dim_{i}": coord for i_dim, coord in enumerate(coords)
+                    f"dim_{i_dim}": coord for i_dim, coord in enumerate(coords)
                 }
                 df_dict["value"] = data.ravel()
                 df = pd.DataFrame(df_dict)


### PR DESCRIPTION
This PR proposes an updated the writer functions in napari-phasors to properly handle exporting multiple selected layers from the napari menu.

When you select multiple layers and use `File -> Save Selected Layer(s)`, napari passes all of those layers as a list to our writer functions (`write_ome_tiff, export_layer_as_image`, and `export_layer_as_csv`). Previously, the code only processed the first item in that list or sequentially overwrote the same file if called individually, which caused only one layer to be successfully saved at the requested path.

Modified the core `_writer.py` file so that it now:

Iterates over all the layers provided in the export list. If more than one layer is being exported, it dynamically appends the layer name to the end of your chosen filename (e.g., if you choose `my_data.ome.tif`, the layers will be saved as `my_data_layer1.ome.tif`, `my_data_layer2.ome.tif`, etc.). This accurately mimics the exact behavior you currently have inside the plugin's Export Phasor widget and resolves the overwriting bug.