### PR TITLE
fix: enhance reader to accept upper and lowercase extensions

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -211,15 +211,16 @@ def napari_get_reader(
     extensions_both = set(extension_mapping["raw"].keys()).intersection(
         extension_mapping["processed"].keys()
     )
-    if path.endswith(tuple(extensions_both)):
+    path_lower = path.lower()
+    if path_lower.endswith(tuple(extensions_both)):
         return lambda path: ambiguous_file_reader(
             path, reader_options=reader_options, harmonics=harmonics
         )
-    elif path.endswith(tuple(extension_mapping["processed"].keys())):
+    elif path_lower.endswith(tuple(extension_mapping["processed"].keys())):
         return lambda path: processed_file_reader(
             path, reader_options=reader_options, harmonics=harmonics
         )
-    elif path.endswith(tuple(extension_mapping["raw"].keys())):
+    elif path_lower.endswith(tuple(extension_mapping["raw"].keys())):
         return lambda path: raw_file_reader(
             path, reader_options=reader_options, harmonics=harmonics
         )

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -578,12 +578,14 @@ def test_reader_bhz():
 def test_reader_r64():
     """Test reading a r64 file."""
     r64_file = fetch("simfcs.r64")
-    reader = napari_get_reader(r64_file)
-    assert callable(reader)
-    layer_data_list = reader(r64_file)
-    assert isinstance(layer_data_list, list) and len(layer_data_list) > 0
-    layer_data = layer_data_list[0]
-    assert "G" in layer_data[1]["metadata"]
+    for filename in (r64_file, r64_file.replace(".r64", ".R64")):
+        reader = napari_get_reader(filename)
+        assert callable(reader)
+        # Note: we call the reader with the actual existing file path (r64_file)
+        layer_data_list = reader(r64_file)
+        assert isinstance(layer_data_list, list) and len(layer_data_list) > 0
+        layer_data = layer_data_list[0]
+        assert "G" in layer_data[1]["metadata"]
 
 
 def test_reader_json_imaging():


### PR DESCRIPTION
This PR suggest minor changes to the reader module to support reading both upper and lowercase extension. This generated a bug that `.R64` files were not read correctly due to them being uppercase.