### PR TITLE
feat: Implement mask copying functionality between layers

### DIFF
--- a/src/napari_phasors/_tests/test_plotter_masks.py
+++ b/src/napari_phasors/_tests/test_plotter_masks.py
@@ -1460,3 +1460,258 @@ def test_on_mask_data_changed_refreshes_label_combo(make_viewer_model):
     assert (
         "2" in combo.allItems()
     ), "New label 2 should appear after data change"
+
+
+def _make_spatial_mask(layer, fill=1):
+    """Build a labels mask matching a phasor layer's spatial dimensions."""
+    g_data = layer.metadata["G"]
+    mask_shape = g_data.shape[1:] if g_data.ndim == 3 else g_data.shape
+    mask = np.zeros(mask_shape, dtype=int)
+    mask[mask_shape[0] // 2 :, :] = fill
+    return mask
+
+
+def test_copy_mask_from_layer_copies_and_applies_mask(make_viewer_model):
+    """_copy_mask_from_layer mirrors the source mask onto the target layer."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    target_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    # Mask the source layer (invert + a label selection so we can assert both
+    # are carried over to the target).
+    mask = _make_spatial_mask(source_layer)
+    mask_layer = viewer.add_labels(mask, name="src_mask")
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [source_layer.name]
+    )
+    plotter._apply_mask_to_phasor_data(
+        mask_layer, source_layer, invert=True, labels=[1]
+    )
+
+    copied = plotter._copy_mask_from_layer(source_layer, target_layer)
+
+    assert copied is True
+    np.testing.assert_array_equal(
+        target_layer.metadata["mask"], source_layer.metadata["mask"]
+    )
+    assert target_layer.metadata["mask_invert"] is True
+    assert target_layer.metadata["mask_labels"] == [1]
+    # Mask was actually applied to the target's phasor coordinates.
+    assert np.isnan(target_layer.metadata["G"]).sum() > 0
+    # The per-layer assignment points at the source's mask layer.
+    assert plotter._mask_assignments[target_layer.name] == "src_mask"
+    assert plotter._mask_invert_assignments[target_layer.name] is True
+    assert plotter._mask_label_assignments[target_layer.name] == [1]
+
+    plotter.deleteLater()
+
+
+def test_copy_mask_from_unmasked_source_clears_target_mask(make_viewer_model):
+    """Copying masking from an unmasked source removes the target's mask."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    target_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    # Give the target an existing mask; the source has none.
+    mask = _make_spatial_mask(target_layer)
+    mask_layer = viewer.add_labels(mask, name="tgt_mask")
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [target_layer.name]
+    )
+    plotter._apply_mask_to_phasor_data(mask_layer, target_layer)
+    assert "mask" in target_layer.metadata
+
+    original_g = target_layer.metadata["G_original"]
+    copied = plotter._copy_mask_from_layer(source_layer, target_layer)
+
+    assert copied is False
+    assert "mask" not in target_layer.metadata
+    assert "mask_invert" not in target_layer.metadata
+    # Phasor data restored to its unmasked original.
+    np.testing.assert_array_almost_equal(
+        target_layer.metadata["G"], original_g
+    )
+
+    plotter.deleteLater()
+
+
+def test_copy_mask_from_layer_shapes_mask_different_image_sizes(
+    make_viewer_model,
+):
+    """A Shapes mask copies across images of different sizes.
+
+    Regression: copying the source's rasterized mask array failed the
+    size check when the target had different dimensions, silently leaving the
+    target's own mask. Copying the mask *layer* re-rasterizes the shapes to the
+    target's shape instead.
+    """
+    from napari_phasors._synthetic_generator import (
+        make_intensity_layer_with_phasors,
+        make_raw_flim_data,
+    )
+
+    def _layer(shape, name):
+        raw = make_raw_flim_data(
+            time_constants=[0.1, 1, 2, 3, 4, 5, 10], shape=shape
+        )
+        layer = make_intensity_layer_with_phasors(raw, harmonic=[1, 2, 3])
+        layer.name = name
+        return layer
+
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = _layer((10, 10), "SOURCE")
+    target_layer = _layer((6, 8), "TARGET")  # different dimensions
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    shapes_src = viewer.add_shapes(
+        [np.array([[0, 0], [5, 0], [5, 5], [0, 5]])],
+        shape_type="polygon",
+        name="shapes_src",
+    )
+    shapes_tgt = viewer.add_shapes(
+        [np.array([[3, 4], [6, 4], [6, 8], [3, 8]])],
+        shape_type="polygon",
+        name="shapes_tgt",
+    )
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(["SOURCE"])
+    plotter._apply_mask_to_phasor_data(shapes_src, source_layer)
+    plotter.image_layers_checkable_combobox.setCheckedItems(["TARGET"])
+    plotter._apply_mask_to_phasor_data(shapes_tgt, target_layer)
+    plotter.mask_layer_combobox.setCurrentText("shapes_tgt")
+
+    plotter._copy_metadata_from_layer("SOURCE", selected_tabs=["masking"])
+
+    # Target now uses the source's Shapes mask, rasterized to its own shape.
+    assert plotter._mask_assignments[target_layer.name] == "shapes_src"
+    assert plotter.mask_layer_combobox.currentText() == "shapes_src"
+    expected = shapes_src.to_labels(labels_shape=target_layer.data.shape)
+    np.testing.assert_array_equal(target_layer.metadata["mask"], expected)
+
+    plotter.deleteLater()
+
+
+def test_copy_mask_from_layer_shape_mismatch_skips(make_viewer_model):
+    """A mask whose shape differs from the target is not copied."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    target_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    # Stash a deliberately mismatched mask on the source.
+    source_layer.metadata["mask"] = np.ones((3, 3), dtype=int)
+    source_layer.metadata["mask_invert"] = False
+
+    with patch(
+        "napari_phasors.plotter.notifications.WarningNotification"
+    ) as warn:
+        copied = plotter._copy_mask_from_layer(source_layer, target_layer)
+
+    assert copied is False
+    assert "mask" not in target_layer.metadata
+    warn.assert_called_once()
+
+    plotter.deleteLater()
+
+
+def test_copy_metadata_from_layer_with_masking_tab(make_viewer_model):
+    """Selecting 'masking' in the import dialog copies the mask to targets."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    target_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    mask = _make_spatial_mask(source_layer)
+    mask_layer = viewer.add_labels(mask, name="src_mask")
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [source_layer.name]
+    )
+    plotter._apply_mask_to_phasor_data(mask_layer, source_layer)
+
+    # Now select the target and import with masking enabled.
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [target_layer.name]
+    )
+    plotter._copy_metadata_from_layer(
+        source_layer.name, selected_tabs=["masking"]
+    )
+
+    assert "mask" in target_layer.metadata
+    np.testing.assert_array_equal(
+        target_layer.metadata["mask"], source_layer.metadata["mask"]
+    )
+
+    plotter.deleteLater()
+
+
+def test_copy_metadata_from_layer_switches_selected_mask(make_viewer_model):
+    """Regression: copying masking replaces the target's own mask selection.
+
+    The target starts with its own mask; after importing masking from a source
+    that uses a *different* (inverted) mask, the target's selected mask layer,
+    invert flag, and NaN pattern must all match the source — not its own
+    previous mask.
+    """
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    target_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    src_mask = viewer.add_labels(
+        _make_spatial_mask(source_layer), name="src_mask"
+    )
+    # A different mask for the target (left half rather than bottom half).
+    g = target_layer.metadata["G"]
+    shape = g.shape[1:] if g.ndim == 3 else g.shape
+    tgt_arr = np.zeros(shape, dtype=int)
+    tgt_arr[:, : shape[1] // 2] = 1
+    tgt_mask = viewer.add_labels(tgt_arr, name="tgt_mask")
+
+    # Apply the inverted source mask to the source.
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [source_layer.name]
+    )
+    plotter._apply_mask_to_phasor_data(src_mask, source_layer, invert=True)
+    source_nan = np.isnan(source_layer.metadata["G"])
+
+    # Give the target its own (non-inverted) mask and select it.
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [target_layer.name]
+    )
+    plotter._apply_mask_to_phasor_data(tgt_mask, target_layer)
+    plotter.mask_layer_combobox.setCurrentText("tgt_mask")
+
+    plotter._copy_metadata_from_layer(
+        source_layer.name, selected_tabs=["masking"]
+    )
+
+    # Selection now points at the source's mask, not the target's old one.
+    assert plotter._mask_assignments[target_layer.name] == "src_mask"
+    assert plotter.mask_layer_combobox.currentText() == "src_mask"
+    assert plotter._mask_invert_assignments[target_layer.name] is True
+    # Invert was honored: the NaN pattern matches the inverted source mask.
+    np.testing.assert_array_equal(
+        np.isnan(target_layer.metadata["G"]), source_nan
+    )
+
+    plotter.deleteLater()

