### PR TITLE
fix: Missing harmonics Metadata

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,6 +72,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: napari-phasors/napari-phasors
 
+      - name: Upload coverage report
+        if: matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.qt-backend == 'pyqt6'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
   static_analysis:
     name: Static code analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - qt-backend: pyside6
             python-version: '3.12'
           - qt-backend: pyside6
-            python-version: '3.13'
+            python-version: '3.14'
 
     steps:
       - uses: actions/checkout@v3

--- a/conftest.py
+++ b/conftest.py
@@ -21,3 +21,14 @@ try:  # pragma: no cover - import guard only
         importlib.import_module(f"vispy.app.backends._{API_NAME.lower()}")
 except Exception:  # noqa: BLE001
     pass
+
+
+try:  # pragma: no cover - environment-dependent mitigation
+    import gc
+
+    from qtpy import API_NAME as _QT_API_NAME
+
+    if (_QT_API_NAME or "").lower() == "pyside6":
+        gc.disable()
+except Exception:  # noqa: BLE001
+    pass

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -1757,3 +1757,30 @@ def test_components_widget_harmonics_none_fallback(make_viewer_model, qtbot):
 
     comp._run_analysis()
     assert len(comp.fraction_layers) == 3
+
+
+def test_components_widget_exceptions(make_viewer_model, qtbot):
+    """Test component analysis handles missing metadata and IndexError."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    # Test Linear Projection with missing G array
+    comp.analysis_type_combo.setCurrentText("Linear Projection")
+    layer.metadata["G"] = None
+    comp._run_analysis()  # Should return early
+
+    # Test Linear Projection with missing harmonic (IndexError)
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["S"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([999])
+    comp._run_analysis()  # Should return early
+
+    # Test Component Fit with missing G array
+    comp._add_component()
+    comp.analysis_type_combo.setCurrentText("Component Fit")
+    layer.metadata["G"] = None
+    comp._run_analysis()  # Should return early
+
+    # Test Component Fit with missing harmonic (IndexError)
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([999])
+    comp._run_analysis()  # Should return early

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -1725,3 +1725,35 @@ def test_components_recreate_variants_and_colormaps(make_viewer_model, qtbot):
     }
     comp._restore_and_recreate_components_from_metadata()
     assert len(comp.fraction_layers) == 3
+
+
+def test_components_widget_harmonics_none_fallback(make_viewer_model, qtbot):
+    """Test component analysis when harmonics metadata is None (e.g. loaded .R64 files)."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    # Modify metadata to simulate a .R64 file where harmonics is None and G/S are 2D arrays (ndim matches data)
+    layer.metadata["harmonics"] = None
+    layer.metadata["G"] = layer.metadata["G"][0]
+    layer.metadata["S"] = layer.metadata["S"][0]
+
+    # 1. Test Linear Projection
+    comp.analysis_type_combo.setCurrentText("Linear Projection")
+    comp.components[0].g_edit.setText("0.2")
+    comp.components[0].s_edit.setText("0.1")
+    comp._on_component_coords_changed(0)
+    comp.components[1].g_edit.setText("0.8")
+    comp.components[1].s_edit.setText("0.5")
+    comp._on_component_coords_changed(1)
+
+    comp._run_analysis()
+    assert comp.comp1_fractions_layer is not None
+
+    # 2. Test Component Fit
+    comp._add_component()
+    comp.analysis_type_combo.setCurrentText("Component Fit")
+    comp.components[2].g_edit.setText("0.5")
+    comp.components[2].s_edit.setText("0.3")
+    comp._on_component_coords_changed(2)
+
+    comp._run_analysis()
+    assert len(comp.fraction_layers) == 3

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -2164,6 +2164,9 @@ def test_fret_widget_exceptions(make_viewer_model, qtbot):
     w._calculate_donor_lifetime()
 
     # 3. Main trajectory loop exceptions
