### PR TITLE
refactor: optimize custom import widget plot updates

### DIFF
--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -629,6 +629,101 @@ def test_phasor_transform_ome_tif_preserves_axis_kwargs(make_napari_viewer):
         )
 
 
+def test_fbd_laser_factor_triggers_plot_only_on_editing_finished(
+    make_napari_viewer,
+):
+    """FbdWidget laser_factor should only update the signal plot on editingFinished, not on each keystroke."""
+    viewer = make_napari_viewer()
+    test_file_path = get_test_file_path("test_file$EI0S.fbd")
+    widget = FbdWidget(viewer, path=test_file_path)
+
+    with patch.object(widget, "_update_signal_plot") as mock_update:
+        # Simulate typing character by character (textChanged-like)
+        widget.laser_factor.setText("0")
+        widget.laser_factor.setText("0.")
+        widget.laser_factor.setText("0.0")
+        # None of the setText calls should have triggered a redraw
+        mock_update.assert_not_called()
+
+        # Finishing the edit should trigger exactly one redraw
+        widget.laser_factor.editingFinished.emit()
+        mock_update.assert_called_once()
+
+
+def test_ptu_dtime_triggers_plot_only_on_editing_finished(
+    make_napari_viewer, caplog
+):
+    """PtuWidget dtime should only update the signal plot on editingFinished, not on each keystroke."""
+    viewer = make_napari_viewer()
+    test_file_path = get_test_file_path("test_file.ptu")
+    caplog.set_level(logging.ERROR, logger="ptufile")
+    widget = PtuWidget(viewer, path=test_file_path)
+
+    with patch.object(widget, "_update_signal_plot") as mock_update:
+        widget.dtime.setText("1")
+        widget.dtime.setText("10")
+        widget.dtime.setText("100")
+        mock_update.assert_not_called()
+
+        widget.dtime.editingFinished.emit()
+        mock_update.assert_called_once()
+
+
+def test_sdt_index_triggers_plot_only_on_editing_finished(make_napari_viewer):
+    """SdtWidget index should only update the signal plot on editingFinished, not on each keystroke."""
+    viewer = make_napari_viewer()
+    file_path = get_test_file_path("seminal_receptacle_FLIM_single_image.sdt")
+    widget = SdtWidget(viewer, path=file_path)
+
+    with patch.object(widget, "_update_signal_plot") as mock_update:
+        widget.index.setText("0")
+        widget.index.setText("1")
+        mock_update.assert_not_called()
+
+        widget.index.editingFinished.emit()
+        mock_update.assert_called_once()
+
+
+def test_lif_image_triggers_plot_only_on_editing_finished(make_napari_viewer):
+    """LifWidget image field should only update the signal plot on editingFinished, not on each keystroke."""
+    from phasorpy.datasets import fetch
+
+    from napari_phasors._widget import LifWidget
+
+    viewer = make_napari_viewer()
+    file_path = fetch("paramecium.lif")
+    widget = LifWidget(viewer, path=file_path)
+
+    with patch.object(widget, "_update_signal_plot") as mock_update:
+        widget.image.setText("0")
+        widget.image.setText("01")
+        mock_update.assert_not_called()
+
+        widget.image.editingFinished.emit()
+        mock_update.assert_called_once()
+
+
+def test_json_channel_triggers_plot_only_on_editing_finished(
+    make_napari_viewer,
+):
+    """JsonWidget channel_entry should only update the signal plot on editingFinished, not on each keystroke."""
+    from phasorpy.datasets import fetch
+
+    from napari_phasors._widget import JsonWidget
+
+    viewer = make_napari_viewer()
+    file_path = fetch("Fluorescein_Calibration_m2_1740751189_imaging.json")
+    widget = JsonWidget(viewer, path=file_path)
+
+    with patch.object(widget, "_update_signal_plot") as mock_update:
+        widget.channel_entry.setText("0")
+        widget.channel_entry.setText("1")
+        mock_update.assert_not_called()
+
+        widget.channel_entry.editingFinished.emit()
+        mock_update.assert_called_once()
+
+
 def test_harmonic_range_slider_functionality(make_napari_viewer):
     """Test QRangeSlider functionality for harmonics in all widget types."""
     viewer = make_napari_viewer()

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -684,25 +684,6 @@ def test_sdt_index_triggers_plot_only_on_editing_finished(make_napari_viewer):
         mock_update.assert_called_once()
 
 
