### PR TITLE
Update phasorpy to v0.10 and refactor CZI file reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization"
 ]
 dependencies = [
-    "phasorpy>=0.8",
+    "phasorpy>=0.10",
     "qtpy",
     "biaplotter>=0.4.2",
     "fbdfile",
@@ -59,7 +59,7 @@ testing = [
     "isort",
     "ruff",
     "pre-commit",
-    "phasorpy>=0.8",
+    "phasorpy>=0.10",
     "tifffile",
     "fbdfile",
     "sdtfile",

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -136,7 +136,7 @@ iter_index_mapping = {
     ".tif": None,
     ".tiff": None,
     '.sdt': "C",
-    ".czi": "C",
+    ".czi": None,
     ".flif": None,
     ".bh": None,
     ".b&h": None,

--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -12,7 +12,6 @@ import os
 from collections.abc import Callable, Sequence
 from typing import Any, Union
 
-import czifile
 import numpy as np
 import phasorpy.io as io
 import tifffile
@@ -65,7 +64,9 @@ extension_mapping = {
             {},
             reader_options,
         ),
-        ".czi": lambda path, reader_options: read_czi(path),
+        ".czi": lambda path, reader_options: _parse_and_call_io_function(
+            path, io.signal_from_czi, {}, reader_options
+        ),
         ".flif": lambda path, reader_options: _parse_and_call_io_function(
             path, io.signal_from_flif, {}, reader_options
         ),
@@ -135,7 +136,7 @@ iter_index_mapping = {
     ".tif": None,
     ".tiff": None,
     '.sdt': "C",
-    ".czi": None,
+    ".czi": "C",
     ".flif": None,
     ".bh": None,
     ".b&h": None,
@@ -982,21 +983,3 @@ def _get_filename_extension(path: str) -> tuple[str, str]:
     parts = filename.split(".", 1)
     file_extension = "." + parts[1] if len(parts) > 1 else ""
     return parts[0], file_extension.lower()
-
-
-def read_czi(path: str) -> xr.DataArray:
-    """Read CZI file and return an xarray DataArray.
-
-    Parameters
-    ----------
-    path : str
-        Path to file.
-
-    Returns
-    -------
-    data : xr.DataArray
-        DataArray with dimensions named after the CZI axes (e.g., 'C', 'Z', 'Y', 'X').
-    """
-    with czifile.CziFile(path) as czi:
-        data = czi.asxarray().squeeze()
-    return data

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -1768,9 +1768,9 @@ class CziWidget(AdvancedOptionsWidget):
     def _get_signal_data(self):
         """Get signal data for CZI files."""
         try:
-            from ._reader import read_czi
+            from phasorpy.io import signal_from_czi
 
-            return read_czi(self.path)
+            return signal_from_czi(self.path)
         except Exception as e:  # noqa: BLE001
             show_error(f"Error reading CZI signal: {str(e)}")
             return None


### PR DESCRIPTION
**Summary**

This PR updates the minimum required PhasorPy version from 0.8 to 0.10 and refactors CZI file loading to use the native `phasorpy.io.signal_from_czi` implementation.

**Changes**

Bump the PhasorPy dependency to `>=0.10`.
Replace the custom `read_czi()` function based on `czifile` with `phasorpy.io.signal_from_czi`.
Route .czi files through the standard _parse_and_call_io_function workflow used by other supported formats.
Set the default signal axis for CZI files to "C" to match the behavior of the PhasorPy reader.
Remove the now-unused direct dependency on czifile from the reader implementation.

**Motivation**

PhasorPy 0.10 includes native support for reading CZI files through `signal_from_czi`, making the custom implementation in napari-phasors redundant. By delegating CZI handling to PhasorPy, we reduce maintenance burden, keep file parsing behavior consistent with the upstream library, and simplify the reader codebase.