--- a/src/napari_phasors/_tests/test_plotter_masks.py
+++ b/src/napari_phasors/_tests/test_plotter_masks.py
@@ -1715,3 +1715,217 @@ def test_copy_metadata_from_layer_switches_selected_mask(make_viewer_model):
     )
 
     plotter.deleteLater()
+
+
+# -- Coverage gaps: masking toggle in the import dialog --------------------
+
+
+def test_show_import_dialog_masking_toggle_checked_by_default(
+    make_viewer_model,
+):
+    """The Masking toggle is offered and checked by default when available."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    with patch("napari_phasors.plotter.QDialog.exec", return_value=1):
+        selected = plotter._show_import_dialog(
+            source_settings={"frequency": 80},
+            mask_available=True,
+        )
+
+    assert "masking" in selected
+
+
+def test_show_import_dialog_masking_toggle_unchecked_when_not_default(
+    make_viewer_model,
+):
+    """The Masking toggle starts unchecked when excluded from default_checked."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    with patch("napari_phasors.plotter.QDialog.exec", return_value=1):
+        selected = plotter._show_import_dialog(
+            source_settings={"frequency": 80},
+            mask_available=True,
+            default_checked=["settings_tab"],
+        )
+
+    assert "masking" not in selected
+
+
+def test_show_import_dialog_no_masking_toggle_when_unavailable(
+    make_viewer_model,
+):
+    """No Masking toggle (and no 'masking' selection) when mask_available=False."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    with patch("napari_phasors.plotter.QDialog.exec", return_value=1):
+        selected = plotter._show_import_dialog(
+            source_settings={"frequency": 80},
+            mask_available=False,
+        )
+
+    assert "masking" not in selected
+
+
+# -- Coverage gaps: _apply_mask_array_to_phasor_data branches ---------------
+
+
+def test_apply_mask_array_clears_stale_mask_labels(make_viewer_model):
+    """Calling with labels=None removes a previously stored mask_labels key."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    mask = _make_spatial_mask(layer)
+
+    plotter._apply_mask_array_to_phasor_data(mask, layer, labels=[1])
+    assert "mask_labels" in layer.metadata
+
+    plotter._apply_mask_array_to_phasor_data(mask, layer, labels=None)
+    assert "mask_labels" not in layer.metadata
+
+    plotter.deleteLater()
+
+
+def test_apply_mask_array_single_harmonic_branch(make_viewer_model):
+    """G/S without a leading harmonic axis take the non-expanded mask branch."""
+    from napari_phasors._synthetic_generator import (
+        make_intensity_layer_with_phasors,
+        make_raw_flim_data,
+    )
+
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    raw = make_raw_flim_data(time_constants=[0.1, 1, 2, 3, 4, 5, 10])
+    # A bare int harmonic yields G/S with the same ndim as the image data
+    # (no leading harmonic axis), exercising the "else" branch.
+    layer = make_intensity_layer_with_phasors(raw, harmonic=1)
+    viewer.add_layer(layer)
+    assert layer.metadata["G"].ndim == layer.data.ndim
+
+    mask = _make_spatial_mask(layer)
+    plotter._apply_mask_array_to_phasor_data(mask, layer)
+
+    assert np.isnan(layer.metadata["G"]).sum() > 0
+    assert np.isnan(layer.metadata["S"]).sum() > 0
+
+    plotter.deleteLater()
+
+
+# -- Coverage gaps: _copy_mask_from_layer / _find_mask_layer_for branches --
+
+
+def test_copy_mask_from_layer_matching_labels_layer_shape_mismatch(
+    make_viewer_model,
+):
+    """A matching Labels mask layer whose shape no longer fits the target is skipped.
+
+    Distinct from the 'mask layer was deleted' fallback: here the mask layer
+    that produced the source's stored mask is still in the viewer and matches
+    by value, but its own shape differs from the target's, so it cannot be
+    re-applied (the Labels case is pixel-bound, unlike Shapes).
+    """
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+
+    mask = _make_spatial_mask(source_layer)
+    mask_layer = viewer.add_labels(mask, name="src_mask")
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [source_layer.name]
+    )
+    plotter._apply_mask_to_phasor_data(mask_layer, source_layer)
+
+    # A differently-shaped target: its data shape won't match the mask layer.
+    g = source_layer.metadata["G"]
+    shape = g.shape[1:] if g.ndim == 3 else g.shape
+    target_data = np.zeros((shape[0] + 2, shape[1] + 2))
+    target_layer = Image(
+        target_data,
+        name="target",
+        metadata={
+            "G": np.zeros((target_data.shape[0], target_data.shape[1])),
+            "S": np.zeros((target_data.shape[0], target_data.shape[1])),
+            "G_original": np.zeros(
+                (target_data.shape[0], target_data.shape[1])
+            ),
+            "S_original": np.zeros(
+                (target_data.shape[0], target_data.shape[1])
+            ),
+            "original_mean": target_data.copy(),
+        },
+    )
+    viewer.add_layer(target_layer)
+
+    with patch(
+        "napari_phasors.plotter.notifications.WarningNotification"
+    ) as warn:
+        copied = plotter._copy_mask_from_layer(source_layer, target_layer)
+
+    assert copied is False
+    warn.assert_called_once()
+
+    plotter.deleteLater()
+
+
+def test_copy_mask_from_layer_fallback_creates_mask_layer(make_viewer_model):
+    """When the source's mask layer can't be found, a Restored Mask layer is created.
+
+    Exercises the array-fallback success path: the source's stored mask has
+    no corresponding Labels/Shapes layer left in the viewer, but its shape
+    still fits the target, so the raw array is applied and a new Labels layer
+    is created to represent it.
+    """
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    source_layer = create_image_layer_with_phasors()
+    target_layer = create_image_layer_with_phasors()
+    viewer.add_layer(source_layer)
+    viewer.add_layer(target_layer)
+
+    # Stash a mask directly in metadata with no backing layer in the viewer.
+    mask = _make_spatial_mask(source_layer)
+    source_layer.metadata["mask"] = mask
+    source_layer.metadata["mask_invert"] = False
+
+    before_layers = set(viewer.layers)
+    copied = plotter._copy_mask_from_layer(source_layer, target_layer)
+    after_layers = set(viewer.layers)
+
+    assert copied is True
+    new_layers = after_layers - before_layers
+    assert len(new_layers) == 1
+    created = new_layers.pop()
+    assert created.name == "Restored Mask: TARGET" or created.name.startswith(
+        "Restored Mask:"
+    )
+    assert plotter._mask_assignments[target_layer.name] == created.name
+    np.testing.assert_array_equal(target_layer.metadata["mask"], mask)
+
+    plotter.deleteLater()
+
+
+def test_find_mask_layer_for_skips_empty_shapes_layer(make_viewer_model):
+    """An empty Shapes layer is skipped when searching for a matching mask."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    # Empty Shapes layer: must be skipped (no data to rasterize).
+    viewer.add_shapes([], name="empty_shapes")
+
+    mask = _make_spatial_mask(layer)
+    result = plotter._find_mask_layer_for(mask, layer)
+
+    assert result is None
+
+    plotter.deleteLater()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -2863,7 +2863,12 @@ class PlotterWidget(QWidget):
         finally:
             self._updating_settings = False
 
-    def _show_import_dialog(self, default_checked=None, source_settings=None):
+    def _show_import_dialog(
+        self,
+        default_checked=None,
+        source_settings=None,
+        mask_available=False,
+    ):
         """Show a dialog to select which analyses to import/apply.
 
         Parameters
