### PR TITLE
Enhance layer visibility management and add phasor intensity detection

### DIFF
--- a/src/napari_phasors/_tests/test_plotter_features.py
+++ b/src/napari_phasors/_tests/test_plotter_features.py
@@ -772,6 +772,161 @@ def test_update_grid_view_single_layer_makes_invisible_visible(
     plotter.deleteLater()
 
 
+def test_is_phasor_intensity_layer(make_viewer_model):
+    """_is_phasor_intensity_layer detects intensity layers with phasor data."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    intensity = create_image_layer_with_phasors()
+    intensity.name = "imgA"
+    viewer.add_layer(intensity)
+
+    # Plain image layer without phasor metadata.
+    plain = viewer.add_image(np.zeros((5, 5)), name="plain")
+
+    assert plotter._is_phasor_intensity_layer(intensity) is True
+    assert plotter._is_phasor_intensity_layer(plain) is False
+
+    plotter.deleteLater()
+
+
+def test_update_layer_visibility_shows_selected_and_associated(
+    make_viewer_model,
+):
+    """Selected intensity layer and its analysis layers are made visible;
+    non-selected layers and their analysis layers are hidden."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    a = create_image_layer_with_phasors()
+    a.name = "imgA"
+    viewer.add_layer(a)
+    b = create_image_layer_with_phasors()
+    b.name = "imgB"
+    viewer.add_layer(b)
+
+    # Analysis layers derived from each intensity layer.
+    comp_a = viewer.add_image(
+        np.zeros((5, 5)), name="Component 1 fractions: imgA"
+    )
+    fret_b = viewer.add_image(np.zeros((5, 5)), name="FRET efficiency: imgB")
+
+    # Start from a mixed visibility state to exercise both directions.
+    a.visible = False
+    b.visible = True
+    comp_a.visible = False
+    fret_b.visible = True
+
+    plotter._update_layer_visibility_for_selection({"imgA"})
+
+    assert a.visible is True
+    assert comp_a.visible is True
+    assert b.visible is False
+    assert fret_b.visible is False
+
+    plotter.deleteLater()
+
+
+def test_update_layer_visibility_leaves_unrelated_layers_untouched(
+    make_viewer_model,
+):
+    """Layers not derived from any phasor layer keep their visibility."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    a = create_image_layer_with_phasors()
+    a.name = "imgA"
+    viewer.add_layer(a)
+
+    unrelated_visible = viewer.add_image(np.zeros((5, 5)), name="reference")
+    unrelated_visible.visible = True
+    unrelated_hidden = viewer.add_image(np.zeros((5, 5)), name="scratch")
+    unrelated_hidden.visible = False
+
+    plotter._update_layer_visibility_for_selection({"imgA"})
+
+    assert unrelated_visible.visible is True
+    assert unrelated_hidden.visible is False
+
+    plotter.deleteLater()
+
+
+def test_update_layer_visibility_longest_suffix_wins(make_viewer_model):
+    """When one intensity name is a suffix of another, the most specific
+    (longest) intensity name claims the analysis layer."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    short = create_image_layer_with_phasors()
+    short.name = "img"
+    viewer.add_layer(short)
+    long = create_image_layer_with_phasors()
+    long.name = "other img"
+    viewer.add_layer(long)
+
+    # Name ends with ": other img" which contains ": img" as well; the
+    # longer intensity name must win so this is associated with "other img".
+    analysis = viewer.add_image(
+        np.zeros((5, 5)), name="Component 1 fractions: other img"
+    )
+    analysis.visible = True
+
+    # Select only the short layer; the analysis layer belongs to "other img"
+    # and must therefore be hidden.
+    plotter._update_layer_visibility_for_selection({"img"})
+
+    assert short.visible is True
+    assert long.visible is False
+    assert analysis.visible is False
+
+    # Now select the long layer; the analysis layer must become visible.
+    plotter._update_layer_visibility_for_selection({"other img"})
+
+    assert analysis.visible is True
+
+    plotter.deleteLater()
+
+
+def test_update_grid_view_multi_layer_hides_associated_layers(
+    make_viewer_model,
+):
+    """Multi-layer selection enables grid mode and syncs analysis layers."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    a = create_image_layer_with_phasors()
+    a.name = "imgA"
+    viewer.add_layer(a)
+    b = create_image_layer_with_phasors()
+    b.name = "imgB"
+    viewer.add_layer(b)
+    c = create_image_layer_with_phasors()
+    c.name = "imgC"
+    viewer.add_layer(c)
+
+    comp_a = viewer.add_image(
+        np.zeros((5, 5)), name="Component 1 fractions: imgA"
+    )
+    comp_c = viewer.add_image(
+        np.zeros((5, 5)), name="Component 1 fractions: imgC"
+    )
+    comp_c.visible = True
+
+    viewer.grid.enabled = False
+
+    # Select imgA and imgB (not imgC).
+    plotter._update_grid_view([a, b])
+
+    assert viewer.grid.enabled is True
+    assert a.visible is True
+    assert b.visible is True
+    assert comp_a.visible is True
+    assert c.visible is False
+    assert comp_c.visible is False
+
+    plotter.deleteLater()
+
+
 def test_get_common_harmonics_empty_layers_returns_none(make_viewer_model):
     viewer = make_viewer_model()
     plotter = PlotterWidget(viewer)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -5857,16 +5857,13 @@ class PlotterWidget(QWidget):
             self._preserve_plot_type_on_restore = False
 
     def _update_grid_view(self, selected_layers):
-        """Update napari grid view based on selected layers.
+        """Update napari grid view and layer visibility for the selection.
 
-        When multiple layers are selected, enables grid mode and makes
-        selected layers visible. When only one layer is selected,
-        disables grid mode.
-
-        Skips no-op writes to ``layer.visible`` so napari doesn't emit
-        redundant redraw events on every selection change. With many
-        layers (10+) the no-op skip alone removes the dominant per-layer
-        cost in the selection-change path.
+        When multiple layers are selected, enables grid mode; otherwise
+        disables it. In both cases the napari viewer visibility is synced
+        to the selection via :meth:`_update_layer_visibility_for_selection`
+        so that only the selected intensity layers and their associated
+        analysis layers are shown.
 
         Parameters
         ----------
@@ -5878,24 +5875,73 @@ class PlotterWidget(QWidget):
         if len(selected_layers) > 1:
             if not self.viewer.grid.enabled:
                 self.viewer.grid.enabled = True
-
-            for layer in self.viewer.layers:
-                if (
-                    isinstance(layer, Image)
-                    and "G" in layer.metadata
-                    and "S" in layer.metadata
-                    and "G_original" in layer.metadata
-                    and "S_original" in layer.metadata
-                ):
-                    desired_visible = layer.name in selected_names
-                    if layer.visible != desired_visible:
-                        layer.visible = desired_visible
         else:
             if self.viewer.grid.enabled:
                 self.viewer.grid.enabled = False
 
-            if selected_layers and not selected_layers[0].visible:
-                selected_layers[0].visible = True
+        self._update_layer_visibility_for_selection(selected_names)
+
+    def _is_phasor_intensity_layer(self, layer):
+        """Return True if ``layer`` is an intensity layer with phasor data."""
+        return (
+            isinstance(layer, Image)
+            and "G" in layer.metadata
+            and "S" in layer.metadata
+            and "G_original" in layer.metadata
+            and "S_original" in layer.metadata
+        )
+
+    def _update_layer_visibility_for_selection(self, selected_names):
+        """Sync napari layer visibility to the phasor plot selection.
+
+        Shows the selected intensity layers and every analysis layer
+        derived from them (components, lifetime, FRET, selections, masks,
+        etc.), and hides the non-selected intensity layers together with
+        their derived analysis layers.
+
+        Association is determined by napari-phasors' layer naming
+        convention: analysis layers are named ``"<descriptor>: <intensity
+        layer name>"``. Layers that are not associated with any phasor
+        intensity layer (e.g. unrelated reference layers) are left
+        untouched. Redundant writes to ``layer.visible`` are skipped so
+        napari does not emit unnecessary redraw events.
+
+        Parameters
+        ----------
+        selected_names : set of str
+            Names of the currently selected intensity layers.
+        """
+        # Intensity layer names sorted longest-first so the most specific
+        # suffix wins when one layer name is a suffix of another.
+        intensity_names = sorted(
+            (
+                layer.name
+                for layer in self.viewer.layers
+                if self._is_phasor_intensity_layer(layer)
+            ),
+            key=len,
+            reverse=True,
+        )
+        intensity_name_set = set(intensity_names)
+
+        def associated_intensity_name(layer_name):
+            """Return the intensity layer this layer derives from, or None."""
+            for intensity_name in intensity_names:
+                if layer_name.endswith(f": {intensity_name}"):
+                    return intensity_name
+            return None
+
+        for layer in self.viewer.layers:
+            if layer.name in intensity_name_set:
+                desired_visible = layer.name in selected_names
+            else:
+                associated = associated_intensity_name(layer.name)
+                if associated is None:
+                    # Unrelated layer; leave its visibility untouched.
+                    continue
+                desired_visible = associated in selected_names
+            if layer.visible != desired_visible:
+                layer.visible = desired_visible
 
     def _get_common_harmonics(self, layers):
         """Get the intersection of harmonics available in all layers.


### PR DESCRIPTION
## Description

This PR refactors and enhances layer visibility management within the `PlotterWidget`. It introduces robust layer dependency parsing so that selecting or deselecting a phasor intensity layer automatically toggles the visibility of its derived analysis layers (e.g., components, lifetime, FRET, selections, masks). 

Additionally, it extracts a helper method to explicitly check for valid phasor intensity layers based on metadata signatures, which fixes edge cases where visibility states would get out of sync or entirely break for derived analysis layers.

Closes #259 

### Key Changes

* **Extracted `_is_phasor_intensity_layer`**: Modularized the metadata validation logic (`"G"`, `"S"`, `"G_original"`, `"S_original"`) into a distinct helper method.
* **Introduced `_update_layer_visibility_for_selection`**: 
    * Walks through viewer layers to toggle visibility based on current selection states.
    * Determines parent-child relationships using the `"<descriptor>: <intensity layer name>"` naming convention.
    * Processes intensity layer names by length (`reverse=True`) to handle edge cases where one intensity layer's name is a suffix of another (the longest/most specific match wins).
    * Preserves the visibility settings of unrelated reference or scratch layers entirely.
* **Refactored `_update_grid_view`**: Cleaned up the entry point logic to delegate visibility synchronization directly to the new `_update_layer_visibility_for_selection` system while keeping the multi-layer grid mode toggles intact.

---

## Related Testing

Extensive unit tests have been added in `src/napari_phasors/_tests/test_plotter_features.py` to cover all new visibility rules and edge cases:

* [x] `test_is_phasor_intensity_layer`: Validates accurate metadata detection.
* [x] `test_update_layer_visibility_shows_selected_and_associated`: Ensures selecting a layer shows both it and its analysis children while hiding unselected siblings.
* [x] `test_update_layer_visibility_leaves_unrelated_layers_untouched`: Confirms completely unrelated layers maintain their visibility state.
* [x] `test_update_layer_visibility_longest_suffix_wins`: Checks name collision logic where one layer name is a sub-string/suffix of another.
* [x] `test_update_grid_view_multi_layer_hides_associated_layers`: Verifies visibility behavior matches expectations under grid mode selections.
