### PR TITLE
docs: update docs for release v.0.6.4

### DIFF
--- a/docs/guides/component_analysis.md
+++ b/docs/guides/component_analysis.md
@@ -3,10 +3,13 @@
 The **Components** tab of the **Phasor Plot** widget lets you decompose phasor distributions into fluorophore components and compute per-pixel fraction maps.
 
 **Component locations can be selected in several ways:**
-- By clicking the **Select** button in the analysis tab for each component
-- By specifying the G and S coordinates directly
-- By specifying the lifetime (for FLIM, only when the frequency is available)
-You can also drag the component locations in the phasor plot for repositioning.
+- Dragging components directly in the phasor plot.
+- Specifying coordinates (G and S) or FLIM lifetime values manually.
+- Using the **Select** dropdown options next to each component:
+  - **Select on plot**: Click manually on the phasor plot.
+  - **Select from phasor center...**: Calculate the location from the center of selected layer(s).
+  - **Select from cursor center**: Use the center of any active cursor.
+  - **Auto intersect semicircle**: Place the component at the intersection of the universal semicircle and the line connecting the previous component to the data center.
 
 **The line and component locations can be fully customized:**
 - Change the width, offset, alpha (transparency), and color of the line joining the components
@@ -16,6 +19,34 @@ Two analysis modes are available:
 
 - **Two-component fit projection**
 - **Multi-component fit**
+
+## Selecting component locations
+
+To set or modify a component's coordinates, click the **Select** button next to the component row in the Components list. A dropdown menu provides the following methods:
+
+### Select on plot
+Allows manual selection by clicking on any position within the phasor plot. You can cancel the selection process at any time by pressing the **Esc** key on your keyboard.
+
+### Select from cursor center
+Hovering over this option opens a submenu listing all active cursors (Circular, Polar, Elliptical, and GMM Clusters). Selecting a cursor instantly snaps the component to that cursor's center of gravity.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20from%20cursor.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20from%20cursor.mp4" type="video/mp4">
+</video>
+
+### Select from phasor center (layer selection)
+Selecting **Select from phasor center...** opens a dialog where you can select one or more image layers with phasor data. The widget will calculate the pooled phasor center of gravity of those layers and use it as the component coordinate.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20from%20layers.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20from%20layers.mp4" type="video/mp4">
+</video>
+
+### Auto intersect semicircle
+For Component 2 and subsequent components, selecting **Auto intersect semicircle** automatically positions the component on the universal semicircle. The position is calculated at the intersection point of the universal semicircle and a line drawn from the previous component's coordinates through the center of the active phasor data.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/intersect%20semicircle.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/intersect%20semicircle.mp4" type="video/mp4">
+</video>
 
 ## Two-component linear projection
 

--- a/docs/guides/mask.md
+++ b/docs/guides/mask.md
@@ -20,10 +20,20 @@ You can use a labels layer (e.g., from manual annotation or segmentation) as a m
 
 1. Add or load a labels layer where each label value defines a region.
 2. In the **Phasor Plot** widget, select the labels layer as the mask source.
-3. You can restrict analysis to a specific label value or include all nonzero labels.
+3. Use the label selection dropdown next to the mask source selection to select specific label values to include in the analysis (by default, all labels are selected).
+   - Use the **All** or **None** shortcuts next to the dropdown to quickly check or uncheck all labels.
+   - Check the **Invert** checkbox next to the mask selection to exclude the selected labels instead of including them.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/mask%20labels.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/mask%20labels.mp4" type="video/mp4">
+</video>
+
+### Selecting specific labels
+
+When masking with a labels layer, the label selection dropdown allows you to restrict the analysis to a subset of labels in the layer.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/filter%20labels%20mask.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/filter%20labels%20mask.mp4" type="video/mp4">
 </video>
 
 ## Masking with cursor selection


### PR DESCRIPTION
**Description**

This PR updates the user documentation guides (component_analysis.md and mask.md) to cover several new features and integrations added to napari-phasors.

Closes #309 

**Changes**

**1. Component Analysis Guide**

Added a new Selecting component locations section detailing the newly supported methods for component placement:

- Select from cursor center: Quick snapping of components to active cursor centers (Circular, Polar, Elliptical, and GMM Clusters).
- Select from phasor center (layer selection): Computing pooled phasor center of gravity from selected layer(s).
- Auto intersect semicircle: Automatic positioning of components on the universal semicircle based on the previous component's coordinates and the data center.
- Select on plot: Documented that manual plot selection can be canceled at any time by pressing the Esc key.

Embedded the corresponding MP4/GIF demonstrations from the remote napari-phasors-data repository.

**2. Masking Guide**

Updated the Masking with labels section to cover selecting specific label values inside a labels layer mask.
Documented the use of the All or None helper shortcuts next to the dropdown menu, as well as the Invert checkbox behavior.

Embedded the demonstration video showing label selection filtering.