### PR TITLE
feat: store groups in the layer metadata and restore across tabs

### DIFF
--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -7,6 +7,9 @@ from napari_phasors._utils import (
     HistogramWidget,
     StatisticsDockWidget,
     StatisticsTableWidget,
+    build_group_styles_from_layer_metadata,
+    build_groups_from_layer_metadata,
+    save_groups_to_layer_metadata,
 )
 
 
@@ -288,3 +291,462 @@ def test_histogram_widget_rename_dataset(qtbot):
     assert "Layer A" not in widget._group_assignments
     assert "Layer B" in widget._group_assignments
     assert widget._group_assignments["Layer B"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by group-metadata tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeLayer:
+    """Minimal stand-in for a napari layer."""
+
+    def __init__(self, metadata=None):
+        self.metadata = metadata if metadata is not None else {}
+
+
+class _FakeLayerList:
+    def __init__(self, layers):
+        self._layers = layers
+
+    def __getitem__(self, name):
+        return self._layers[name]
+
+
+class _FakeViewer:
+    def __init__(self, layers):
+        self.layers = _FakeLayerList(layers)
+
+
+# ---------------------------------------------------------------------------
+# build_groups_from_layer_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_build_groups_from_layer_metadata_basic():
+    """Layers with settings['group'] are grouped by name and assigned IDs."""
+    layers = {
+        'A': _FakeLayer(
+            {
+                'settings': {
+                    'group': {'name': 'Control', 'color': [1.0, 0.0, 0.0]}
+                }
+            }
+        ),
+        'B': _FakeLayer(
+            {
+                'settings': {
+                    'group': {'name': 'Treatment', 'color': [0.0, 0.0, 1.0]}
+                }
+            }
+        ),
+        'C': _FakeLayer(
+            {
+                'settings': {
+                    'group': {'name': 'Control', 'color': [1.0, 0.0, 0.0]}
+                }
+            }
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    assignments, names, colors = build_groups_from_layer_metadata(
+        viewer, ['A', 'B', 'C']
+    )
+
+    assert assignments == {'A': 1, 'C': 1, 'B': 2}
+    assert names == {1: 'Control', 2: 'Treatment'}
+    assert colors[1] == (1.0, 0.0, 0.0)
+    assert colors[2] == (0.0, 0.0, 1.0)
+
+
+def test_build_groups_from_layer_metadata_skips_missing():
+    """Layers without group metadata are silently skipped."""
+    layers = {
+        'A': _FakeLayer(
+            {'settings': {'group': {'name': 'Ctrl', 'color': [1.0, 0.0, 0.0]}}}
+        ),
+        'B': _FakeLayer({}),
+        'C': _FakeLayer({'settings': {}}),
+    }
+    viewer = _FakeViewer(layers)
+
+    assignments, names, colors = build_groups_from_layer_metadata(
+        viewer, ['A', 'B', 'C']
+    )
+
+    assert list(assignments.keys()) == ['A']
+    assert 'B' not in assignments
+    assert 'C' not in assignments
+
+
+def test_build_groups_from_layer_metadata_missing_layer_name():
+    """Layer names that don't exist in the viewer are silently skipped."""
+    layers = {
+        'A': _FakeLayer(
+            {'settings': {'group': {'name': 'G', 'color': [0.0, 1.0, 0.0]}}}
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    assignments, names, colors = build_groups_from_layer_metadata(
+        viewer, ['A', 'nonexistent']
+    )
+
+    assert 'nonexistent' not in assignments
+    assert 'A' in assignments
+
+
+def test_build_groups_from_layer_metadata_empty_input():
+    """Empty layer-name list returns three empty dicts."""
+    viewer = _FakeViewer({})
+    assignments, names, colors = build_groups_from_layer_metadata(viewer, [])
+    assert assignments == {}
+    assert names == {}
+    assert colors == {}
+
+
+def test_build_groups_from_layer_metadata_backward_compat_top_level():
+    """Layers tagged at the top-level metadata['group'] key are still read."""
+    layers = {
+        'X': _FakeLayer(
+            {'group': {'name': 'Legacy', 'color': [0.5, 0.5, 0.0]}}
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    assignments, names, colors = build_groups_from_layer_metadata(
+        viewer, ['X']
+    )
+
+    assert assignments == {'X': 1}
+    assert names == {1: 'Legacy'}
+    assert colors[1] == (0.5, 0.5, 0.0)
+
+
+def test_build_groups_from_layer_metadata_settings_takes_priority():
+    """settings['group'] takes priority over top-level metadata['group']."""
+    layers = {
+        'X': _FakeLayer(
+            {
+                'group': {'name': 'OldName', 'color': [0.0, 0.0, 0.0]},
+                'settings': {
+                    'group': {'name': 'NewName', 'color': [1.0, 1.0, 1.0]}
+                },
+            }
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    assignments, names, _ = build_groups_from_layer_metadata(viewer, ['X'])
+
+    assert names[1] == 'NewName'
+
+
+# ---------------------------------------------------------------------------
+# build_group_styles_from_layer_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_build_group_styles_colormap():
+    """Layers with colormap style produce correct group_styles dict."""
+    layers = {
+        'A': _FakeLayer(
+            {
+                'settings': {
+                    'group': {
+                        'name': 'G1',
+                        'color': [1.0, 0.0, 0.0],
+                        'colormap': 'turbo',
+                        'style': 'colormap',
+                    }
+                }
+            }
+        ),
+        'B': _FakeLayer(
+            {
+                'settings': {
+                    'group': {
+                        'name': 'G2',
+                        'color': [0.0, 1.0, 0.0],
+                        'style': 'solid',
+                    }
+                }
+            }
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    assignments, names, colors, styles = (
+        build_group_styles_from_layer_metadata(viewer, ['A', 'B'])
+    )
+
+    assert styles[1]['style'] == 'colormap'
+    assert styles[1]['colormap'] == 'turbo'
+    assert styles[2]['style'] == 'solid'
+
+
+def test_build_group_styles_defaults_to_solid_when_no_style_field():
+    """Layers without a 'style' key default to 'solid' when no colormap."""
+    layers = {
+        'A': _FakeLayer(
+            {'settings': {'group': {'name': 'G', 'color': [1.0, 0.0, 0.0]}}}
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    _, _, _, styles = build_group_styles_from_layer_metadata(viewer, ['A'])
+
+    assert styles[1]['style'] == 'solid'
+
+
+# ---------------------------------------------------------------------------
+# save_groups_to_layer_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_save_groups_writes_to_settings():
+    """save_groups_to_layer_metadata stores data inside metadata['settings']."""
+    layers = {
+        'A': _FakeLayer({}),
+        'B': _FakeLayer({'settings': {}}),
+    }
+    viewer = _FakeViewer(layers)
+
+    save_groups_to_layer_metadata(
+        viewer,
+        ['A', 'B'],
+        {'A': 1, 'B': 2},
+        {1: 'Alpha', 2: 'Beta'},
+        {1: (1.0, 0.0, 0.0), 2: (0.0, 1.0, 0.0)},
+    )
+
+    assert 'settings' in layers['A'].metadata
+    grp_a = layers['A'].metadata['settings']['group']
+    assert grp_a['name'] == 'Alpha'
+    assert grp_a['color'] == [1.0, 0.0, 0.0]
+
+    grp_b = layers['B'].metadata['settings']['group']
+    assert grp_b['name'] == 'Beta'
+    assert grp_b['color'] == [0.0, 1.0, 0.0]
+
+
+def test_save_groups_unassigned_layer_clears_group():
+    """A layer not in group_assignments has its group entry removed."""
+    layers = {
+        'A': _FakeLayer({'settings': {'group': {'name': 'Old'}}}),
+    }
+    viewer = _FakeViewer(layers)
+
+    save_groups_to_layer_metadata(viewer, ['A'], {}, {}, {})
+
+    assert 'group' not in layers['A'].metadata['settings']
+
+
+def test_save_groups_with_colormap_style():
+    """When group_styles is provided, colormap and style are persisted."""
+    layers = {'A': _FakeLayer({})}
+    viewer = _FakeViewer(layers)
+
+    save_groups_to_layer_metadata(
+        viewer,
+        ['A'],
+        {'A': 1},
+        {1: 'G1'},
+        {1: (1.0, 0.0, 0.0)},
+        group_styles={
+            1: {
+                'style': 'colormap',
+                'colormap': 'plasma',
+                'color': (1.0, 0.0, 0.0),
+            }
+        },
+    )
+
+    grp = layers['A'].metadata['settings']['group']
+    assert grp['style'] == 'colormap'
+    assert grp['colormap'] == 'plasma'
+
+
+def test_save_groups_solid_style_omits_colormap():
+    """Solid-style groups do not store a colormap key."""
+    layers = {'A': _FakeLayer({})}
+    viewer = _FakeViewer(layers)
+
+    save_groups_to_layer_metadata(
+        viewer,
+        ['A'],
+        {'A': 1},
+        {1: 'G1'},
+        {1: (0.0, 1.0, 0.0)},
+        group_styles={
+            1: {
+                'style': 'solid',
+                'colormap': 'turbo',
+                'color': (0.0, 1.0, 0.0),
+            }
+        },
+    )
+
+    grp = layers['A'].metadata['settings']['group']
+    assert grp['style'] == 'solid'
+    assert 'colormap' not in grp
+
+
+def test_save_groups_skips_nonexistent_layer():
+    """save_groups_to_layer_metadata silently ignores unknown layer names."""
+    layers = {'A': _FakeLayer({})}
+    viewer = _FakeViewer(layers)
+
+    # 'ghost' is not in the viewer — should not raise
+    save_groups_to_layer_metadata(
+        viewer,
+        ['A', 'ghost'],
+        {'A': 1, 'ghost': 1},
+        {1: 'G'},
+        {1: (1.0, 0.0, 0.0)},
+    )
+
+    assert layers['A'].metadata['settings']['group']['name'] == 'G'
+
+
+def test_save_then_build_roundtrip():
+    """save followed by build restores identical assignments, names, and colors."""
+    layers = {'A': _FakeLayer({}), 'B': _FakeLayer({})}
+    viewer = _FakeViewer(layers)
+
+    original_assignments = {'A': 1, 'B': 2}
+    original_names = {1: 'Control', 2: 'Treated'}
+    original_colors = {1: (1.0, 0.0, 0.0), 2: (0.0, 0.0, 1.0)}
+
+    save_groups_to_layer_metadata(
+        viewer,
+        ['A', 'B'],
+        original_assignments,
+        original_names,
+        original_colors,
+    )
+
+    assignments, names, colors = build_groups_from_layer_metadata(
+        viewer, ['A', 'B']
+    )
+
+    assert assignments == original_assignments
+    assert names == original_names
+    assert colors[1] == (1.0, 0.0, 0.0)
+    assert colors[2] == (0.0, 0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# HistogramWidget — group metadata integration
+# ---------------------------------------------------------------------------
+
+
+def test_histogram_widget_restores_groups_from_layer_metadata(
+    qtbot, monkeypatch
+):
+    """When no group assignments exist, the settings dialog is pre-populated
+    from each layer's settings['group'] metadata."""
+    from qtpy.QtWidgets import QDialog
+
+    layers = {
+        'LayerA': _FakeLayer(
+            {'settings': {'group': {'name': 'Ctrl', 'color': [1.0, 0.0, 0.0]}}}
+        ),
+        'LayerB': _FakeLayer(
+            {'settings': {'group': {'name': 'Trt', 'color': [0.0, 0.0, 1.0]}}}
+        ),
+    }
+    viewer = _FakeViewer(layers)
+
+    widget = HistogramWidget(bins=10, viewer=viewer)
+    qtbot.addWidget(widget)
+
+    data = {'LayerA': np.array([1.0, 2.0]), 'LayerB': np.array([3.0, 4.0])}
+    widget.update_multi_data(data)
+
+    captured = {}
+
+    def fake_exec(self):
+        # Record what group_assignments the dialog received
+        captured['assignments'] = {
+            row['name_edit'].text(): row['layer_combo'].checkedItems()
+            for row in self._group_row_data
+        }
+        return QDialog.Rejected  # don't apply, just inspect
+
+    from napari_phasors._utils import HistogramSettingsDialog
+
+    monkeypatch.setattr(HistogramSettingsDialog, 'exec', fake_exec)
+
+    widget._open_settings_dialog()
+
+    # Dialog should have been pre-populated with the two groups
+    assert 'Ctrl' in captured['assignments']
+    assert 'Trt' in captured['assignments']
+    assert 'LayerA' in captured['assignments']['Ctrl']
+    assert 'LayerB' in captured['assignments']['Trt']
+
+
+def test_histogram_widget_saves_groups_to_layer_metadata(qtbot, monkeypatch):
+    """After the settings dialog is accepted, each layer receives a
+    settings['group'] entry matching the user's selections."""
+    from qtpy.QtWidgets import QDialog
+
+    layers = {
+        'LayerA': _FakeLayer({}),
+        'LayerB': _FakeLayer({}),
+    }
+    viewer = _FakeViewer(layers)
+
+    widget = HistogramWidget(bins=10, viewer=viewer)
+    qtbot.addWidget(widget)
+
+    data = {'LayerA': np.array([1.0, 2.0]), 'LayerB': np.array([3.0, 4.0])}
+    widget.update_multi_data(data)
+
+    def fake_exec(self):
+        # Simulate user choosing Grouped mode and confirming
+        self.mode_combo.setCurrentText('Grouped')
+        return QDialog.Accepted
+
+    from napari_phasors._utils import HistogramSettingsDialog
+
+    monkeypatch.setattr(HistogramSettingsDialog, 'exec', fake_exec)
+
+    # Pre-load group state as if the dialog had been filled in
+    widget._group_assignments = {'LayerA': 1, 'LayerB': 2}
+    widget._group_names = {1: 'GroupX', 2: 'GroupY'}
+    widget._group_colors = {1: (1.0, 0.0, 0.0), 2: (0.0, 1.0, 0.0)}
+
+    widget._open_settings_dialog()
+
+    grp_a = layers['LayerA'].metadata['settings']['group']
+    grp_b = layers['LayerB'].metadata['settings']['group']
+    assert grp_a['name'] == 'GroupX'
+    assert grp_b['name'] == 'GroupY'
+    assert grp_a['color'] == [1.0, 0.0, 0.0]
+
+
+def test_histogram_widget_no_viewer_does_not_crash(qtbot, monkeypatch):
+    """HistogramWidget without a viewer still opens the settings dialog normally."""
+    from qtpy.QtWidgets import QDialog
+
+    widget = HistogramWidget(bins=10)  # no viewer
+    qtbot.addWidget(widget)
+
+    widget.update_multi_data(
+        {
+            'A': np.array([1.0, 2.0]),
+            'B': np.array([3.0, 4.0]),
+        }
+    )
+
+    from napari_phasors._utils import HistogramSettingsDialog
+
+    monkeypatch.setattr(
+        HistogramSettingsDialog, 'exec', lambda self: QDialog.Rejected
+    )
+
+    # Should not raise even though _viewer is None
+    widget._open_settings_dialog()

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -114,6 +114,77 @@ def test_write_ometif_with_numpy_settings(tmp_path):
     assert "1" in positions or 1 in positions
 
 
+def test_write_ometif_group_metadata_roundtrip(tmp_path):
+    """Group metadata stored in settings['group'] survives an OME-TIFF roundtrip.
+
+    This verifies the end-to-end OME-TIFF persistence path:
+    1. A layer has group info in metadata['settings']['group'].
+    2. write_ome_tiff serialises that settings dict into the file.
+    3. The reader deserialises it back and the group entry is intact.
+    """
+    time_constants = [0.1, 1, 10]
+    raw_flim_data = make_raw_flim_data(time_constants=time_constants)
+    harmonic = [1, 2, 3]
+    layer = make_intensity_layer_with_phasors(raw_flim_data, harmonic=harmonic)
+
+    if "settings" not in layer.metadata:
+        layer.metadata["settings"] = {}
+    layer.metadata["settings"]["group"] = {
+        "name": "Control",
+        "color": [1.0, 0.0, 0.0],
+    }
+
+    filepath = str(tmp_path / "group_roundtrip.ome.tif")
+    write_ome_tiff(
+        filepath,
+        [(layer.data, {"metadata": layer.metadata})],
+    )
+
+    assert os.path.exists(filepath)
+
+    reader = napari_get_reader(filepath, harmonics=harmonic)
+    layer_data_list = reader(filepath)
+    restored_settings = layer_data_list[0][1]["metadata"]["settings"]
+
+    assert "group" in restored_settings
+    grp = restored_settings["group"]
+    assert grp["name"] == "Control"
+    assert grp["color"] == [1.0, 0.0, 0.0]
+
+
+def test_write_ometif_group_metadata_with_colormap_roundtrip(tmp_path):
+    """Group metadata that includes a colormap/style entry (from the contour
+    dialog) also survives an OME-TIFF roundtrip."""
+    time_constants = [0.1, 1, 10]
+    raw_flim_data = make_raw_flim_data(time_constants=time_constants)
+    harmonic = [1]
+    layer = make_intensity_layer_with_phasors(raw_flim_data, harmonic=harmonic)
+
+    if "settings" not in layer.metadata:
+        layer.metadata["settings"] = {}
+    layer.metadata["settings"]["group"] = {
+        "name": "Treated",
+        "color": [0.0, 0.5, 1.0],
+        "style": "colormap",
+        "colormap": "plasma",
+    }
+
+    filepath = str(tmp_path / "group_colormap_roundtrip.ome.tif")
+    write_ome_tiff(
+        filepath,
+        [(layer.data, {"metadata": layer.metadata})],
+    )
+
+    reader = napari_get_reader(filepath, harmonics=harmonic)
+    layer_data_list = reader(filepath)
+    grp = layer_data_list[0][1]["metadata"]["settings"]["group"]
+
+    assert grp["name"] == "Treated"
+    assert grp["style"] == "colormap"
+    assert grp["colormap"] == "plasma"
+    assert grp["color"] == [0.0, 0.5, 1.0]
+
+
 def test_write_ometif(tmp_path):
     time_constants = [0.1, 1, 10]
     raw_flim_data = make_raw_flim_data(time_constants=time_constants)

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -767,15 +767,32 @@ def update_frequency_in_metadata(
     image_layer.metadata["settings"]["frequency"] = frequency
 
 
-def build_groups_from_layer_metadata(viewer, layer_names):
-    """Build group assignment dicts from per-layer ``'group'`` metadata.
+def _get_layer_group_entry(layer):
+    """Return the ``group`` dict for *layer*, or ``None`` if absent.
 
-    Each layer may carry ``layer.metadata['group']`` with keys ``name``
-    (str), ``color`` (RGB 3-tuple of 0–1 floats), and optionally
-    ``colormap``/``style`` (written by the contour dialog).  This function
-    reconstructs the ``(assignments, names, colors)`` triple expected by
-    ``HistogramSettingsDialog`` and ``PhasorCenterLayerSettingsDialog`` from
-    those individual entries.
+    Reads from ``layer.metadata['settings']['group']`` (the location that
+    survives OME-TIFF round-trips) and falls back to the top-level
+    ``layer.metadata['group']`` key for backward compatibility with layers
+    that were tagged before this convention was established.
+    """
+    g = layer.metadata.get('settings', {}).get('group')
+    if g:
+        return g
+    return layer.metadata.get('group')
+
+
+def build_groups_from_layer_metadata(viewer, layer_names):
+    """Build group assignment dicts from per-layer ``settings['group']`` metadata.
+
+    Each layer carries ``layer.metadata['settings']['group']`` with keys
+    ``name`` (str), ``color`` (RGB 3-tuple of 0–1 floats), and optionally
+    ``colormap``/``style`` (written by the contour dialog).  Because group
+    data lives inside the ``settings`` dict it is automatically included when
+    the layer is saved as OME-TIFF and restored when the file is re-opened.
+
+    This function reconstructs the ``(assignments, names, colors)`` triple
+    expected by ``HistogramSettingsDialog`` and
+    ``PhasorCenterLayerSettingsDialog`` from those individual entries.
 
     Parameters
     ----------
@@ -799,7 +816,7 @@ def build_groups_from_layer_metadata(viewer, layer_names):
             layer = viewer.layers[layer_name]
         except KeyError:
             continue
-        g = layer.metadata.get('group')
+        g = _get_layer_group_entry(layer)
         if not g or not g.get('name'):
             continue
         gname = g['name']
@@ -836,7 +853,7 @@ def build_group_styles_from_layer_metadata(viewer, layer_names):
             layer = viewer.layers[layer_name]
         except KeyError:
             continue
-        g = layer.metadata.get('group')
+        g = _get_layer_group_entry(layer)
         if not g or not g.get('name'):
             continue
         gname = g['name']
@@ -867,11 +884,16 @@ def save_groups_to_layer_metadata(
     group_colors,
     group_styles=None,
 ):
-    """Write group assignments back to each layer's ``'group'`` metadata entry.
+    """Write group assignments back to each layer's ``settings['group']`` entry.
 
-    This makes group configuration portable: any grouped-mode dialog that
-    reads ``layer.metadata['group']`` can restore the previous grouping
-    without the user having to re-enter it.
+    Storing the group inside the ``settings`` dict (rather than at the
+    top level of ``metadata``) means the information is automatically
+    serialised into the ``napari_phasors_settings`` JSON block when the layer
+    is exported as OME-TIFF and restored when the file is re-opened.
+
+    Any grouped-mode dialog (histogram, phasor center, contour) that calls
+    :func:`build_groups_from_layer_metadata` will therefore find the previous
+    grouping pre-populated without the user having to re-enter it.
 
     Parameters
     ----------
@@ -890,15 +912,17 @@ def save_groups_to_layer_metadata(
             layer = viewer.layers[layer_name]
         except KeyError:
             continue
+        if 'settings' not in layer.metadata:
+            layer.metadata['settings'] = {}
         gid = group_assignments.get(layer_name)
         if gid is None:
-            layer.metadata.pop('group', None)
+            layer.metadata['settings'].pop('group', None)
             continue
         gname = group_names.get(gid, f'Group {gid}')
         gcolor = group_colors.get(gid)
         group_data = {
             'name': gname,
-            'color': tuple(gcolor) if gcolor is not None else None,
+            'color': list(gcolor) if gcolor is not None else None,
         }
         if group_styles:
             style_data = group_styles.get(gid, {})
@@ -906,7 +930,7 @@ def save_groups_to_layer_metadata(
             group_data['style'] = gstyle
             if gstyle == 'colormap':
                 group_data['colormap'] = style_data.get('colormap', 'turbo')
-        layer.metadata['group'] = group_data
+        layer.metadata['settings']['group'] = group_data
 
 
 class _ColormapDelegate(QStyledItemDelegate):

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -767,6 +767,148 @@ def update_frequency_in_metadata(
     image_layer.metadata["settings"]["frequency"] = frequency
 
 
+def build_groups_from_layer_metadata(viewer, layer_names):
+    """Build group assignment dicts from per-layer ``'group'`` metadata.
+
+    Each layer may carry ``layer.metadata['group']`` with keys ``name``
+    (str), ``color`` (RGB 3-tuple of 0–1 floats), and optionally
+    ``colormap``/``style`` (written by the contour dialog).  This function
+    reconstructs the ``(assignments, names, colors)`` triple expected by
+    ``HistogramSettingsDialog`` and ``PhasorCenterLayerSettingsDialog`` from
+    those individual entries.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+    layer_names : list of str
+
+    Returns
+    -------
+    assignments : dict {layer_name: gid}
+    names : dict {gid: str}
+    colors : dict {gid: tuple}
+    """
+    name_to_gid = {}
+    assignments = {}
+    names = {}
+    colors = {}
+    next_gid = 1
+
+    for layer_name in layer_names:
+        try:
+            layer = viewer.layers[layer_name]
+        except KeyError:
+            continue
+        g = layer.metadata.get('group')
+        if not g or not g.get('name'):
+            continue
+        gname = g['name']
+        gcolor = g.get('color')
+        if gname not in name_to_gid:
+            name_to_gid[gname] = next_gid
+            names[next_gid] = gname
+            if gcolor is not None:
+                colors[next_gid] = tuple(gcolor)
+            next_gid += 1
+        assignments[layer_name] = name_to_gid[gname]
+
+    return assignments, names, colors
+
+
+def build_group_styles_from_layer_metadata(viewer, layer_names):
+    """Like :func:`build_groups_from_layer_metadata` but also returns
+    ``group_styles`` for ``ContourLayerSettingsDialog``.
+
+    Returns
+    -------
+    assignments, names, colors, styles : dicts
+        ``styles`` maps ``{gid: {'style': str, 'colormap': str, 'color': tuple}}``.
+    """
+    name_to_gid = {}
+    assignments = {}
+    names = {}
+    colors = {}
+    styles = {}
+    next_gid = 1
+
+    for layer_name in layer_names:
+        try:
+            layer = viewer.layers[layer_name]
+        except KeyError:
+            continue
+        g = layer.metadata.get('group')
+        if not g or not g.get('name'):
+            continue
+        gname = g['name']
+        gcolor = g.get('color')
+        gcmap = g.get('colormap')
+        gstyle = g.get('style', 'colormap' if gcmap else 'solid')
+        if gname not in name_to_gid:
+            name_to_gid[gname] = next_gid
+            names[next_gid] = gname
+            c = tuple(gcolor) if gcolor is not None else (1.0, 0.0, 0.0)
+            colors[next_gid] = c
+            styles[next_gid] = {
+                'style': gstyle,
+                'colormap': gcmap or 'turbo',
+                'color': c,
+            }
+            next_gid += 1
+        assignments[layer_name] = name_to_gid[gname]
+
+    return assignments, names, colors, styles
+
+
+def save_groups_to_layer_metadata(
+    viewer,
+    layer_names,
+    group_assignments,
+    group_names,
+    group_colors,
+    group_styles=None,
+):
+    """Write group assignments back to each layer's ``'group'`` metadata entry.
+
+    This makes group configuration portable: any grouped-mode dialog that
+    reads ``layer.metadata['group']`` can restore the previous grouping
+    without the user having to re-enter it.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+    layer_names : list of str
+    group_assignments : dict {layer_name: gid}
+    group_names : dict {gid: str}
+    group_colors : dict {gid: tuple}
+    group_styles : dict {gid: dict}, optional
+        Contour-specific style data with keys ``style``, ``colormap``,
+        ``color``.  When provided the ``colormap`` and ``style`` keys are
+        also persisted so the contour dialog can restore them.
+    """
+    for layer_name in layer_names:
+        try:
+            layer = viewer.layers[layer_name]
+        except KeyError:
+            continue
+        gid = group_assignments.get(layer_name)
+        if gid is None:
+            layer.metadata.pop('group', None)
+            continue
+        gname = group_names.get(gid, f'Group {gid}')
+        gcolor = group_colors.get(gid)
+        group_data = {
+            'name': gname,
+            'color': tuple(gcolor) if gcolor is not None else None,
+        }
+        if group_styles:
+            style_data = group_styles.get(gid, {})
+            gstyle = style_data.get('style', 'solid')
+            group_data['style'] = gstyle
+            if gstyle == 'colormap':
+                group_data['colormap'] = style_data.get('colormap', 'turbo')
+        layer.metadata['group'] = group_data
+
+
 class _ColormapDelegate(QStyledItemDelegate):
     """Custom delegate to ensure colormap icons have vertical spacing in dropdowns."""
 
@@ -1678,6 +1820,11 @@ class HistogramWidget(QWidget):
     exclude_nonpositive : bool, optional
         If ``True``, values ``<= 0`` are removed before histogramming.
         If ``False`` (default), only NaN/Inf values are removed.
+    viewer : napari.Viewer, optional
+        Napari viewer instance used to look up layer metadata for restoring
+        group assignments across analyses.  When provided, grouped-mode
+        settings are automatically populated from and persisted to each
+        layer's ``metadata['group']`` entry.
     parent : QWidget, optional
         Parent widget.
     """
@@ -1699,6 +1846,7 @@ class HistogramWidget(QWidget):
         range_label_prefix: str = "Range",
         range_factor: int = 1000,
         exclude_nonpositive: bool = False,
+        viewer=None,
         parent: QWidget = None,
     ):
         super().__init__(parent)
@@ -1707,6 +1855,7 @@ class HistogramWidget(QWidget):
         self.bins = bins
         self.default_colormap_name = default_colormap_name
         self._exclude_nonpositive = exclude_nonpositive
+        self._viewer = viewer
 
         # Histogram state
         self.counts = None
@@ -2110,16 +2259,26 @@ class HistogramWidget(QWidget):
     def _open_settings_dialog(self):
         """Open the histogram settings dialog."""
         layer_labels = list(self._datasets.keys()) if self._datasets else None
+
+        # Pre-populate groups from per-layer metadata when none are set yet
+        group_assignments = self._group_assignments
+        group_names = self._group_names
+        group_colors = self._group_colors
+        if self._viewer is not None and not group_assignments and layer_labels:
+            group_assignments, group_names, group_colors = (
+                build_groups_from_layer_metadata(self._viewer, layer_labels)
+            )
+
         dlg = HistogramSettingsDialog(
             display_mode=self._display_mode,
             show_sd=self._show_sd,
             central_tendency=self._central_tendency,
             show_legend=self._show_legend,
             layer_labels=layer_labels,
-            group_assignments=self._group_assignments,
+            group_assignments=group_assignments,
             layer_colors=self._layer_colors,
-            group_colors=self._group_colors,
-            group_names=self._group_names,
+            group_colors=group_colors,
+            group_names=group_names,
             parent=self,
         )
         dlg.white_bg_checkbox.setChecked(self._white_background)
@@ -2136,6 +2295,14 @@ class HistogramWidget(QWidget):
                 self._group_assignments = dlg.get_group_assignments()
                 self._group_colors = dlg.get_group_colors()
                 self._group_names = dlg.get_group_names()
+                if self._viewer is not None and layer_labels:
+                    save_groups_to_layer_metadata(
+                        self._viewer,
+                        layer_labels,
+                        self._group_assignments,
+                        self._group_names,
+                        self._group_colors,
+                    )
             if dlg._layer_color_buttons:
                 self._layer_colors = dlg.get_layer_colors()
             if self.counts is not None:

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -396,6 +396,7 @@ class ComponentsWidget(QWidget):
             range_slider_enabled=True,
             range_label_prefix="Fraction range",
             range_factor=1000,
+            viewer=self.viewer,
             parent=self,
         )
         self.histogram_widget.rangeChanged.connect(

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -342,6 +342,7 @@ class FretWidget(QWidget):
             range_slider_enabled=True,
             range_label_prefix="FRET efficiency range",
             range_factor=1000,
+            viewer=self.viewer,
             parent=self,
         )
 

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -228,6 +228,7 @@ class PhasorMappingWidget(QWidget):
             range_slider_enabled=True,
             range_label_prefix="Lifetime range (ns)",
             range_factor=self.lifetime_range_factor,
+            viewer=self.viewer,
             parent=self,
         )
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -54,8 +54,11 @@ from ._utils import (
     StatisticsDockWidget,
     StatisticsTableWidget,
     apply_filter_and_threshold,
+    build_group_styles_from_layer_metadata,
+    build_groups_from_layer_metadata,
     populate_colormap_combobox,
     resolve_colormap_by_name,
+    save_groups_to_layer_metadata,
     update_frequency_in_metadata,
 )
 from .calibration_tab import CalibrationWidget
@@ -3565,6 +3568,19 @@ class PlotterWidget(QWidget):
             for k, v in (self._contour_group_styles or {}).items()
         }
 
+        # Fall back to per-layer group metadata when no assignments exist yet
+        if not current_assignments and selected_names:
+            meta_a, meta_n, meta_c, meta_s = (
+                build_group_styles_from_layer_metadata(
+                    self.viewer, selected_names
+                )
+            )
+            if meta_a:
+                current_assignments = meta_a
+                current_group_names = meta_n
+                current_group_colors = meta_c
+                current_group_styles = meta_s
+
         merged_colormap = self._contour_multi_layer_colormap
         if not merged_colormap:
             merged_colormap = (
@@ -3637,6 +3653,17 @@ class PlotterWidget(QWidget):
             'contour_show_legend', self._contour_show_legend
         )
 
+        # Also persist groups to each individual layer for cross-analysis restore
+        if self._contour_group_assignments:
+            save_groups_to_layer_metadata(
+                self.viewer,
+                selected_names,
+                self._contour_group_assignments,
+                self._contour_group_names,
+                self._contour_group_colors,
+                group_styles=self._contour_group_styles,
+            )
+
         if self.plot_type == 'CONTOUR':
             self.plot()
 
@@ -3692,6 +3719,16 @@ class PlotterWidget(QWidget):
             for k, v in (self._phasor_center_group_names or {}).items()
         }
 
+        # Fall back to per-layer group metadata when no assignments exist yet
+        if not current_assignments and selected_names:
+            meta_a, meta_n, meta_c = build_groups_from_layer_metadata(
+                self.viewer, selected_names
+            )
+            if meta_a:
+                current_assignments = meta_a
+                current_group_names = meta_n
+                current_group_colors = meta_c
+
         dialog = PhasorCenterLayerSettingsDialog(
             display_mode=self._phasor_center_display_mode,
             center_method=self._phasor_center_method,
@@ -3719,7 +3756,7 @@ class PlotterWidget(QWidget):
         self._phasor_center_group_colors = dialog.get_group_colors()
         self._phasor_center_group_names = dialog.get_group_names()
 
-        # Save all to metadata
+        # Save all to primary layer metadata
         for key in (
             'phasor_center_display_mode',
             'phasor_center_method',
@@ -3732,6 +3769,16 @@ class PlotterWidget(QWidget):
             'phasor_center_group_names',
         ):
             self._update_setting_in_metadata(key, getattr(self, f'_{key}'))
+
+        # Also persist groups to each individual layer for cross-analysis restore
+        if self._phasor_center_group_assignments:
+            save_groups_to_layer_metadata(
+                self.viewer,
+                selected_names,
+                self._phasor_center_group_assignments,
+                self._phasor_center_group_names,
+                self._phasor_center_group_colors,
+            )
 
         if self._phasor_center_enabled:
             self._update_phasor_centers()


### PR DESCRIPTION
This PR proposes storing the group information (name, color, layers assigned to each group) in the metadata of each layer so that it can be restored along the different tabs and the user doesn't have to assign the groups in each of the different analysis. Assigning layers to groups once will apply the same grouping (if that option is selected) along the different tabs/analyses.

Closes #286 