### PR TITLE
feat: add dynamic kwargs support to reader and widget classes

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -954,8 +954,12 @@ def _parse_and_call_io_function(
     # Validate arguments against the function's signature
     valid_args = {}
     sig = inspect.signature(func)
+    has_kwargs = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD
+        for p in sig.parameters.values()
+    )
     for arg, value in args.items():
-        if arg in sig.parameters:
+        if arg in sig.parameters or has_kwargs:
             valid_args[arg] = value
         else:
             raise ValueError(

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -681,4 +681,36 @@ def test_clamp_harmonics():
         _clamp_harmonics([1], 1)
 
 
+def test_parse_and_call_io_function():
+    from napari_phasors._reader import _parse_and_call_io_function
+
+    def func_with_kwargs(path, a=1, **kwargs):
+        return {"path": path, "a": a, "kwargs": kwargs}
+
+    def func_without_kwargs(path, a=1):
+        return {"path": path, "a": a}
+
+    # Test function that accepts kwargs - custom kwargs should be passed through
+    res = _parse_and_call_io_function(
+        "dummy_path",
+        func_with_kwargs,
+        args_defaults={"a": (1, False)},
+        reader_options={"a": 42, "custom_kwarg": "hello", "another": [1, 2]},
+    )
+    assert res == {
+        "path": "dummy_path",
+        "a": 42,
+        "kwargs": {"custom_kwarg": "hello", "another": [1, 2]},
+    }
+
+    # Test function that does NOT accept kwargs - custom kwargs should raise ValueError
+    with pytest.raises(ValueError, match="Invalid argument 'custom_kwarg'"):
+        _parse_and_call_io_function(
+            "dummy_path",
+            func_without_kwargs,
+            args_defaults={"a": (1, False)},
+            reader_options={"a": 42, "custom_kwarg": "hello"},
+        )
+
+
 # TODO: Add tests for .tif files

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1575,3 +1575,189 @@ def test_writer_widget_mask_checkbox(make_napari_viewer, tmp_path):
 
     # Clean up
     widget.close()
+
+
+def test_advanced_options_widget_kwargs(make_napari_viewer):
+    """Test the dynamic kwargs functionality in AdvancedOptionsWidget."""
+    viewer = make_napari_viewer()
+    widget = FbdWidget(viewer, path=get_test_file_path("test_file$EI0S.fbd"))
+
+    # Initially, kwargs_widgets should be empty
+    assert hasattr(widget, "kwargs_widgets")
+    assert len(widget.kwargs_widgets) == 0
+
+    # 1. Add a kwarg row
+    widget.add_kwarg_btn.click()
+    assert len(widget.kwargs_widgets) == 1
+
+    key_edit, val_edit, row_widget = widget.kwargs_widgets[0]
+    key_edit.setText("test_key")
+    val_edit.setText("123")
+
+    options = {}
+    widget._apply_kwargs(options)
+    assert options == {"test_key": 123}
+
+    # 2. Add another kwarg row with a list
+    widget.add_kwarg_btn.click()
+    assert len(widget.kwargs_widgets) == 2
+
+    key_edit2, val_edit2, row_widget2 = widget.kwargs_widgets[1]
+    key_edit2.setText("list_key")
+    val_edit2.setText("[1, 2, 'three']")
+
+    options = {}
+    widget._apply_kwargs(options)
+    assert options == {
+        "test_key": 123,
+        "list_key": [1, 2, "three"],
+    }
+
+    # 3. Add one more with string value that fails ast.literal_eval
+    widget.add_kwarg_btn.click()
+    key_edit3, val_edit3, row_widget3 = widget.kwargs_widgets[2]
+    key_edit3.setText("str_key")
+    val_edit3.setText("hello_world")
+
+    options = {}
+    widget._apply_kwargs(options)
+    assert options == {
+        "test_key": 123,
+        "list_key": [1, 2, "three"],
+        "str_key": "hello_world",
+    }
+
+    # 4. Remove a kwarg row (the first one)
+    layout = row_widget.layout()
+    del_btn = layout.itemAt(2).widget()
+    del_btn.click()
+
+    assert len(widget.kwargs_widgets) == 2
+    # Verify the remaining widgets are row_widget2 and row_widget3
+    assert widget.kwargs_widgets[0][2] == row_widget2
+    assert widget.kwargs_widgets[1][2] == row_widget3
+
+    options = {}
+    widget._apply_kwargs(options)
+    assert options == {
+        "list_key": [1, 2, "three"],
+        "str_key": "hello_world",
+    }
+
+    widget.close()
+
+
+def test_ifli_widget(make_napari_viewer):
+    """Test IfliWidget UI initialization and kwargs integration."""
+    from napari_phasors._widget import IfliWidget, ProcessedOnlyWidget
+
+    viewer = make_napari_viewer()
+    widget = IfliWidget(viewer, path="dummy.ifli")
+
+    # Check that UI elements are correctly set up
+    assert widget.channel_entry.text() == "0"
+    assert widget.reader_options["channel"] == 0
+    assert hasattr(widget, "kwargs_widgets")
+
+    # Add a kwarg row
+    widget.add_kwarg_btn.click()
+    key_edit, val_edit, _ = widget.kwargs_widgets[0]
+    key_edit.setText("ifli_kwarg")
+    val_edit.setText("'yes'")
+
+    # Change the channel entry
+    widget.channel_entry.setText("2")
+
+    # Mock super()._on_click to see what arguments it receives
+    with patch.object(ProcessedOnlyWidget, "_on_click") as mock_on_click:
+        widget.btn.click()
+
+        mock_on_click.assert_called_once()
+        args, kwargs = mock_on_click.call_args
+        assert args[0] == "dummy.ifli"
+        assert args[1]["channel"] == 2
+        assert args[1]["ifli_kwarg"] == "yes"
+
+    # Test fallback to channel 0 when channel entry is empty
+    widget.channel_entry.setText("")
+    with patch.object(ProcessedOnlyWidget, "_on_click") as mock_on_click:
+        widget.btn.click()
+        assert widget.reader_options["channel"] == 0
+        assert widget.channel_entry.text() == ""
+
+    # Test fallback to channel 0 when channel entry is invalid
+    widget.channel_entry.setText("abc")
+    with patch.object(ProcessedOnlyWidget, "_on_click") as mock_on_click:
+        widget.btn.click()
+        assert widget.reader_options["channel"] == 0
+        assert widget.channel_entry.text() == "0"
+
+    widget.close()
+
+
+def test_lsm_widget_get_signal_data_with_kwargs(make_napari_viewer):
+    """Test that LSM file reading forwards kwargs."""
+    viewer = make_napari_viewer()
+    widget = LsmWidget(viewer, path="dummy.lsm")
+    widget._is_lsm = True
+
+    # Add a custom kwarg row
+    widget.add_kwarg_btn.click()
+    key_edit, val_edit, _ = widget.kwargs_widgets[0]
+    key_edit.setText("custom_param")
+    val_edit.setText("99")
+
+    with patch("phasorpy.io.signal_from_lsm") as mock_signal_from_lsm:
+        mock_signal_from_lsm.return_value = np.zeros((2, 2, 2))
+        widget._get_signal_data()
+
+        mock_signal_from_lsm.assert_called_once_with(
+            "dummy.lsm", custom_param=99
+        )
+
+    widget.close()
+
+
+def test_tiff_widget_get_signal_data_with_kwargs(make_napari_viewer):
+    """Test that TIFF file reading forwards kwargs."""
+    viewer = make_napari_viewer()
+    widget = LsmWidget(viewer, path="dummy.tif")
+    widget._is_lsm = False
+
+    # Add a custom kwarg row
+    widget.add_kwarg_btn.click()
+    key_edit, val_edit, _ = widget.kwargs_widgets[0]
+    key_edit.setText("custom_tiff_param")
+    val_edit.setText("True")
+
+    with patch("tifffile.imread") as mock_imread:
+        mock_imread.return_value = np.zeros((2, 2, 2))
+        widget._get_signal_data()
+
+        mock_imread.assert_called_once_with(
+            "dummy.tif", custom_tiff_param=True
+        )
+
+    widget.close()
+
+
+def test_czi_widget_get_signal_data_with_kwargs(make_napari_viewer):
+    """Test that CZI file reading forwards kwargs."""
+    viewer = make_napari_viewer()
+    widget = CziWidget(viewer, path="dummy.czi")
+
+    # Add a custom kwarg row
+    widget.add_kwarg_btn.click()
+    key_edit, val_edit, _ = widget.kwargs_widgets[0]
+    key_edit.setText("czi_param")
+    val_edit.setText("4.5")
+
+    with patch("phasorpy.io.signal_from_czi") as mock_signal_from_czi:
+        mock_signal_from_czi.return_value = np.zeros((2, 2, 2))
+        widget._get_signal_data()
+
+        mock_signal_from_czi.assert_called_once_with(
+            "dummy.czi", czi_param=4.5
+        )
+
+    widget.close()

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -452,6 +452,103 @@ class AdvancedOptionsWidget(QWidget):
         axis_layout.addStretch()
         self.mainLayout.addLayout(axis_layout)
 
+    def _kwargs_widget(self):
+        """Widget to add arbitrary kwargs."""
+        self.kwargs_widgets = []
+
+        self.kwargs_layout = QVBoxLayout()
+        self.kwargs_layout.setAlignment(Qt.AlignTop)
+        self.kwargs_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.kwargs_container = QWidget()
+        self.kwargs_container.setLayout(self.kwargs_layout)
+
+        self.add_kwarg_btn = QPushButton("+")
+        self.add_kwarg_btn.setFixedWidth(30)
+        self.add_kwarg_btn.clicked.connect(self._add_kwarg_row)
+
+        self.kwargs_section = CollapsibleSection(
+            "Additional kwargs",
+            initially_collapsed=True,
+            text_color="#c7c7c7",
+        )
+        self.kwargs_section.add_widget(self.kwargs_container)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.setContentsMargins(0, 5, 0, 0)
+        btn_layout.addWidget(self.add_kwarg_btn)
+        btn_layout.addStretch()
+        btn_widget = QWidget()
+        btn_widget.setLayout(btn_layout)
+
+        self.kwargs_section.add_widget(btn_widget)
+
+        self.mainLayout.addWidget(self.kwargs_section)
+
+    def _add_kwarg_row(self):
+        row_widget = QWidget()
+        row_layout = QHBoxLayout(row_widget)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+
+        key_edit = QLineEdit()
+        key_edit.setPlaceholderText("Name")
+        key_edit.editingFinished.connect(
+            lambda: (
+                self._update_signal_plot()
+                if hasattr(self, '_update_signal_plot')
+                else None
+            )
+        )
+
+        val_edit = QLineEdit()
+        val_edit.setPlaceholderText("Value")
+        val_edit.editingFinished.connect(
+            lambda: (
+                self._update_signal_plot()
+                if hasattr(self, '_update_signal_plot')
+                else None
+            )
+        )
+
+        del_btn = QPushButton("X")
+        del_btn.setFixedWidth(30)
+
+        row_layout.addWidget(key_edit)
+        row_layout.addWidget(val_edit)
+        row_layout.addWidget(del_btn)
+
+        self.kwargs_layout.addWidget(row_widget)
+
+        kwarg_entry = (key_edit, val_edit, row_widget)
+        self.kwargs_widgets.append(kwarg_entry)
+
+        del_btn.clicked.connect(lambda: self._remove_kwarg_row(kwarg_entry))
+
+    def _remove_kwarg_row(self, kwarg_entry):
+        if kwarg_entry in self.kwargs_widgets:
+            self.kwargs_widgets.remove(kwarg_entry)
+        key_edit, val_edit, row_widget = kwarg_entry
+        self.kwargs_layout.removeWidget(row_widget)
+        row_widget.deleteLater()
+        if hasattr(self, '_update_signal_plot'):
+            self._update_signal_plot()
+
+    def _apply_kwargs(self, options):
+        """Apply dynamic kwargs to the provided options dict."""
+        import ast
+
+        if not hasattr(self, 'kwargs_widgets'):
+            return
+        for key_edit, val_edit, _ in self.kwargs_widgets:
+            key = key_edit.text().strip()
+            val_str = val_edit.text().strip()
+            if key and val_str:
+                try:
+                    val = ast.literal_eval(val_str)
+                except (ValueError, TypeError, SyntaxError, MemoryError):
+                    val = val_str
+                options[key] = val
+
     def _update_axis_options(self):
         """Refresh axis options based on preview signal shape and dims."""
         if not hasattr(self, 'axis_combo'):
@@ -1091,6 +1188,8 @@ class AdvancedOptionsWidget(QWidget):
         If ``_multi_file_paths`` is set, all files are stacked into a
         single 3D layer via :func:`raw_file_stack_reader`.
         """
+        if hasattr(self, '_apply_kwargs'):
+            self._apply_kwargs(reader_options)
         grouped_paths = getattr(self, '_grouped_file_paths', None)
         multi_paths = getattr(self, '_multi_file_paths', None)
         self._on_stack_z_spacing_changed()
@@ -1410,6 +1509,8 @@ class FbdWidget(AdvancedOptionsWidget):
         laser_layout.addStretch()
         self.mainLayout.addLayout(laser_layout)
 
+        self._kwargs_widget()
+
         self.btn = QPushButton("Phasor Transform")
         self.btn.clicked.connect(
             lambda: self._on_click(
@@ -1427,6 +1528,7 @@ class FbdWidget(AdvancedOptionsWidget):
         options = self.reader_options.copy()
         if self.laser_factor.text():
             options["laser_factor"] = float(self.laser_factor.text())
+        self._apply_kwargs(options)
 
         try:
             with warnings.catch_warnings():
@@ -1451,6 +1553,7 @@ class FbdWidget(AdvancedOptionsWidget):
         """Callback whenever the calculate phasor button is clicked."""
         if self.laser_factor.text():
             reader_options["laser_factor"] = float(self.laser_factor.text())
+        self._apply_kwargs(reader_options)
         super()._on_click(path, reader_options, harmonics)
 
 
@@ -1496,6 +1599,8 @@ class PtuWidget(AdvancedOptionsWidget):
         dtime_layout.addStretch()
         self.mainLayout.addLayout(dtime_layout)
 
+        self._kwargs_widget()
+
         self.btn = QPushButton("Phasor Transform")
         self.btn.clicked.connect(
             lambda: self._on_click(
@@ -1513,6 +1618,7 @@ class PtuWidget(AdvancedOptionsWidget):
         options = self.reader_options.copy()
         if self.dtime.text():
             options["dtime"] = float(self.dtime.text())
+        self._apply_kwargs(options)
 
         try:
             with _silence_ptufile_logger():
@@ -1536,6 +1642,7 @@ class PtuWidget(AdvancedOptionsWidget):
         """Callback whenever the calculate phasor button is clicked."""
         if self.dtime.text():
             reader_options["dtime"] = float(self.dtime.text())
+        self._apply_kwargs(reader_options)
         with _silence_ptufile_logger():
             super()._on_click(path, reader_options, harmonics)
 
@@ -1574,6 +1681,8 @@ class LsmWidget(AdvancedOptionsWidget):
         self._axis_widget()
         self._update_axis_options()
 
+        self._kwargs_widget()
+
         self.btn = QPushButton("Phasor Transform")
         self.btn.clicked.connect(
             lambda: self._on_click(
@@ -1587,14 +1696,19 @@ class LsmWidget(AdvancedOptionsWidget):
     def _get_signal_data(self):
         """Get signal data for LSM or TIFF files."""
         try:
+            options = self.reader_options.copy()
+            self._apply_kwargs(options)
+            # Remove keys that shouldn't be passed to io functions
+            options.pop('phasor_axis', None)
+
             if self._is_lsm:
                 from phasorpy.io import signal_from_lsm
 
-                return signal_from_lsm(self.path)
+                return signal_from_lsm(self.path, **options)
             else:
                 import tifffile
 
-                signal = tifffile.imread(self.path)
+                signal = tifffile.imread(self.path, **options)
                 return signal
         except Exception as e:  # noqa: BLE001
             show_error(
@@ -1755,6 +1869,8 @@ class CziWidget(AdvancedOptionsWidget):
 
         self._harmonic_widget()
 
+        self._kwargs_widget()
+
         self.btn = QPushButton("Phasor Transform")
         self.btn.clicked.connect(
             lambda: self._on_click(
@@ -1770,7 +1886,9 @@ class CziWidget(AdvancedOptionsWidget):
         try:
             from phasorpy.io import signal_from_czi
 
-            return signal_from_czi(self.path)
+            options = self.reader_options.copy()
+            self._apply_kwargs(options)
+            return signal_from_czi(self.path, **options)
         except Exception as e:  # noqa: BLE001
             show_error(f"Error reading CZI signal: {str(e)}")
             return None
@@ -2315,6 +2433,12 @@ class IfliWidget(ProcessedOnlyWidget):
         chan_layout.addStretch()
         self.mainLayout.insertLayout(1, chan_layout)
 
+        self._kwargs_widget()
+        # insert before the button which is the last widget
+        self.mainLayout.insertWidget(
+            self.mainLayout.count() - 1, self.kwargs_section
+        )
+
     def _on_click(self, path, reader_options, harmonics):
         """Callback whenever the calculate phasor button is clicked."""
         txt = self.channel_entry.text().strip()
@@ -2323,6 +2447,7 @@ class IfliWidget(ProcessedOnlyWidget):
         except ValueError:
             reader_options["channel"] = 0
             self.channel_entry.setText("0")
+        self._apply_kwargs(reader_options)
         super()._on_click(path, reader_options, harmonics)
 
 


### PR DESCRIPTION
**Description**

This PR introduces the ability to pass arbitrary keyword arguments (`kwargs`) and values from the advanced options widgets to the underlying reader functions, and adds full unit test coverage for the changes.

Closes #308 

**Changes**

1. Advanced Options Widgets & UI Improvements
Dynamic Kwargs Support: Added widget logic (`_kwargs_widget`, `_add_kwarg_row`, `_remove_kwarg_row`, and `_apply_kwargs`) in `AdvancedOptionsWidget` to dynamically add, edit, and remove custom key-value configuration rows. Values are parsed with `ast.literal_eval` (supporting standard Python literals like lists, integers, booleans, and dictionaries) with a fallback to raw strings if parsing fails.
Layout Design: Positioned a compact + button at the bottom of the active list of keyword arguments inside the collapsible "Additional kwargs" section.
Widget Integration: Incorporated the kwargs interface into `FbdWidget`, `PtuWidget`, `LsmWidget`, `CziWidget`, and `IfliWidget`.

2. Readers
Arguments Validation: Modified `_parse_and_call_io_function` in `src/napari_phasors/_reader.py` to allow arbitrary dynamic arguments to pass through to underlying phasorpy.io read functions if the function signature accepts variable keyword arguments (`**kwargs`).

3. Test Coverage & Code Quality
New Unit Tests:
`test_parse_and_call_io_function` verifying valid/invalid dynamic `kwargs` routing.
`test_advanced_options_widget_kwargs` verifying UI interactive adding, removing, and literal parsing.
`test_ifli_widget` checking IFLI settings layout and channel fallback parsing.
`test_lsm_widget_get_signal_data_with_kwargs`, `test_tiff_widget_get_signal_data_with_kwargs`, and `test_czi_widget_get_signal_data_with_kwargs` ensuring option dictionaries match function expectations.