+    # Reset G/S to valid matching shapes before triggering plotter update via combobox
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["S"] = np.ones((2, 10, 10))
     parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
     layer.metadata["G"] = None
     w.calculate_fret_efficiency()

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -2104,3 +2104,71 @@ def test_fret_harmonics_none_fallback(make_viewer_model, qtbot):
     # 3. Test main FRET efficiency trajectory calculation loop with harmonics is None
     w.calculate_fret_efficiency()
     assert w.fret_layer is not None
+
+
+def test_fret_widget_exceptions(make_viewer_model, qtbot):
+    """Test FRET module handles missing metadata, IndexError, and Exception gracefully."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    w = parent.fret_tab
+    parent.tab_widget.setCurrentWidget(w)
+
+    w.frequency_input.setText("80")
+
+    # 1. Background position exceptions
+    w.bg_source_selector.setCurrentText("From layer(s)")
+    w._update_background_combobox()
+    w.background_image_combobox.setCheckedItems([layer.name])
+
+    # Missing G/S arrays
+    layer.metadata["G"] = None
+    w._calculate_background_position()  # Should continue/return
+
+    # Harmonic not found
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["S"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([999])
+    w._calculate_background_position()  # Should continue/return
+
+    # Mismatched shapes causing Exception in phasor_center
+    layer.metadata["G"] = np.ones(
+        (10, 10)
+    )  # Intentionally 2D when expected 3D or vice versa
+    layer.metadata["S"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([1])
+    parent.harmonic = 1
+    w._calculate_background_position()  # Should catch Exception
+
+    # Same for harmonics is None
+    layer.metadata["harmonics"] = None
+    w._calculate_background_position()  # Should catch Exception
+
+    # 2. Donor lifetime exceptions
+    w.donor_source_selector.setCurrentIndex(1)  # From layer(s)
+    w._update_donor_lifetime_combobox()
+    w.donor_lifetime_combobox.setCheckedItems([layer.name])
+
+    layer.metadata["G"] = None
+    w._calculate_donor_lifetime()
+
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([999])
+    w._calculate_donor_lifetime()
+
+    layer.metadata["G"] = np.ones((10, 10))
+    layer.metadata["S"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([1])
+    w._calculate_donor_lifetime()
+
+    # 3. Main trajectory loop exceptions
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+    layer.metadata["G"] = None
+    w.calculate_fret_efficiency()
+
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["S"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([999])
+    w.calculate_fret_efficiency()

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -2067,3 +2067,40 @@ def test_fret_calculate_donor_lifetime_from_layers(make_viewer_model, qtbot):
         # A finite averaged lifetime is computed and shown in the UI.
         assert w.donor_lifetime is not None and w.donor_lifetime > 0
         assert w.donor_line_edit.text() != ""
+
+
+def test_fret_harmonics_none_fallback(make_viewer_model, qtbot):
+    """Cover FRET calculations when harmonics metadata is None (e.g. loaded .R64 files)."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    layer.metadata["settings"] = {"frequency": 80.0}
+    # Simulate a .R64 file where harmonics is None and G/S are 2D arrays
+    layer.metadata["harmonics"] = None
+    layer.metadata["G"] = layer.metadata["G"][0]
+    layer.metadata["S"] = layer.metadata["S"][0]
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    w = parent.fret_tab
+    parent.tab_widget.setCurrentWidget(w)
+
+    w.frequency_input.setText("80")
+
+    # 1. Test _calculate_background_position with harmonics is None
+    w.bg_source_selector.setCurrentText("From layer(s)")
+    w._update_background_combobox()
+    w.background_image_combobox.setCheckedItems([layer.name])
+    w._calculate_background_position()
+    assert len(w.background_positions_by_harmonic) > 0
+
+    # 2. Test _calculate_donor_lifetime with harmonics is None
+    w.donor_source_selector.setCurrentIndex(1)  # From layer(s)
+    w._update_donor_lifetime_combobox()
+    w.donor_lifetime_combobox.setCheckedItems([layer.name])
+    w.lifetime_type_combobox.setCurrentText("Normal Lifetime")
+    w._calculate_donor_lifetime()
+    assert w.donor_lifetime is not None and w.donor_lifetime > 0
+
+    # 3. Test main FRET efficiency trajectory calculation loop with harmonics is None
+    w.calculate_fret_efficiency()
+    assert w.fret_layer is not None

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -2123,3 +2123,32 @@ def test_phasor_mapping_custom_color_mesh_and_frequency(
     pm.output_mode_combobox.setCurrentText("Lifetime")
     pm.frequency_input.setText("80")
     pm._on_frequency_changed()
+
+
+def test_phasor_mapping_harmonics_none_fallback(make_viewer_model, qtbot):
+    """Cover phasor mapping calculations when harmonics metadata is None (e.g. loaded .R64 files)."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    layer.metadata["settings"] = {"frequency": 80.0}
+    # Simulate a .R64 file where harmonics is None and G/S are 2D arrays
+    layer.metadata["harmonics"] = None
+    layer.metadata["G"] = layer.metadata["G"][0]
+    layer.metadata["S"] = layer.metadata["S"][0]
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    pm = parent.phasor_mapping_tab
+    parent.tab_widget.setCurrentWidget(pm)
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+
+    # 1. Phase output mode
+    pm.output_mode_combobox.setCurrentText("Phase")
+    pm.calculate_output_data()
+    # Confirm output layers/data created successfully
+    assert pm.current_metric_data_original is not None
+
+    # 2. Lifetime output mode
+    pm.output_mode_combobox.setCurrentText("Lifetime")
+    pm.calculate_output_data()
+    # Confirm output layers/data created successfully
+    assert pm.current_metric_data_original is not None

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -2152,3 +2152,25 @@ def test_phasor_mapping_harmonics_none_fallback(make_viewer_model, qtbot):
     pm.calculate_output_data()
     # Confirm output layers/data created successfully
     assert pm.current_metric_data_original is not None
+
+
+def test_phasor_mapping_exceptions(make_viewer_model, qtbot):
+    """Test Phasor Mapping module handles missing metadata and IndexError gracefully."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    pm = parent.phasor_mapping_tab
+    parent.tab_widget.setCurrentWidget(pm)
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+
+    # Missing G/S arrays
+    layer.metadata["G"] = None
+    pm.calculate_output_data()  # Should return early
+
+    # Harmonic not found
+    layer.metadata["G"] = np.ones((2, 10, 10))
+    layer.metadata["S"] = np.ones((2, 10, 10))
+    layer.metadata["harmonics"] = np.array([999])
+    pm.calculate_output_data()  # Should return early

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -4063,20 +4063,23 @@ class ComponentsWidget(QWidget):
         s_array = layer.metadata.get('S')
         harmonics = layer.metadata.get('harmonics')
 
-        if g_array is None or s_array is None or harmonics is None:
+        if g_array is None or s_array is None:
             return
 
-        try:
-            harmonics_array = np.atleast_1d(harmonics)
-            harmonic_idx = np.where(
-                harmonics_array == self.parent_widget.harmonic
-            )[0][0]
-        except IndexError:
-            return
-
-        if g_array.ndim == layer.data.ndim + 1:
-            real = g_array[harmonic_idx]
-            imag = s_array[harmonic_idx]
+        if harmonics is not None:
+            try:
+                harmonics_array = np.atleast_1d(harmonics)
+                harmonic_idx = np.where(
+                    harmonics_array == self.parent_widget.harmonic
+                )[0][0]
+                if g_array.ndim == layer.data.ndim + 1:
+                    real = g_array[harmonic_idx]
+                    imag = s_array[harmonic_idx]
+                else:
+                    real = g_array
+                    imag = s_array
+            except IndexError:
+                return
         else:
             real = g_array
             imag = s_array
@@ -4315,14 +4318,19 @@ class ComponentsWidget(QWidget):
                 )
                 return
 