@@ -2872,6 +2877,10 @@ class PlotterWidget(QWidget):
             List of tab keys that should be checked by default
         source_settings : dict, optional
             Settings dictionary from source layer/file to determine which tabs to show
+        mask_available : bool, optional
+            If True, show a "Masking" toggle so the user can choose whether to
+            copy the source's mask (the assigned mask layer) onto the target
+            layers. When checked, ``"masking"`` is included in the returned list.
         """
         dialog = QDialog(self)
         dialog.setWindowTitle("Select Analyses to Import")
@@ -2945,6 +2954,33 @@ class PlotterWidget(QWidget):
                 layout.addWidget(cb)
                 checkboxes[attr] = cb
 
+        # Masking toggle: lets the user copy the source's assigned mask layer
+        # onto the target layers. Only offered when the source actually has a
+        # mask (e.g. layer-to-layer import); masks are not stored in OME-TIFFs.
+        masking_cb = None
+        if mask_available:
+            line = QFrame()
+            line.setFrameShape(QFrame.HLine)
+            line.setFrameShadow(QFrame.Sunken)
+            layout.addWidget(line)
+
+            masking_cb = QToggleSwitch("Masking")
+            masking_cb.onColor = QColor("#27ae60")  # Nice Green
+            masking_cb.setToolTip(
+                "Copy the mask (assigned mask layer) from the source onto the "
+                "selected layers."
+            )
+            masking_cb.setChecked(
+                default_checked is None
+                or "masking"
+                in (
+                    default_checked
+                    if isinstance(default_checked, list)
+                    else []
+                )
+            )
+            layout.addWidget(masking_cb)
+
         button_box = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
@@ -2959,6 +2995,8 @@ class PlotterWidget(QWidget):
             ]
             if frequency_cb is not None and frequency_cb.isChecked():
                 selected.insert(0, "frequency")
+            if masking_cb is not None and masking_cb.isChecked():
+                selected.append("masking")
             return selected
         return []
 
@@ -3208,7 +3246,8 @@ class PlotterWidget(QWidget):
             source_settings = source_layer.metadata.get('settings', {}).copy()
 
             selected_tabs = self._show_import_dialog(
-                source_settings=source_settings
+                source_settings=source_settings,
+                mask_available='mask' in source_layer.metadata,
             )
             if selected_tabs:
                 self._copy_metadata_from_layer(
@@ -3258,8 +3297,11 @@ class PlotterWidget(QWidget):
                 source_layer.metadata.get('settings', {})
             )
 
+            copy_masking = "masking" in selected_tabs
             selected_analysis_tabs = [
-                tab for tab in selected_tabs if tab != "frequency"
+                tab
+                for tab in selected_tabs
+                if tab not in ("frequency", "masking")
             ]
 
             for target_layer in selected_layers:
@@ -3285,6 +3327,16 @@ class PlotterWidget(QWidget):
                 ):
                     freq_val = source_settings['frequency']
                     update_frequency_in_metadata(target_layer, freq_val)
+
+                if copy_masking:
+                    self._copy_mask_from_layer(source_layer, target_layer)
+
+            if copy_masking:
+                # Sync the mask combobox / invert / labels controls from the
+                # freshly-set assignments. Doing this before the settings
+                # restore below makes that restore's mask handling a no-op, so
+                # it can't re-apply the mask with a stale invert/label state.
+                self._update_mask_ui_mode()
 
             if "frequency" in selected_tabs and 'frequency' in source_settings:
                 self._broadcast_frequency_value_across_tabs(
@@ -5919,6 +5971,34 @@ class PlotterWidget(QWidget):
         else:
             return
 
+        self._apply_mask_array_to_phasor_data(
+            mask_data, image_layer, invert=invert, labels=labels
+        )
+
+    def _apply_mask_array_to_phasor_data(
+        self, mask_data, image_layer, invert=False, labels=None
+    ):
+        """Apply a mask *array* to phasor data, setting outside pixels to NaN.
+
+        Stores the mask (and its invert/labels selection) in the image layer's
+        metadata and masks ``image_layer.data`` together with the ``G``/``S``
+        phasor coordinates. This is the array-based core shared by
+        :meth:`_apply_mask_to_phasor_data` and by mask copying between layers.
+
+        Parameters
+        ----------
+        mask_data : numpy.ndarray
+            2-D label array matching ``image_layer.data`` (a pixel is inside
+            the mask when its value is non-zero / in ``labels``).
+        image_layer : napari.layers.Image
+            The image layer to store mask metadata on and mask.
+        invert : bool
+            If True, invert the mask so pixels inside the mask are excluded.
+        labels : list of int, optional
+            Labels whose pixels are considered valid. ``None`` means all
+            non-zero pixels are valid; an empty list means no masking.
+        """
+        mask_data = np.asarray(mask_data)
         image_layer.metadata['mask'] = mask_data.copy()
         image_layer.metadata['mask_invert'] = invert
         if labels is not None:
@@ -5926,7 +6006,7 @@ class PlotterWidget(QWidget):
         elif 'mask_labels' in image_layer.metadata:
             del image_layer.metadata['mask_labels']
 
-        if isinstance(mask_layer, Labels) and labels is not None:
+        if labels is not None:
             if len(labels) > 0:
                 if invert:
                     mask_invalid = np.isin(mask_data, labels)
@@ -5957,6 +6037,116 @@ class PlotterWidget(QWidget):
             image_layer.metadata['S'] = np.where(mask_invalid, np.nan, s_array)
 
         self._invalidate_features_cache()
+
+    def _copy_mask_from_layer(self, source_layer, target_layer):
+        """Copy the mask of ``source_layer`` onto ``target_layer`` and apply it.
+
+        Mirrors assigning the source's mask *layer* to the target: the mask
+        layer the source used is re-applied to the target (re-rasterizing it to
+        the target's own shape), and the invert / label selection is carried
+        over. Copying the mask layer rather than the source's rasterized array
+        is what lets a Shapes mask — or any mask shared by differently sized
+        images — be applied correctly to the target.
+
+        If the source has no mask, any mask on the target is removed so the
+        target ends up matching the (unmasked) source.
+
+        Returns
+        -------
+        bool
+            True if a mask was copied, False otherwise.
+        """
+        if 'mask' not in source_layer.metadata:
+            # Source is unmasked: clear any mask currently on the target.
+            self._restore_original_phasor_data(target_layer)
+            for key in ('mask', 'mask_invert', 'mask_labels'):
+                target_layer.metadata.pop(key, None)
+            self._mask_assignments.pop(target_layer.name, None)
+            self._mask_invert_assignments.pop(target_layer.name, None)
+            self._mask_label_assignments.pop(target_layer.name, None)
+            return False
+
+        source_mask = np.asarray(source_layer.metadata['mask'])
+        invert = bool(source_layer.metadata.get('mask_invert', False))
+        labels = source_layer.metadata.get('mask_labels', None)
+
+        # Identify the mask *layer* the source used (by matching its stored,
+        # source-shaped mask). Re-applying that layer re-rasterizes it to the
+        # target's shape, so Shapes masks and differently sized targets work.
+        mask_layer = self._find_mask_layer_for(source_mask, source_layer)
+
+        self._restore_original_phasor_data(target_layer)
+
+        if mask_layer is not None:
+            if isinstance(
+                mask_layer, Labels
+            ) and mask_layer.data.shape != tuple(target_layer.data.shape):
+                notifications.WarningNotification(
+                    f"Mask layer '{mask_layer.name}' "
+                    f"{tuple(mask_layer.data.shape)} does not match layer "
+                    f"'{target_layer.name}' {tuple(target_layer.data.shape)}; "
+                    "mask not copied to this layer."
+                )
+                return False
+            self._apply_mask_to_phasor_data(
+                mask_layer, target_layer, invert=invert, labels=labels
+            )
+            mask_layer_name = mask_layer.name
+        else:
+            # No matching mask layer in the viewer (e.g. it was deleted): fall
+            # back to the source's raster, which only fits a same-shaped target.
+            if source_mask.shape != tuple(target_layer.data.shape):
+                notifications.WarningNotification(
+                    f"Source mask {source_mask.shape} does not match layer "
+                    f"'{target_layer.name}' {tuple(target_layer.data.shape)} "
+                    "and its mask layer is unavailable; mask not copied."
+                )
+                return False
+            self._apply_mask_array_to_phasor_data(
+                source_mask, target_layer, invert=invert, labels=labels
+            )
+            mask_layer_name = self._create_mask_layer_from_array(
+                source_mask, target_layer
+            )
+
+        self._mask_assignments[target_layer.name] = mask_layer_name
+        self._mask_invert_assignments[target_layer.name] = invert
+        self._mask_label_assignments[target_layer.name] = labels
+        return True
+
+    def _find_mask_layer_for(self, mask_data, reference_layer):
+        """Return the viewer mask layer whose pixels equal ``mask_data``.
+
+        ``mask_data`` is the mask as stored on ``reference_layer`` (rasterized
+        at that layer's shape), so Shapes candidates are rasterized to the same
+        shape for comparison. Returns the matching ``Labels``/``Shapes`` layer,
+        or ``None`` if no layer matches.
+        """
+        mask_data = np.asarray(mask_data)
+        for mask_l in self.viewer.layers:
+            if not isinstance(mask_l, (Labels, Shapes)):
+                continue
+            if isinstance(mask_l, Shapes):
+                if len(mask_l.data) == 0:
+                    continue
+                existing = mask_l.to_labels(
+                    labels_shape=reference_layer.data.shape
+                )
+            else:
+                existing = mask_l.data
+            if np.array_equal(existing, mask_data):
+                return mask_l
+        return None
+
+    def _create_mask_layer_from_array(self, mask_data, reference_layer):
+        """Add a Labels layer from ``mask_data`` and return its name."""
+        name = f"Restored Mask: {reference_layer.name}"
+        self.viewer.add_labels(
+            np.asarray(mask_data).copy(),
+            name=name,
+            scale=reference_layer.scale,
+        )
+        return name
 
     def _set_mask_labels_visible(self, visible):
         """Set the visibility of the mask labels combobox and its container."""


### PR DESCRIPTION
## Description

This PR implements the functionality to copy masking configuration between layers within the `PlotterWidget`. It introduces a **Masking** option in the import dialog, allowing users to propagate mask metadata, selection parameters, and pixel exclusions from a source image layer across multiple target layers.

Closes #317 

### Key Enhancements:
* **Dynamic Mask Copying (`_copy_mask_from_layer`)**: Mirrors the masking properties (assigned layer, invert state, specific label selections) from a source layer onto selected target layers.
* **Shape-agnostic Mask Transfers**: Rather than blindly copying raw pixel grids, the system resolves the mask back to its original `Labels` or `Shapes` layer. For vector-based `Shapes` masks, this ensures they are correctly re-rasterized to fit the specific resolution and dimensions of each target layer.
* **Fallback Resolution (`_find_mask_layer_for`)**: If a mask layer cannot be explicitly resolved (e.g., if it was deleted), the implementation safely falls back to a same-shaped array copy or adds a newly restored `Labels` layer into the viewer hierarchy.
* **UI Integration**: Extended `_show_import_dialog` to feature a customized green `QToggleSwitch("Masking")` with full tooltips, visible whenever the source layer contains active mask metadata.
* **UI Synced States**: Updates control elements (`mask_layer_combobox`, labels, and inverted flag) natively before setting down parameters to prevent any stale UI state from overriding newly imported masks.

---

## Technical Changes

### Core Logic (`src/napari_phasors/plotter.py`)
* Refactored array-based masking out of `_apply_mask_to_phasor_data` into a reusable internal method `_apply_mask_array_to_phasor_data`.
* Added `_copy_mask_from_layer`, `_find_mask_layer_for`, and `_create_mask_layer_from_array` to handle layer lookup, shape validation, and structural replication.
* Modified metadata import routines to decouple frequency settings broadcast from mask assignment adjustments, ensuring clear dependency paths during multi-attribute imports.

### Test Coverage (`src/napari_phasors/_tests/test_plotter_masks.py`)
Comprehensive test coverage has been added covering core functionalities and handling edge-case regressions:
* `test_copy_mask_from_layer_copies_and_applies_mask`: Ensures mask arrays, invert states, active label arrays, and internal UI tracking indices propagate correctly.
* `test_copy_mask_from_unmasked_source_clears_target_mask`: Assures that importing from an unmasked source properly strips existing target masks and cleanly restores native `G` and `S` arrays.
* `test_copy_mask_from_layer_shapes_mask_different_image_sizes`: Confirms vector-based shapes are correctly adapted to mismatched canvas sizes.
* `test_copy_mask_from_layer_shape_mismatch_skips`: Verifies graceful failure and notifications when array shapes conflict without a valid source layer.
* `test_copy_metadata_from_layer_with_masking_tab`: Confirms high-level interaction integration with multi-tab dialog prompts.
* `test_copy_metadata_from_layer_switches_selected_mask`: Validates that tracking values change over instantly, neutralizing potential collisions with outdated local preferences.