### PR TITLE
feat: Implement label color application to combo boxes in dialogs

### DIFF
--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from biaplotter.plotter import CanvasWidget
 from napari.layers import Image
+from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -28,6 +29,7 @@ from napari_phasors.plotter import (
     MaskAssignmentDialog,
     PhasorCenterLayerSettingsDialog,
     PlotterWidget,
+    _apply_label_colors_to_combo,
 )
 from napari_phasors.selection_tab import SelectionWidget
 
@@ -4435,3 +4437,217 @@ def test_mask_assignment_dialog_get_label_assignments_normalises_all_checked(
     ), "All-checked labels should normalise to None in get_label_assignments"
 
     dialog.close()
+
+
+def test_mask_assignment_dialog_label_items_colored_by_layer(
+    make_napari_viewer,
+):
+    """Label combo items get foreground color and background matching the Labels layer."""
+    viewer = make_napari_viewer()
+    layer1 = create_image_layer_with_phasors()
+    viewer.add_layer(layer1)
+
+    G = layer1.metadata["G"]
+    shape = G.shape[1:] if G.ndim == 3 else G.shape
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[:, : shape[1] // 2] = 1
+    mask_data[:, shape[1] // 2 :] = 2
+    labels_layer = viewer.add_labels(mask_data, name="colored_labels")
+
+    dialog = MaskAssignmentDialog(
+        image_layer_names=[layer1.name],
+        mask_layer_names=["None", "colored_labels"],
+        mask_layers=[labels_layer],
+        current_assignments={layer1.name: "None"},
+        current_label_assignments={},
+        current_invert_assignments={},
+        parent=None,
+    )
+
+    # Trigger mask selection to populate label combo with colored items
+    dialog._combos[layer1.name].setCurrentText("colored_labels")
+
+    label_combo = dialog._label_combos[layer1.name]
+    model = label_combo.model()
+    offset = label_combo._header_count
+
+    expected_bg = QColor(160, 160, 160, 160)
+    for i, lbl in enumerate([1, 2]):
+        item = model.item(offset + i)
+        assert item is not None, f"Item for label {lbl} is missing"
+        rgba = labels_layer.get_color(lbl)
+        assert rgba is not None, f"Labels layer has no color for label {lbl}"
+        r, g, b = (int(c * 255) for c in rgba[:3])
+        assert item.foreground().color() == QColor(
+            r, g, b
+        ), f"Label {lbl}: wrong foreground color"
+        assert (
+            item.background().color() == expected_bg
+        ), f"Label {lbl}: wrong background color"
+
+    dialog.close()
+
+
+def test_single_layer_mask_label_items_colored_by_layer(make_napari_viewer):
+    """mask_labels_combobox items get label colors in single-layer mode."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    G = layer.metadata["G"]
+    shape = G.shape[1:] if G.ndim == 3 else G.shape
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[:, : shape[1] // 2] = 1
+    mask_data[:, shape[1] // 2 :] = 2
+    labels_layer = viewer.add_labels(mask_data, name="single_colored_labels")
+
+    plotter = PlotterWidget(viewer)
+    # Select the image layer so single-layer mode is active
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer.name])
+
+    # Selecting the labels layer triggers _on_mask_layer_changed
+    plotter.mask_layer_combobox.setCurrentText("single_colored_labels")
+
+    combo = plotter.mask_labels_combobox
+    model = combo.model()
+    offset = combo._header_count
+
+    expected_bg = QColor(160, 160, 160, 160)
+    for i, lbl in enumerate([1, 2]):
+        item = model.item(offset + i)
+        assert item is not None, f"Item for label {lbl} is missing"
+        rgba = labels_layer.get_color(lbl)
+        assert rgba is not None, f"Labels layer has no color for label {lbl}"
+        r, g, b = (int(c * 255) for c in rgba[:3])
+        assert item.foreground().color() == QColor(
+            r, g, b
+        ), f"Label {lbl}: wrong foreground color in single-layer mode"
+        assert (
+            item.background().color() == expected_bg
+        ), f"Label {lbl}: wrong background color in single-layer mode"
+
+
+def test_apply_label_colors_to_combo(make_napari_viewer):
+    """_apply_label_colors_to_combo sets foreground and background on items."""
+    from napari_phasors._utils import CheckableComboBox
+
+    viewer = make_napari_viewer()
+    mask_data = np.array([[0, 1], [2, 3]], dtype=int)
+    labels_layer = viewer.add_labels(mask_data, name="helper_test_labels")
+
+    combo = CheckableComboBox(
+        placeholder="All Labels",
+        enable_primary_layer=False,
+        unit="labels",
+        show_select_all_none=False,
+        no_selection_text="No labels",
+    )
+    unique_labels = np.unique(labels_layer.data)
+    valid_labels = [str(lbl) for lbl in unique_labels if lbl > 0]
+    combo.addItems(valid_labels)
+
+    _apply_label_colors_to_combo(combo, labels_layer, unique_labels)
+
+    expected_bg = QColor(160, 160, 160, 160)
+    offset = combo._header_count
+    for i, lbl in enumerate([1, 2, 3]):
+        item = combo.model().item(offset + i)
+        assert item is not None
+        rgba = labels_layer.get_color(lbl)
+        if rgba is not None:
+            r, g, b = (int(c * 255) for c in rgba[:3])
+            assert item.foreground().color() == QColor(r, g, b)
+            assert item.background().color() == expected_bg
+
+
+def test_refresh_mask_labels_combobox_adds_new_label(make_napari_viewer):
+    """_refresh_mask_labels_combobox adds a new label and preserves selection."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    G = layer.metadata["G"]
+    shape = G.shape[1:] if G.ndim == 3 else G.shape
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[:, : shape[1] // 2] = 1
+    labels_layer = viewer.add_labels(mask_data, name="refresh_labels")
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer.name])
+    plotter.mask_layer_combobox.setCurrentText("refresh_labels")
+
+    combo = plotter.mask_labels_combobox
+    assert combo.allItems() == ["1"], "Should start with only label 1"
+    # Check only label 1 (simulates user deselecting nothing — all checked)
+    combo.selectAll()
+
+    # Add a new label to the layer data
+    new_data = mask_data.copy()
+    new_data[: shape[0] // 2, shape[1] // 2 :] = 2
+    labels_layer.data = new_data
+
+    plotter._refresh_mask_labels_combobox(labels_layer)
+
+    assert combo.allItems() == ["1", "2"], "Label 2 should be added"
+    # New label 2 should be unchecked (previously_checked only had "1")
+    checked = combo.checkedItems()
+    assert "1" in checked, "Previously checked label 1 should remain checked"
+
+
+def test_refresh_mask_labels_combobox_noop_when_unchanged(make_napari_viewer):
+    """_refresh_mask_labels_combobox does nothing when label set is unchanged."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    G = layer.metadata["G"]
+    shape = G.shape[1:] if G.ndim == 3 else G.shape
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[:, : shape[1] // 2] = 1
+    mask_data[:, shape[1] // 2 :] = 2
+    labels_layer = viewer.add_labels(mask_data, name="noop_labels")
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer.name])
+    plotter.mask_layer_combobox.setCurrentText("noop_labels")
+
+    combo = plotter.mask_labels_combobox
+    assert combo.allItems() == ["1", "2"]
+    combo.setCheckedItems(["1"])  # user selects only label 1
+
+    # Call refresh with the same data — should be a no-op
+    plotter._refresh_mask_labels_combobox(labels_layer)
+
+    assert combo.checkedItems() == ["1"], "Selection should be unchanged"
+
+
+def test_on_mask_data_changed_refreshes_label_combo(make_napari_viewer):
+    """Paint event on Labels layer updates mask_labels_combobox items."""
+    viewer = make_napari_viewer()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    G = layer.metadata["G"]
+    shape = G.shape[1:] if G.ndim == 3 else G.shape
+    mask_data = np.zeros(shape, dtype=int)
+    mask_data[:, : shape[1] // 2] = 1
+    labels_layer = viewer.add_labels(mask_data, name="paint_event_labels")
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer.name])
+    plotter.mask_layer_combobox.setCurrentText("paint_event_labels")
+
+    combo = plotter.mask_labels_combobox
+    assert combo.allItems() == ["1"]
+
+    # Simulate painting a new label by modifying data and calling the handler
+    new_data = mask_data.copy()
+    new_data[: shape[0] // 2, shape[1] // 2 :] = 2
+    labels_layer.data = new_data
+
+    # Fire the paint-event handler directly
+    plotter._refresh_mask_labels_combobox(labels_layer)
+
+    assert (
+        "2" in combo.allItems()
+    ), "New label 2 should appear after data change"

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -822,6 +822,39 @@ class TestCheckableComboBoxBasics:
         assert combo.allItems() == []
         assert combo.checkedItems() == []
 
+    def test_primary_layer_delegate_paint_custom_color(self, qtbot):
+        """Test that _PrimaryLayerDelegate.paint handles custom ForegroundRole colors without crashing."""
+        from qtpy.QtCore import Qt
+        from qtpy.QtGui import QColor, QImage, QPainter
+        from qtpy.QtWidgets import QStyleOptionViewItem
+
+        from napari_phasors._utils import CheckableComboBox
+
+        combo = CheckableComboBox()
+        qtbot.addWidget(combo)
+        combo.addItems(["test_item"])
+
+        item = combo.model().item(0)
+        item.setForeground(QColor(255, 0, 0))
+        item.setCheckState(Qt.Checked)
+
+        delegate = combo.itemDelegate()
+        option = QStyleOptionViewItem()
+        option.widget = combo
+        option.rect = combo.rect()
+
+        image = QImage(100, 30, QImage.Format_ARGB32)
+        painter = QPainter(image)
+        try:
+            # Should paint without crashing (handles the custom color path, checked)
+            delegate.paint(painter, option, combo.model().index(0, 0))
+
+            # Handles the custom color path, unchecked
+            item.setCheckState(Qt.Unchecked)
+            delegate.paint(painter, option, combo.model().index(0, 0))
+        finally:
+            painter.end()
+
 
 class TestCheckableComboBoxHeaderControls:
     """Tests for the show_select_all_none 'All' / 'None' header rows."""

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -999,11 +999,49 @@ class _PrimaryLayerDelegate(QStyledItemDelegate):
             cb_size,
             cb_size,
         )
-        if _check_state_value(check_state) == _check_state_value(Qt.Checked):
-            cb_option.state = QStyle.State_On | QStyle.State_Enabled
+        is_checked = _check_state_value(check_state) == _check_state_value(
+            Qt.Checked
+        )
+        item_color = index.data(Qt.ForegroundRole)
+        if hasattr(item_color, "color"):
+            item_color = item_color.color()
+
+        if isinstance(item_color, QColor) and item_color.isValid():
+            painter.save()
+            painter.setRenderHint(QPainter.Antialiasing, True)
+            if is_checked:
+                painter.setBrush(item_color)
+                painter.setPen(Qt.NoPen)
+                painter.drawRoundedRect(cb_option.rect, 3, 3)
+
+                painter.setPen(
+                    QPen(Qt.white, 2, Qt.SolidLine, Qt.RoundCap, Qt.RoundJoin)
+                )
+                painter.drawLine(
+                    cb_option.rect.left() + 4,
+                    cb_option.rect.top() + 8,
+                    cb_option.rect.left() + 7,
+                    cb_option.rect.top() + 11,
+                )
+                painter.drawLine(
+                    cb_option.rect.left() + 7,
+                    cb_option.rect.top() + 11,
+                    cb_option.rect.left() + 12,
+                    cb_option.rect.top() + 4,
+                )
+            else:
+                light_color = QColor(item_color)
+                light_color.setAlpha(100)
+                painter.setBrush(light_color)
+                painter.setPen(Qt.NoPen)
+                painter.drawRoundedRect(cb_option.rect, 3, 3)
+            painter.restore()
         else:
-            cb_option.state = QStyle.State_Off | QStyle.State_Enabled
-        style.drawControl(QStyle.CE_CheckBox, cb_option, painter)
+            if is_checked:
+                cb_option.state = QStyle.State_On | QStyle.State_Enabled
+            else:
+                cb_option.state = QStyle.State_Off | QStyle.State_Enabled
+            style.drawControl(QStyle.CE_CheckBox, cb_option, painter)
 
         text_left = rect.left() + cb_margin + cb_size + cb_margin
 

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -1243,6 +1243,11 @@ class CheckableComboBox(QComboBox):
             self.model().insertRow(row_idx, item)
         self._header_count = 2
 
+    @property
+    def header_count(self):
+        """Number of non-checkable header rows at the top of the dropdown."""
+        return self._header_count
+
     def _is_header_row(self, row):
         """Return True if *row* is a header control row (not a data item)."""
         item = self.model().item(row)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -245,7 +245,7 @@ def _apply_label_colors_to_combo(combo, labels_layer, unique_labels):
     colored text stays readable against napari's dark theme.
     """
     bg = QColor(160, 160, 160, 160)
-    offset = combo._header_count
+    offset = combo.header_count
     for i, lbl in enumerate(lbl for lbl in unique_labels if lbl > 0):
         rgba = labels_layer.get_color(lbl)
         if rgba is None:
@@ -6153,6 +6153,21 @@ class PlotterWidget(QWidget):
         else:
             self.mask_labels_combobox.setCheckedItems(still_checked)
         self.mask_labels_combobox.blockSignals(False)
+
+        # The label set changed, so the checked selection above may differ
+        # from what was stored before (e.g. "all" -> a subset, or vice
+        # versa). Resync _mask_label_assignments so the filter the caller
+        # applies right after matches what the combobox now shows.
+        checked = [
+            int(lbl) for lbl in self.mask_labels_combobox.checkedItems()
+        ]
+        all_count = (
+            self.mask_labels_combobox.model().rowCount()
+            - self.mask_labels_combobox.header_count
+        )
+        labels = None if len(checked) == all_count else checked
+        for image_layer in self.get_selected_layers():
+            self._mask_label_assignments[image_layer.name] = labels
 
     def _on_mask_invert_changed(self, checked):
         """Handle invert checkbox state change."""

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -237,6 +237,30 @@ _patch_nap_plot_tools_safe_disconnect()
 _patch_biaplotter_safe_toggle_sender()
 
 
+def _apply_label_colors_to_combo(combo, labels_layer, unique_labels):
+    """Set foreground color and light background on each item in *combo*.
+
+    Colors are derived from *labels_layer* for each positive label value in
+    *unique_labels*.  A semi-transparent light background is added so the
+    colored text stays readable against napari's dark theme.
+    """
+    bg = QColor(160, 160, 160, 160)
+    offset = combo._header_count
+    for i, lbl in enumerate(lbl for lbl in unique_labels if lbl > 0):
+        rgba = labels_layer.get_color(lbl)
+        if rgba is None:
+            continue
+        r, g, b = (int(c * 255) for c in rgba[:3])
+        item = combo.model().item(offset + i)
+        if item is None:
+            continue
+        item.setForeground(QColor(r, g, b))
+        item.setBackground(bg)
+        font = item.font()
+        font.setBold(True)
+        item.setFont(font)
+
+
 class MaskAssignmentDialog(QDialog):
     """Dialog to assign a mask layer to each selected image layer.
 
@@ -397,6 +421,7 @@ class MaskAssignmentDialog(QDialog):
                         str(lbl) for lbl in unique_labels if lbl > 0
                     ]
                     lc.addItems(valid_labels)
+                    _apply_label_colors_to_combo(lc, layer, unique_labels)
                     # Restore previous selection if applicable
                     if text == current_assignments.get(name, "None"):
                         prev_labels = current_label_assignments.get(name)
@@ -5969,6 +5994,9 @@ class PlotterWidget(QWidget):
                         str(lbl) for lbl in unique_labels if lbl > 0
                     ]
                     self.mask_labels_combobox.addItems(valid_labels)
+                    _apply_label_colors_to_combo(
+                        self.mask_labels_combobox, layer, unique_labels
+                    )
                     # Keep previously selected labels if applicable
                     current_labels = None
                     for image_layer in selected_layers:
@@ -6076,6 +6104,9 @@ class PlotterWidget(QWidget):
 
         mask_layer = event.source
 
+        if len(selected_layers) <= 1 and isinstance(mask_layer, Labels):
+            self._refresh_mask_labels_combobox(mask_layer)
+
         for image_layer in affected_layers:
             invert = self._mask_invert_assignments.get(image_layer.name, False)
             labels = self._mask_label_assignments.get(image_layer.name, None)
@@ -6096,6 +6127,32 @@ class PlotterWidget(QWidget):
                 self.filter_tab.apply_button_clicked()
 
         self.refresh_current_plot()
+
+    def _refresh_mask_labels_combobox(self, layer):
+        """Repopulate mask_labels_combobox if the label set in *layer* changed.
+
+        Preserves the user's checked selection where possible: items that were
+        checked and still exist in the new label set remain checked; brand-new
+        labels are added unchecked unless all labels are newly checked, in which
+        case selectAll is called to keep the "All Labels" default.
+        """
+        unique_labels = np.unique(layer.data)
+        new_valid = [str(lbl) for lbl in unique_labels if lbl > 0]
+        if new_valid == self.mask_labels_combobox.allItems():
+            return
+        previously_checked = set(self.mask_labels_combobox.checkedItems())
+        self.mask_labels_combobox.blockSignals(True)
+        self.mask_labels_combobox.clear()
+        self.mask_labels_combobox.addItems(new_valid)
+        _apply_label_colors_to_combo(
+            self.mask_labels_combobox, layer, unique_labels
+        )
+        still_checked = [lbl for lbl in new_valid if lbl in previously_checked]
+        if not still_checked or set(still_checked) == set(new_valid):
+            self.mask_labels_combobox.selectAll()
+        else:
+            self.mask_labels_combobox.setCheckedItems(still_checked)
+        self.mask_labels_combobox.blockSignals(False)
 
     def _on_mask_invert_changed(self, checked):
         """Handle invert checkbox state change."""


### PR DESCRIPTION
# Summary

Enhances the label-selection user experience in mask assignment and plotting dialogs by displaying label entries using the corresponding `Labels` layer colors. Also improves the checkable combo box delegate to correctly render checkbox indicators when custom item colors are applied.

# Changes

## `plotter.py`

* Added `_apply_label_colors_to_combo` to apply per-label foreground colors and semi-transparent backgrounds based on the underlying `Labels` layer colormap.
* Updated `MaskAssignmentDialog` and `PlotterWidget` to display colored label entries in label-selection comboboxes.
* Added `_refresh_mask_labels_combobox` to refresh `mask_labels_combobox` when a `Labels` layer changes, while preserving the previous selection whenever possible.

## `_utils.py`

* Updated `_PrimaryLayerDelegate.paint` to correctly render checkbox indicators for items with custom `Qt.ForegroundRole` colors.
* Preserved the existing fallback behavior for standard items without custom colors.

# Tests

## `test_plotter.py`

* Added tests covering colored label entries in both `MaskAssignmentDialog` and `PlotterWidget`.
* Added tests for `_apply_label_colors_to_combo`.
* Added tests for `_refresh_mask_labels_combobox`, including selection preservation behavior.

## `test_utils_widgets.py`

* Added a regression test for `_PrimaryLayerDelegate.paint` when items use custom `Qt.ForegroundRole` colors.