-            try:
-                harmonic_idx = np.where(harmonics == current_harmonic)[0][0]
-            except IndexError:
-                return
-
-            if g_array.ndim == layer.data.ndim + 1:
-                real = g_array[harmonic_idx]
-                imag = s_array[harmonic_idx]
+            if harmonics is not None:
+                try:
+                    harmonic_idx = np.where(harmonics == current_harmonic)[0][
+                        0
+                    ]
+                    if g_array.ndim == layer.data.ndim + 1:
+                        real = g_array[harmonic_idx]
+                        imag = s_array[harmonic_idx]
+                    else:
+                        real = g_array
+                        imag = s_array
+                except IndexError:
+                    return
             else:
                 real = g_array
                 imag = s_array

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -759,31 +759,45 @@ class FretWidget(QWidget):
                 harmonics = background_layer.metadata.get("harmonics")
                 mean = background_layer.metadata.get("original_mean")
 
-                if g_array is None or s_array is None or harmonics is None:
+                if g_array is None or s_array is None:
                     continue
 
             except (KeyError, AttributeError):
                 continue
 
-            harmonics = np.atleast_1d(harmonics)
-            for harmonic in harmonics:
-                try:
-                    harmonic_idx = np.where(harmonics == harmonic)[0]
-                    if len(harmonic_idx) == 0:
+            if harmonics is not None:
+                harmonics_arr = np.atleast_1d(harmonics)
+                for harmonic in harmonics_arr:
+                    try:
+                        harmonic_idx = np.where(harmonics_arr == harmonic)[0]
+                        if len(harmonic_idx) == 0:
+                            continue
+                        harmonic_idx = harmonic_idx[0]
+
+                        if g_array.ndim > background_layer.data.ndim:
+                            real = g_array[harmonic_idx]
+                            imag = s_array[harmonic_idx]
+                        else:
+                            real = g_array
+                            imag = s_array
+
+                        _, center_real, center_imag = phasor_center(
+                            mean, real, imag
+                        )
+
+                        if harmonic not in positions_by_harmonic:
+                            positions_by_harmonic[harmonic] = []
+                        positions_by_harmonic[harmonic].append(
+                            (center_real, center_imag)
+                        )
+                    except Exception:  # noqa: BLE001
                         continue