-def test_lif_image_triggers_plot_only_on_editing_finished(make_napari_viewer):
-    """LifWidget image field should only update the signal plot on editingFinished, not on each keystroke."""
-    from phasorpy.datasets import fetch
-
-    from napari_phasors._widget import LifWidget
-
-    viewer = make_napari_viewer()
-    file_path = fetch("paramecium.lif")
-    widget = LifWidget(viewer, path=file_path)
-
-    with patch.object(widget, "_update_signal_plot") as mock_update:
-        widget.image.setText("0")
-        widget.image.setText("01")
-        mock_update.assert_not_called()
-
-        widget.image.editingFinished.emit()
-        mock_update.assert_called_once()
-
-
 def test_json_channel_triggers_plot_only_on_editing_finished(
     make_napari_viewer,
 ):

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -11,6 +11,7 @@ import glob
 import json
 import logging
 import os
+import warnings
 from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING
 
@@ -1370,9 +1371,11 @@ class FbdWidget(AdvancedOptionsWidget):
         """Initialize the widget."""
         from fbdfile import FbdFile
 
-        with FbdFile(path) as fbd:
-            self.all_frames = len(fbd.frames(None)[1])
-            self.all_channels = fbd.channels
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with FbdFile(path) as fbd:
+                self.all_frames = len(fbd.frames(None)[1])
+                self.all_channels = fbd.channels
 
         super().__init__(viewer, path)
         self.reader_options["frame"] = -1
@@ -1400,7 +1403,7 @@ class FbdWidget(AdvancedOptionsWidget):
         self.laser_factor.setValidator(QDoubleValidator())
         laser_factor_completer = QCompleter(["0.00022", "2.50012", "2.50016"])
         self.laser_factor.setCompleter(laser_factor_completer)
-        self.laser_factor.textChanged.connect(
+        self.laser_factor.editingFinished.connect(
             lambda: self._update_signal_plot()
         )
         laser_layout.addWidget(self.laser_factor)
@@ -1426,7 +1429,9 @@ class FbdWidget(AdvancedOptionsWidget):
             options["laser_factor"] = float(self.laser_factor.text())
 
         try:
-            signal = signal_from_fbd(self.path, **options)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                signal = signal_from_fbd(self.path, **options)
             return signal
         except Exception as e:  # noqa: BLE001
             show_error(f"Error reading FBD signal: {str(e)}")
@@ -1486,7 +1491,7 @@ class PtuWidget(AdvancedOptionsWidget):
             "If < 0, integrate delay time axis."
             "If > 0, return up to specified bin."
         )
-        self.dtime.textChanged.connect(lambda: self._update_signal_plot())
+        self.dtime.editingFinished.connect(lambda: self._update_signal_plot())
         dtime_layout.addWidget(self.dtime)
         dtime_layout.addStretch()
         self.mainLayout.addLayout(dtime_layout)
@@ -1697,7 +1702,7 @@ class SdtWidget(AdvancedOptionsWidget):
             "Index of dataset to read in case the file contains multiple "
             "datasets. By default, the first dataset is read."
         )
-        self.index.textChanged.connect(lambda: self._update_signal_plot())
+        self.index.editingFinished.connect(lambda: self._update_signal_plot())
         index_layout.addWidget(self.index)
         index_layout.addStretch()
         self.mainLayout.addLayout(index_layout)
@@ -2100,7 +2105,7 @@ class LifWidget(AdvancedOptionsWidget):
         image_layout.addWidget(QLabel("Image (regex/index): "))
         self.image = QLineEdit()
         self.image.setToolTip("Index or regex pattern of image to return.")
-        self.image.textChanged.connect(self._on_lif_options_changed)
+        self.image.editingFinished.connect(self._on_lif_options_changed)
         image_layout.addWidget(self.image)
         image_layout.addStretch()
         self.mainLayout.addLayout(image_layout)
@@ -2207,7 +2212,9 @@ class JsonWidget(AdvancedOptionsWidget):
         self.channel_entry.setToolTip(
             "Index of channel or empty for all channel reading."
         )
-        self.channel_entry.textChanged.connect(self._on_json_channel_changed)
+        self.channel_entry.editingFinished.connect(
+            self._on_json_channel_changed
+        )
         chan_layout.addWidget(self.channel_entry)
         chan_layout.addStretch()
         self.mainLayout.addLayout(chan_layout)


### PR DESCRIPTION
This PR proposes optimizing the signal plot redraw in the Custom Import Widget when modifying any parameter.

Replaced textChanged with editingFinished for all QLineEdit fields that were triggering signal plot redraws on every keystroke. Qt's editingFinished signal fires only when the user presses Enter/Return or when the field loses focus (clicks away or tabs out).