### PR TITLE
Fix segfault issues by managing widget connections and timers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ testing = [
     "pytest-cov",  # https://pytest-cov.readthedocs.io/en/latest/
     "pytest-qt",  # https://pytest-qt.readthedocs.io/en/latest/
     "pytest-xdist",  # https://pytest-xdist.readthedocs.io/ (parallel test runs)
+    "pytest-timeout",  # https://pypi.org/project/pytest-timeout/ (kills hung Qt workers)
     "napari",
     "qtpy",
     "scikit-image",
@@ -76,7 +77,19 @@ testing = [
 # ``--dist loadfile`` keeps every test from the same file on a single worker,
 # which avoids PySide6 teardown segfaults caused by interleaving tests from
 # different modules on one worker. Override with ``-n0`` for serial debugging.
-addopts = "-n auto --dist loadfile"
+#
+# ``--max-worker-restart=0`` makes a PySide6 worker segfault fail the run
+# cleanly (naming the crashed worker) instead of xdist's ``loadscope``
+# scheduler hitting its ``KeyError`` while spawning a replacement and hanging
+# the controller until GitHub's 6-hour cap — the "runs forever at ~95%" symptom.
+#
+# ``--timeout`` is a safety net for the recurring PySide6 + xdist worker hangs
+# (a worker deadlocks inside a C-level Qt event loop and never returns to
+# Python). ``--timeout-method=thread`` runs the watchdog in a separate thread so
+# it can kill the worker even when the main thread is blocked in C — the default
+# ``signal`` method cannot, since its handler only runs at a Python bytecode
+# boundary. On expiry it dumps every thread's stack and terminates the worker.
+addopts = "-n auto --dist loadfile --max-worker-restart=0 --timeout=1200 --timeout-method=thread"
 # Silence benign, unavoidable third-party teardown/rendering warnings so the
 # test output stays readable. Genuine deprecations in our own code are fixed
 # rather than filtered. Each entry below is library noise we cannot act on:

--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -15,6 +15,7 @@ interactive analysis tabs.
 """
 
 import ast
+import contextlib
 import csv
 import os
 import shutil
@@ -1173,12 +1174,13 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
 
         self._build_run_footer(layout)
 
-        self.viewer.layers.events.inserted.connect(
-            lambda e: self._populate_layer_comboboxes()
-        )
-        self.viewer.layers.events.removed.connect(
-            lambda e: self._populate_layer_comboboxes()
-        )
+        # Connect a bound method (not a lambda) so ``closeEvent`` can
+        # disconnect it. The napari viewer outlives this top-level widget; a
+        # lingering connection to a destroyed widget fires during teardown and
+        # segfaults under PySide6 (where PyQt would raise a catchable
+        # RuntimeError). A lambda cannot be disconnected by reference.
+        self.viewer.layers.events.inserted.connect(self._on_layers_changed)
+        self.viewer.layers.events.removed.connect(self._on_layers_changed)
         self._connect_run_enabled_signals()
         self._populate_layer_comboboxes()
         self._update_run_enabled()
@@ -3949,6 +3951,30 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
                 for key in ["G", "S", "G_original", "S_original"]
             )
         ]
+
+    def _on_layers_changed(self, event=None):
+        """Refresh layer comboboxes when the viewer's layer list changes."""
+        self._populate_layer_comboboxes()
+
+    def closeEvent(self, event):
+        """Disconnect viewer events so teardown can't fire into a freed widget.
+
+        The napari viewer outlives this (top-level) widget, so its
+        ``layers.events`` connections must be dropped here. Without this, the
+        emitter keeps a reference to a bound method of a destroyed widget and
+        firing it during teardown segfaults under PySide6 — the same class of
+        crash that leaks BatchAnalysisWidget instances across a ``loadfile``
+        worker until it dies near the end of ``test_batch_analysis.py``.
+        """
+        with contextlib.suppress(TypeError, ValueError, AttributeError):
+            self.viewer.layers.events.inserted.disconnect(
+                self._on_layers_changed
+            )
+        with contextlib.suppress(TypeError, ValueError, AttributeError):
+            self.viewer.layers.events.removed.disconnect(
+                self._on_layers_changed
+            )
+        event.accept()
 
     def _populate_layer_comboboxes(self):
         names = self._phasor_layer_names()

--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -85,29 +85,25 @@ def _cleanup_widgets_after_test(request):
     import matplotlib.pyplot as plt
     from qtpy.QtWidgets import QApplication
 
-    from napari_phasors._widget import (
-        AdvancedOptionsWidget,
-        PhasorTransform,
-        WriterWidget,
-    )
     from napari_phasors.plotter import PlotterWidget
 
     widgets = []
     with contextlib.suppress(Exception):
         widgets = QApplication.allWidgets()
 
-    phasor_widgets = []
-    for w in widgets:
-        if isinstance(
-            w,
-            (
-                PhasorTransform,
-                WriterWidget,
-                AdvancedOptionsWidget,
-                PlotterWidget,
-            ),
-        ):
-            phasor_widgets.append(w)
+    # Collect every widget defined by this plugin, not a hand-maintained list of
+    # types. Heavy widgets instantiated many times in a single test file and
+    # never explicitly closed — notably BatchAnalysisWidget (~140 instances in
+    # test_batch_analysis.py) and the standalone analysis tabs — otherwise
+    # accumulate on one ``loadfile`` xdist worker and segfault during PySide6
+    # teardown near the end of the file. Closing them here also runs each
+    # widget's ``closeEvent``, which disconnects its ``viewer.layers.events``
+    # handlers so the (longer-lived) viewer can't fire into a freed widget.
+    phasor_widgets = [
+        w
+        for w in widgets
+        if type(w).__module__.split(".")[0] == "napari_phasors"
+    ]
 
     # 1. Break parent relationships to avoid double-free/deletion issues in PySide6
     for w in phasor_widgets:
@@ -133,6 +129,7 @@ def _cleanup_widgets_after_test(request):
                 '_dock_resize_timer',
                 '_layer_selection_timer',
                 '_bins_timer',
+                '_resize_canvas_timer',
             ):
                 with contextlib.suppress(AttributeError):
                     timer = getattr(w, attr, None)

--- a/src/napari_phasors/_tests/test_batch_analysis.py
+++ b/src/napari_phasors/_tests/test_batch_analysis.py
@@ -121,6 +121,33 @@ def test_format_combobox_populated(qtbot, make_viewer_model, tmp_path):
     assert widget.format_combobox.count() == 2
 
 
+def test_layer_events_refresh_reference_combo_via_bound_method(
+    qtbot, make_viewer_model
+):
+    """``viewer.layers.events`` are connected to a bound method (not a
+    lambda) so ``closeEvent`` can disconnect them; this exercises that the
+    connection actually refreshes the UI on insert/remove after
+    construction (not just the initial population call in ``__init__``).
+    """
+    viewer = make_viewer_model()
+    widget = BatchAnalysisWidget(viewer)
+    qtbot.addWidget(widget)
+
+    assert widget.calib_reference_combo.count() == 0
+
+    layer = _make_phasor_layer(name="new_layer")
+    viewer.add_layer(layer)
+
+    labels = [
+        widget.calib_reference_combo.itemText(i)
+        for i in range(widget.calib_reference_combo.count())
+    ]
+    assert layer.name in labels
+
+    viewer.layers.remove(layer)
+    assert widget.calib_reference_combo.count() == 0
+
+
 def test_get_reader_options_with_dynamic_kwargs(qtbot, make_viewer_model):
     widget = BatchAnalysisWidget(make_viewer_model())
     qtbot.addWidget(widget)

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from biaplotter.plotter import CanvasWidget
 from napari.layers import Image
+from qtpy.QtCore import QEvent
 from qtpy.QtWidgets import (
     QPushButton,
     QSpinBox,
@@ -275,6 +276,33 @@ def test_phasor_plotter_initialization_values(make_viewer_model):
     assert hasattr(plotter, 'import_from_file_button')
     assert isinstance(plotter.import_from_file_button, QPushButton)
     assert plotter.import_from_file_button.text() == "OME-TIFF File"
+
+
+def test_canvas_container_resize_starts_debounce_timer(make_viewer_model):
+    """Resize/Show events on the watched containers should (re)start the
+    debounced resize timer rather than firing the resize immediately.
+
+    ``_resize_canvas_timer`` is parented to the widget precisely so it cannot
+    outlive it (see ``PopoutWindowMixin``/PySide6 teardown segfault notes);
+    this exercises the timer actually getting started from ``eventFilter``.
+    """
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    assert not plotter._resize_canvas_timer.isActive()
+
+    handled = plotter.eventFilter(
+        plotter.canvas_container, QEvent(QEvent.Resize)
+    )
+
+    assert plotter._resize_canvas_timer.isActive()
+    # eventFilter should not consume the event for the container itself.
+    assert handled is False
+
+    # An event on an unrelated object must not start the timer.
+    plotter._resize_canvas_timer.stop()
+    plotter.eventFilter(plotter, QEvent(QEvent.Resize))
+    assert not plotter._resize_canvas_timer.isActive()
 
     # Tab widget tests
     assert hasattr(plotter, 'tab_widget')

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -305,7 +305,14 @@ class PopoutWindowMixin:
         if not getattr(self, "_floated", False):
             self._floated = True
             # Defer so napari finishes wiring up the dock before we remove it.
-            QTimer.singleShot(0, self._popout_to_window)
+            # Parent the timer to self (single-shot) so Qt cancels it when the
+            # widget is destroyed; a bare ``QTimer.singleShot(0, self.method)``
+            # is orphaned and can fire into a freed C++ object during teardown
+            # (a PySide6 segfault).
+            self._popout_timer = QTimer(self)
+            self._popout_timer.setSingleShot(True)
+            self._popout_timer.timeout.connect(self._popout_to_window)
+            self._popout_timer.start(0)
 
     def _popout_to_window(self):
         """Detach from the napari dock and become a separate top-level window."""

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1936,6 +1936,18 @@ class PlotterWidget(QWidget):
         self._bins_timer.setInterval(500)  # 500ms delay
         self._bins_timer.timeout.connect(self._process_bins_change)
 
+        # Debounce canvas resizes triggered from eventFilter. Parented to self
+        # (single-shot) so Qt destroys it with the widget: a bare
+        # ``QTimer.singleShot(0, self._resize_canvas_to_available_space)`` would
+        # be orphaned and could still fire after the widget is deleted during
+        # teardown, calling into a freed C++ object — a PySide6 segfault.
+        self._resize_canvas_timer = QTimer(self)
+        self._resize_canvas_timer.setSingleShot(True)
+        self._resize_canvas_timer.setInterval(0)
+        self._resize_canvas_timer.timeout.connect(
+            self._resize_canvas_to_available_space
+        )
+
         # Create Settings tab
         self.settings_tab = QWidget()
         self.settings_tab.setLayout(QVBoxLayout())
@@ -2378,7 +2390,7 @@ class PlotterWidget(QWidget):
             getattr(self, 'controls_container', None),
         }
         if obj in watched and event.type() in {QEvent.Resize, QEvent.Show}:
-            QTimer.singleShot(0, self._resize_canvas_to_available_space)
+            self._resize_canvas_timer.start()
         return super().eventFilter(obj, event)
 
     def resizeEvent(self, event):
@@ -8230,6 +8242,8 @@ class PlotterWidget(QWidget):
             self._layer_selection_timer.stop()
         with contextlib.suppress(AttributeError):
             self._bins_timer.stop()
+        with contextlib.suppress(AttributeError):
+            self._resize_canvas_timer.stop()
 
         # Disconnect timer callbacks to avoid queued invocations during teardown.
         with contextlib.suppress(TypeError, ValueError, AttributeError):

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ extras =
 setenv =
     pyqt6: QT_API = pyqt6
     pyside6: QT_API = pyside6
+    # Dump a C-level traceback if a worker segfaults (e.g. PySide6 teardown).
+    PYTHONFAULTHANDLER = 1
 deps =
     pyqt6: pyqt6
     pyside6: pyside6


### PR DESCRIPTION
## Description

This PR addresses and fixes several persistent segmentation fault (segfault) and deadlock issues encountered during test suite teardown on CI runners utilizing PySide6. The crashes primarily stem from lingering C++ references, unmanaged event listener connections to long-lived parent objects, and orphaned single-shot timers firing after a widget has been destroyed.

Additionally, this PR hardened the test execution pipeline by utilizing `pytest-timeout` and configuring `pytest-xdist` to prevent silent test hangs and infinitely running CI jobs.

## Changes

### 1. Robust PySide6 Lifecycle & Event Disconnection
* **`BatchAnalysisWidget`**: Refactored `viewer.layers.events` handling. Replaced anonymous `lambda` connections with a explicit bound method (`self._on_layers_changed`). Added a `closeEvent` hook to properly disconnect these listeners before destruction, preventing the long-lived `viewer` from firing events into a freed widget shell.
* **Orphaned `QTimer.singleShot` Mitigations**: Refactored loose single-shot timers in `PopoutWindowMixin` (`_utils.py`) and `PlotterWidget` (`plotter.py`). Timers are now properly parented to their respective widgets (`QTimer(self)`), ensuring Qt automatically cancels pending callbacks upon widget destruction rather than calling into freed C++ objects.
* **Test Fixture Cleanup (`conftest.py`)**: Updated the global `_cleanup_widgets_after_test` routine to dynamically find and close all widgets under the `napari_phasors` module footprint (e.g., catching heavily-instantiated components like `BatchAnalysisWidget`) instead of maintaining a hard-coded class whitelist. Added tracking and safety teardown for the newly added `_resize_canvas_timer`.

### 2. CI Pipeline Stabilization & Timeout Controls
* **`pyproject.toml` & `tox.ini`**:
    * Integrated `pytest-timeout` utilizing `thread` method watchdogs to force-dump stack traces and terminate workers if a C-level Qt event loop enters a deadlock.
    * Configured `--max-worker-restart=0` to force `pytest-xdist` to fail cleanly immediately upon a worker segfault, preventing worker-spawning death loops that hang the test runner.
    * Enabled `PYTHONFAULTHANDLER=1` under `tox` environments to provide detailed C-level trace logs in the event of an unexpected crash.

### 3. Unit Tests
* **`test_batch_analysis.py`**: Added explicit verification testing that bound method connections properly update the calibration combo box on layer modifications and clear cleanly.
* **`test_plotter.py`**: Added structural validation ensuring that `eventFilter` resize/show events safely trigger and debounce through the newly parented `_resize_canvas_timer`.