-                    harmonic_idx = harmonic_idx[0]
-
-                    if g_array.ndim > background_layer.data.ndim:
-                        real = g_array[harmonic_idx]
-                        imag = s_array[harmonic_idx]
-                    else:
-                        real = g_array
-                        imag = s_array
-
+            else:
+                try:
                     _, center_real, center_imag = phasor_center(
-                        mean, real, imag
+                        mean, g_array, s_array
                     )
-
+                    harmonic = self.parent_widget.harmonic
                     if harmonic not in positions_by_harmonic:
                         positions_by_harmonic[harmonic] = []
                     positions_by_harmonic[harmonic].append(
@@ -890,20 +904,24 @@ class FretWidget(QWidget):
                 harmonics = donor_layer.metadata.get("harmonics")
                 mean = donor_layer.metadata.get("original_mean")
 
-                if g_array is None or s_array is None or harmonics is None:
+                if g_array is None or s_array is None:
                     continue
 
-                harmonics = np.atleast_1d(harmonics)
-                harmonic_idx = np.where(harmonics == current_harmonic)[0]
+                if harmonics is not None:
+                    harmonics = np.atleast_1d(harmonics)
+                    harmonic_idx = np.where(harmonics == current_harmonic)[0]
 
-                if len(harmonic_idx) == 0:
-                    continue
+                    if len(harmonic_idx) == 0:
+                        continue
 
-                harmonic_idx = harmonic_idx[0]
+                    harmonic_idx = harmonic_idx[0]
 
-                if g_array.ndim > donor_layer.data.ndim:
-                    real = g_array[harmonic_idx]
-                    imag = s_array[harmonic_idx]
+                    if g_array.ndim > donor_layer.data.ndim:
+                        real = g_array[harmonic_idx]
+                        imag = s_array[harmonic_idx]
+                    else:
+                        real = g_array
+                        imag = s_array
                 else:
                     real = g_array
                     imag = s_array
@@ -1783,19 +1801,24 @@ class FretWidget(QWidget):
             # Retrieve arrays from metadata
             g_array = layer.metadata.get("G")
             s_array = layer.metadata.get("S")
-            harmonics = np.atleast_1d(layer.metadata.get("harmonics"))
+            harmonics = layer.metadata.get("harmonics")
 
             if g_array is None or s_array is None:
                 continue
 
-            try:
-                harmonic_index = np.where(
-                    harmonics == self.parent_widget.harmonic
-                )[0][0]
-                real = g_array[harmonic_index]
-                imag = s_array[harmonic_index]
-            except IndexError:
-                continue
+            if harmonics is not None:
+                try:
+                    harmonics = np.atleast_1d(harmonics)
+                    harmonic_index = np.where(
+                        harmonics == self.parent_widget.harmonic
+                    )[0][0]
+                    real = g_array[harmonic_index]
+                    imag = s_array[harmonic_index]
+                except IndexError:
+                    continue
+            else:
+                real = g_array
+                imag = s_array
 
             fret_efficiency = phasor_nearest_neighbor(
                 real,

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -1220,19 +1220,24 @@ class PhasorMappingWidget(QWidget):
         for layer in selected_layers:
             g_array = layer.metadata.get("G")
             s_array = layer.metadata.get("S")
-            harmonics = np.atleast_1d(layer.metadata.get("harmonics"))
+            harmonics = layer.metadata.get("harmonics")
 
             if g_array is None or s_array is None:
                 continue
 
-            try:
-                harmonic_index = np.where(
-                    harmonics == self.parent_widget.harmonic
-                )[0][0]
-                real = g_array[harmonic_index]
-                imag = s_array[harmonic_index]
-            except IndexError:
-                continue
+            if harmonics is not None:
+                try:
+                    harmonics = np.atleast_1d(harmonics)
+                    harmonic_index = np.where(
+                        harmonics == self.parent_widget.harmonic
+                    )[0][0]
+                    real = g_array[harmonic_index]
+                    imag = s_array[harmonic_index]
+                except IndexError:
+                    continue
+            else:
+                real = g_array
+                imag = s_array
 
             if self._output_requires_frequency(output_type):
                 effective_frequency = (


### PR DESCRIPTION
## Description

This PR resolves an issue where processed/referenced phasor files (such as `.R64` or `.ref` files) could not be analyzed using any of the calculation tabs (Component Analysis, Lifetime Mapping, or FRET Analysis). 

### The Problem
Processed referenced phasor files do not carry a list of harmonics in their metadata. Consequently, `layer.metadata['harmonics']` is initialized as `None`. 
While the main plotter implemented a fallback to default to the raw `G` and `S` arrays when `harmonics` is `None` (see `plotter.py`), all the analysis widgets lacked this fallback. When you clicked any analysis run/calculate button:
1. They checked if `harmonics` was `None` and returned early silently.
2. Or they attempted to locate `np.where(harmonics == target_harmonic)[0][0]`, which raised an `IndexError` on the `None` array, causing them to exit early silently.

### The Fix
This PR implements the fallback logic in all three analysis tabs. If the `harmonics` metadata is `None` (indicating a single-harmonic processed file), we bypass the harmonic indexing logic and default directly to the 2D `G` and `S` arrays (treating them as the target harmonic).

---

## Changes

### Component Analysis
* **`components_tab.py`**:
  * Updated `_run_linear_projection_for_layer` to check if `harmonics is None` and use raw `G`/`S` arrays.
  * Updated `_run_component_fit_for_layer` to skip target index lookup when `harmonics` is `None` and proceed using `g_array` and `s_array` directly.

### Lifetime Mapping
* **`phasor_mapping_tab.py`**:
  * Updated `calculate_output_data` to bypass target harmonic indexing and use the raw `G`/`S` arrays directly when `harmonics` is `None`.

### FRET Analysis
* **`fret_tab.py`**:
  * Updated `_calculate_background_position` to calculate background coordinates using raw arrays under the current harmonic when `harmonics` is `None`.
  * Updated `_calculate_donor_lifetime` to handle `harmonics is None` cases by bypassing index lookup.
  * Updated the main trajectory calculation loop to use raw arrays directly when `harmonics` is `None`.
