### PR TITLE
fix more PySide6 teardown errors during testing

### DIFF
--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -21,6 +21,33 @@ except (AttributeError, ImportError, TypeError):
     pass
 
 
+# Harden superqt's SliderLabel against the same PySide6 + Python 3.14 shiboken
+# wrapper-corruption bug: under address reuse, `widget.style()` can return a
+# transient QWidgetItem instead of a QStyle, so `_get_size()` raises
+# `AttributeError: 'QWidgetItem' object has no attribute 'sizeFromContents'`.
+# This is triggered deep inside napari's layer-controls creation (via
+# `viewer.add_image`), aborts the `events.inserted` callback, and cascades into
+# KeyError on layer removal at teardown and a leaked QtViewer in the next test.
+# `_update_size` only sets a cosmetic fixed size, so swallowing a corrupted-
+# style failure and keeping the current size is safe.
+try:
+    from superqt.sliders._labeled import SliderLabel
+
+    _orig_SliderLabel_update_size = SliderLabel._update_size
+
+    def _safe_update_size(self, *args):
+        try:
+            return _orig_SliderLabel_update_size(self, *args)
+        except (AttributeError, TypeError):
+            # PySide6/shiboken handed back a non-QStyle object; skip the
+            # cosmetic resize rather than letting it abort widget creation.
+            return None
+
+    SliderLabel._update_size = _safe_update_size
+except (AttributeError, ImportError, TypeError):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def _hide_qdialog(monkeypatch):
     orig_show = QDialog.show


### PR DESCRIPTION
## Summary

The root cause of failing PySide6 tests appears to be a PySide6 + Python 3.14 shiboken wrapper corruption bug rather than a problem in the widget implementation itself. This explains why the issue is both PySide-specific and intermittent, depending on C++ object address reuse.

### Root Cause

In `superqt.SliderLabel._get_size`, `self.style()` can occasionally return a transient `QWidgetItem` instead of a `QStyle` instance. When this occurs, the subsequent call to `sizeFromContents(...)` raises an `AttributeError`.

This is the same class of wrapper-corruption issue already handled in `_QtMainWindow.eventFilter`, where `source` could unexpectedly arrive as a `QWidgetItem`.

### Failure Cascade

1. `btn.click()` triggers `add_image()`.
2. napari begins constructing layer controls.
3. A `superqt` slider is created.
4. `SliderLabel._get_size()` calls `sizeFromContents(...)` on a corrupted wrapper and raises.
5. The exception propagates as `"Exceptions caught in Qt event loop"` and the test fails.
6. The layer is successfully added to the layer list, but its controls are never fully registered.
7. During teardown, `viewer.close()` calls `_remove()`, which encounters a `KeyError` due to the incomplete layer-controls mapping.
8. The `KeyError` interrupts cleanup.
9. The associated `QtViewer` is never deregistered.
10. Subsequent tests report `"Some instance of QtViewer is not properly cleaned"`.

### Fix

This PR adds a module-level monkeypatch in `conftest.py` that hardens `SliderLabel._update_size()` against corrupted-style failures, mirroring the existing defensive handling in `_QtMainWindow.eventFilter`.

The patch catches `AttributeError` and `TypeError` raised during size calculation and simply leaves the current widget size unchanged.

This is considered safe because `_update_size()` only updates a cosmetic fixed size and does not affect application state or functionality.

By preventing the exception at its source:

* Layer controls are created successfully.
* The layer ↔ controls mapping remains consistent.
* `viewer.close()` completes normally.
* `QtViewer` instances are properly deregistered.
* The downstream teardown failures disappear.

### Notes

* This change does not affect PyQt6 behavior, as PyQt6 does not appear to exhibit the underlying shiboken wrapper corruption.
* Local testing showed no regressions in the affected tests under PySide6.
* Since the issue depends on address reuse, reproducing the exact CI failure locally is difficult. The most meaningful validation will be successful Python 3.14 + PySide6 CI runs.
* If additional PySide-only teardown failures appear in the future, they are likely to be other manifestations of the same wrapper-corruption bug and can be addressed with similar targeted guards.