### PR TITLE
Add retry logic for transient network errors in data fetching

### DIFF
--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -21,6 +21,23 @@ except (AttributeError, ImportError, TypeError):
     pass
 
 
+# ``phasorpy.datasets.fetch`` downloads sample files (e.g. "simfcs.r64") from
+# GitHub/Zenodo on first use via Pooch, which by default makes a single
+# attempt per file. On CI this occasionally hits a transient
+# ``requests.exceptions.ReadTimeout`` against github.com, failing the test
+# even though a retry would succeed. Pooch retries connection errors
+# (including read timeouts) itself when a repository's ``retry_if_failed`` is
+# set, so opt every phasorpy dataset repository into a few retries with
+# backoff instead of failing on the first flake.
+try:
+    from phasorpy.datasets import REPOSITORIES as _PHASORPY_REPOSITORIES
+
+    for _repo in _PHASORPY_REPOSITORIES.values():
+        _repo.retry_if_failed = 3
+except (AttributeError, ImportError, TypeError):
+    pass
+
+
 # Harden superqt's SliderLabel against the same PySide6 + Python 3.14 shiboken
 # wrapper-corruption bug: under address reuse, `widget.style()` can return a
 # transient QWidgetItem instead of a QStyle, so `_get_size()` raises

--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -21,21 +21,29 @@ except (AttributeError, ImportError, TypeError):
     pass
 
 
-# ``phasorpy.datasets.fetch`` downloads sample files (e.g. "simfcs.r64") from
-# GitHub/Zenodo on first use via Pooch, which by default makes a single
-# attempt per file. On CI this occasionally hits a transient
-# ``requests.exceptions.ReadTimeout`` against github.com, failing the test
-# even though a retry would succeed. Pooch retries connection errors
-# (including read timeouts) itself when a repository's ``retry_if_failed`` is
-# set, so opt every phasorpy dataset repository into a few retries with
-# backoff instead of failing on the first flake.
-try:
-    from phasorpy.datasets import REPOSITORIES as _PHASORPY_REPOSITORIES
+def configure_phasorpy_retries():
+    """Opt every phasorpy dataset repository into a few download retries.
 
-    for _repo in _PHASORPY_REPOSITORIES.values():
-        _repo.retry_if_failed = 3
-except (AttributeError, ImportError, TypeError):
-    pass
+    ``phasorpy.datasets.fetch`` downloads sample files (e.g. "simfcs.r64")
+    from GitHub/Zenodo on first use via Pooch, which by default makes a
+    single attempt per file. On CI this occasionally hits a transient
+    ``requests.exceptions.ReadTimeout`` against github.com, failing the test
+    even though a retry would succeed. Pooch retries connection errors
+    (including read timeouts) itself when a repository's ``retry_if_failed``
+    is set, so opt every phasorpy dataset repository into a few retries with
+    backoff instead of failing on the first flake. Silently does nothing if
+    phasorpy's dataset registry is unavailable or has a different shape.
+    """
+    try:
+        from phasorpy.datasets import REPOSITORIES as _phasorpy_repositories
+
+        for repo in _phasorpy_repositories.values():
+            repo.retry_if_failed = 3
+    except (AttributeError, ImportError, TypeError):
+        pass
+
+
+configure_phasorpy_retries()
 
 
 # Harden superqt's SliderLabel against the same PySide6 + Python 3.14 shiboken

--- a/src/napari_phasors/_tests/test_conftest.py
+++ b/src/napari_phasors/_tests/test_conftest.py
@@ -1,0 +1,35 @@
+"""Tests for helpers defined directly in ``_tests/conftest.py``."""
+
+import sys
+from unittest.mock import patch
+
+from napari_phasors._tests.conftest import configure_phasorpy_retries
+
+
+def test_configure_phasorpy_retries_sets_retry_on_all_repositories():
+    """Every phasorpy dataset repository gets retries enabled."""
+    import phasorpy.datasets
+
+    for repo in phasorpy.datasets.REPOSITORIES.values():
+        repo.retry_if_failed = 0
+
+    configure_phasorpy_retries()
+
+    assert phasorpy.datasets.REPOSITORIES
+    for repo in phasorpy.datasets.REPOSITORIES.values():
+        assert repo.retry_if_failed == 3
+
+
+def test_configure_phasorpy_retries_swallows_import_error():
+    """A missing/incompatible phasorpy.datasets must not raise or fail setup."""
+    # Setting a module to None in sys.modules makes the next `import`/`from
+    # ... import` statement for it raise ImportError, simulating an
+    # environment where ``phasorpy.datasets`` is unavailable.
+    with patch.dict(sys.modules, {"phasorpy.datasets": None}):
+        configure_phasorpy_retries()  # must not raise
+
+
+def test_configure_phasorpy_retries_swallows_attribute_error():
+    """An unexpected REPOSITORIES shape (e.g. no ``.values()``) is ignored."""
+    with patch("phasorpy.datasets.REPOSITORIES", None):
+        configure_phasorpy_retries()  # must not raise

--- a/src/napari_phasors/_tests/test_data_utils.py
+++ b/src/napari_phasors/_tests/test_data_utils.py
@@ -4,9 +4,13 @@ import pooch
 from phasorpy.datasets import fetch
 
 # Create a pooch downloader for test data
+# ``retry_if_failed`` retries transient network errors (e.g. GitHub read
+# timeouts on CI runners) instead of letting a single flaky download fail
+# the test outright.
 test_data_downloader = pooch.create(
     path=pooch.os_cache("napari-phasors-test-data"),
     base_url="https://github.com/napari-phasors/napari-phasors-data/raw/main/test_files/",
+    retry_if_failed=3,
     registry={
         'test_file.ptu': (
             'sha256:'


### PR DESCRIPTION
## Description

This PR introduces retry logic for test data fetching to mitigate transient network errors (such as `requests.exceptions.ReadTimeout` from GitHub or Zenodo) that occasionally cause flaky test failures on CI runners.

By configuring Pooch's `retry_if_failed` attribute, we opt into a few retries with exponential backoff instead of allowing a single connection timeout to fail the entire test suite.

## Changes

* **`src/napari_phasors/_tests/conftest.py`**: Intercepts `phasorpy.datasets.REPOSITORIES` during test initialization and dynamically sets `retry_if_failed = 3` for all registered upstream repositories. This ensures that any `phasorpy.datasets.fetch` calls made during testing are resilient to network drops.
* **`src/napari_phasors/_tests/test_data_utils.py`**: Explicitly passes `retry_if_failed=3` to the local `test_data_downloader` Pooch instance used for plugin-specific test files.
