### PR TITLE
Add UI support and interoperability enhancements for FLIMari

### DIFF
--- a/src/napari_phasors/_flimari.py
+++ b/src/napari_phasors/_flimari.py
@@ -1,0 +1,256 @@
+"""Interoperability bridge between napari-phasors and FLIMari.
+
+`FLIMari <https://github.com/GuangchenW/FLIMari>`_ is a separate napari plugin
+for phasor-based FLIM analysis. It exposes a lightweight callback bridge,
+``flimari.core.bridge.import_from_napari_phasors(data_list)``, that accepts a
+list of plain dicts describing pre-computed phasor datasets and builds a
+``flimari...ExternalDataset`` from each. This module builds those dicts from
+napari-phasors image layers and hands them to a running FLIMari session, live,
+within the same napari process -- no files are written.
+
+Recovering total photon counts
+-------------------------------
+FLIMari filters and thresholds on *total photon counts*, whereas napari-phasors
+keeps only the *mean* intensity that ``phasorpy.phasor.phasor_from_signal``
+returns after discarding the raw signal. By definition that mean is
+
+.. math:: F_{DC} = \\frac{1}{K} \\sum_{k=0}^{K-1} F_k
+
+i.e. the sum of the signal along the histogram axis divided by the number of
+samples ``K``. The per-pixel total photon count is therefore recovered exactly
+as ``mean * K`` -- no need to re-read or re-transform the raw data files.
+
+``K`` is the length of the aggregate decay curve that napari-phasors already
+stores in ``metadata['summed_signal']`` (``np.sum`` of the signal over the
+spatial axes leaves one value per histogram bin). When it is unavailable (for
+example, a processed OME-TIFF from a third party with no summed signal),
+counts cannot be recovered and only the mean intensity is sent -- exactly the
+behaviour FLIMari falls back to today.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+import numpy as np
+
+#: Max harmonics FLIMari consumes (it requires harmonic ``[1, 2]``).
+_MAX_HARMONICS = 2
+
+FLIMARI_INSTALL_HINT = (
+    "Could not reach FLIMari. Make sure it is installed "
+    "(see https://github.com/GuangchenW/FLIMari)."
+)
+
+
+class FlimariNotAvailable(RuntimeError):
+    """Raised when the FLIMari bridge module cannot be imported."""
+
+
+def _import_bridge():
+    """Import and return FLIMari's ``core.bridge`` module.
+
+    Raises
+    ------
+    FlimariNotAvailable
+        If FLIMari is not installed / importable.
+    """
+    try:
+        from flimari.core import bridge
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - any import failure means "unavailable"
+        raise FlimariNotAvailable(FLIMARI_INSTALL_HINT) from exc
+    return bridge
+
+
+def _as_harmonic_stack(array: Any) -> np.ndarray:
+    """Return ``array`` with a leading harmonic axis (``_MAX_HARMONICS`` max).
+
+    A 2D ``(Y, X)`` array is promoted to ``(1, Y, X)``; arrays that already
+    carry a harmonic axis are returned with at most the first two harmonics,
+    matching FLIMari's ``[1, 2]`` requirement.
+    """
+    arr = np.asarray(array, dtype=float)
+    if arr.ndim == 2:
+        arr = arr[np.newaxis]
+    return arr[:_MAX_HARMONICS]
+
+
+def _histogram_bins(metadata: dict) -> int | None:
+    """Return ``K``, the number of histogram bins, or ``None`` if unknown.
+
+    ``K`` is read from the aggregate decay curve stored in
+    ``metadata['summed_signal']`` (or, for layers loaded from a processed file,
+    ``metadata['settings']['summed_signal']``). Its length along the last axis
+    is the number of histogram bins.
+    """
+    summed = metadata.get("summed_signal")
+    if summed is None:
+        summed = metadata.get("settings", {}).get("summed_signal")
+    if summed is None:
+        return None
+    arr = np.asarray(summed)
+    if arr.ndim == 0 or arr.size == 0:
+        return None
+    return int(arr.shape[-1])
+
+
+def _filter_value(settings: dict, key: str, default: int) -> int:
+    """Read a median-filter parameter from ``settings['filter']``."""
+    filter_settings = settings.get("filter")
+    if (
+        isinstance(filter_settings, dict)
+        and filter_settings.get(key) is not None
+    ):
+        return int(filter_settings[key])
+    return int(default)
+
+
+def build_flimari_dataset(layer: Any) -> dict | None:
+    """Build a FLIMari import dict from a napari-phasors image layer.
+
+    The returned dict follows the schema documented in
+    ``flimari.core.bridge`` and additionally carries a ``counts`` key holding
+    the recovered per-pixel total photon count (``mean * K``). FLIMari uses
+    ``counts`` when present and otherwise falls back to ``mean``.
+
+    Parameters
+    ----------
+    layer : napari.layers.Image
+        Layer carrying napari-phasors phasor metadata (``G``, ``S``,
+        ``G_original``, ``S_original``, ``original_mean``, ...).
+
+    Returns
+    -------
+    dict or None
+        The import dict, or ``None`` if ``layer`` has no phasor metadata.
+    """
+    metadata = getattr(layer, "metadata", None) or {}
+    required = ("G", "S", "G_original", "S_original")
+    if not all(
+        key in metadata and metadata[key] is not None for key in required
+    ):
+        return None
+
+    settings = metadata.get("settings", {}) or {}
+
+    g = _as_harmonic_stack(metadata["G"])
+    s = _as_harmonic_stack(metadata["S"])
+    g_original = _as_harmonic_stack(metadata["G_original"])
+    s_original = _as_harmonic_stack(metadata["S_original"])
+    n_harmonics = int(g.shape[0])
+
+    payload: dict[str, Any] = {
+        "name": str(getattr(layer, "name", "napari-phasors layer")),
+        "channel": _safe_int(settings.get("channel"), 0),
+        "g": g,
+        "s": s,
+        "g_original": g_original,
+        "s_original": s_original,
+        # napari-phasors bakes any calibration into both G and G_original,
+        # so identity coefficients keep FLIMari from applying it a second time.
+        "calibration_phase": [0.0] * n_harmonics,
+        "calibration_modulation": [1.0] * n_harmonics,
+        "filter_size": _filter_value(settings, "size", 3),
+        "filter_repeat": _filter_value(settings, "repeat", 0),
+    }
+
+    # Only send a frequency when we actually know it; otherwise let FLIMari
+    # apply its own default rather than forcing a possibly-wrong value.
+    frequency = settings.get("frequency")
+    if frequency is not None:
+        with suppress(TypeError, ValueError):
+            payload["frequency"] = float(frequency)
+
+    mean = metadata.get("original_mean")
+    mean_arr = None if mean is None else np.asarray(mean, dtype=float)
+    if mean_arr is not None and mean_arr.size:
+        payload["mean"] = mean_arr
+
+    k = _histogram_bins(metadata)
+    threshold = settings.get("threshold")
+    threshold_upper = settings.get("threshold_upper")
+
+    if k is not None and mean_arr is not None and mean_arr.size:
+        # Recover true per-pixel photon counts: mean is sum-over-histogram / K.
+        payload["counts"] = np.rint(mean_arr * k)
+        # napari-phasors thresholds are expressed in mean-intensity units;
+        # scale them to photon-count units so they match `counts`.
+        payload["min_count"] = int(round(_safe_float(threshold, 0.0) * k))
+        payload["max_count"] = (
+            int(round(_safe_float(threshold_upper, 0.0) * k))
+            if threshold_upper is not None
+            else None
+        )
+    else:
+        # No histogram-bin count available: fall back to mean-based thresholds
+        # (FLIMari will use `mean` as its counts proxy, as it does today).
+        payload["min_count"] = int(round(_safe_float(threshold, 0.0)))
+        payload["max_count"] = (
+            int(round(_safe_float(threshold_upper, 0.0)))
+            if threshold_upper is not None
+            else None
+        )
+
+    return payload
+
+
+def send_layers_to_flimari(layers: list[Any]) -> tuple[list[dict], list[str]]:
+    """Send phasor layers to a running FLIMari session via its bridge.
+
+    Parameters
+    ----------
+    layers : list of napari.layers.Image
+        Candidate layers to export. Layers without phasor metadata are skipped.
+
+    Returns
+    -------
+    (sent, skipped) : tuple of (list of dict, list of str)
+        The payloads handed to FLIMari and the names of skipped layers.
+
+    Raises
+    ------
+    FlimariNotAvailable
+        If FLIMari is not installed.
+    ValueError
+        If none of the layers carry phasor data.
+    RuntimeError
+        Propagated from FLIMari's bridge when no FLIMari dock is open to
+        receive the data.
+    """
+    bridge = _import_bridge()
+
+    sent: list[dict] = []
+    skipped: list[str] = []
+    for layer in layers:
+        payload = build_flimari_dataset(layer)
+        if payload is None:
+            skipped.append(str(getattr(layer, "name", "?")))
+        else:
+            sent.append(payload)
+
+    if not sent:
+        raise ValueError(
+            "No selected layer contains phasor data to send to FLIMari."
+        )
+
+    bridge.import_from_napari_phasors(sent)
+    return sent, skipped
+
+
+def _safe_int(value: Any, default: int) -> int:
+    """Best-effort int conversion with a fallback."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(value: Any, default: float) -> float:
+    """Best-effort float conversion with a fallback."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/napari_phasors/_flimari.py
+++ b/src/napari_phasors/_flimari.py
@@ -43,6 +43,11 @@ FLIMARI_INSTALL_HINT = (
     "(see https://github.com/GuangchenW/FLIMari)."
 )
 
+#: napari plugin name and dock widget display name, as declared in
+#: FLIMari's ``napari.yaml`` manifest. Used to open/dock it automatically.
+_FLIMARI_PLUGIN_NAME = "flimari"
+_FLIMARI_WIDGET_NAME = "Phasor Analysis"
+
 
 class FlimariNotAvailable(RuntimeError):
     """Raised when the FLIMari bridge module cannot be imported."""
@@ -63,6 +68,32 @@ def _import_bridge():
     ) as exc:  # noqa: BLE001 - any import failure means "unavailable"
         raise FlimariNotAvailable(FLIMARI_INSTALL_HINT) from exc
     return bridge
+
+
+def _open_flimari_dock(viewer: Any) -> None:
+    """Open and dock FLIMari's main widget in the given napari viewer.
+
+    Constructing FLIMari's widget registers its import callback with the
+    bridge synchronously (``SampleManagerWidget.__init__`` calls
+    ``register_import_callback``), so once this call returns FLIMari is
+    ready to receive data -- no need to wait or poll.
+
+    Raises
+    ------
+    FlimariNotAvailable
+        If the dock widget could not be opened (for example, FLIMari is
+        installed as a library but not registered as a napari plugin).
+    """
+    try:
+        viewer.window.add_plugin_dock_widget(
+            plugin_name=_FLIMARI_PLUGIN_NAME,
+            widget_name=_FLIMARI_WIDGET_NAME,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise FlimariNotAvailable(
+            "Could not open the FLIMari dock widget automatically. "
+            "Please open it manually from Plugins > FLIMari."
+        ) from exc
 
 
 def _as_harmonic_stack(array: Any) -> np.ndarray:
@@ -108,6 +139,28 @@ def _filter_value(settings: dict, key: str, default: int) -> int:
     return int(default)
 
 
+#: Metadata keys a layer must carry to be exportable to FLIMari. Derived
+#: layers that hold analysis results rather than phasor coordinates -- e.g.
+#: component-analysis fraction images, which only carry
+#: ``fraction_data_original`` -- do not have these and are excluded.
+_REQUIRED_PHASOR_KEYS = ("G", "S", "G_original", "S_original")
+
+
+def has_phasor_data(layer: Any) -> bool:
+    """Return whether ``layer`` carries the phasor metadata FLIMari needs.
+
+    Used both to decide what to export and to drive the "Export Phasor
+    Layer to FLIMARI" button's enabled state: layers produced by other
+    analyses (component analysis, FRET, phasor mapping, ...) do not carry
+    raw phasor coordinates and must not be offered for export.
+    """
+    metadata = getattr(layer, "metadata", None) or {}
+    return all(
+        key in metadata and metadata[key] is not None
+        for key in _REQUIRED_PHASOR_KEYS
+    )
+
+
 def build_flimari_dataset(layer: Any) -> dict | None:
     """Build a FLIMari import dict from a napari-phasors image layer.
 
@@ -127,13 +180,10 @@ def build_flimari_dataset(layer: Any) -> dict | None:
     dict or None
         The import dict, or ``None`` if ``layer`` has no phasor metadata.
     """
-    metadata = getattr(layer, "metadata", None) or {}
-    required = ("G", "S", "G_original", "S_original")
-    if not all(
-        key in metadata and metadata[key] is not None for key in required
-    ):
+    if not has_phasor_data(layer):
         return None
 
+    metadata = layer.metadata
     settings = metadata.get("settings", {}) or {}
 
     g = _as_harmonic_stack(metadata["G"])
@@ -197,28 +247,40 @@ def build_flimari_dataset(layer: Any) -> dict | None:
     return payload
 
 
-def send_layers_to_flimari(layers: list[Any]) -> tuple[list[dict], list[str]]:
+def send_layers_to_flimari(
+    layers: list[Any], viewer: Any | None = None
+) -> tuple[list[dict], list[str], bool]:
     """Send phasor layers to a running FLIMari session via its bridge.
+
+    If FLIMari's dock widget is not open yet, its bridge raises a
+    ``RuntimeError``. Rather than surfacing that as an error, when a
+    ``viewer`` is provided this opens and docks FLIMari's widget (which
+    registers its import callback synchronously) and retries once.
 
     Parameters
     ----------
     layers : list of napari.layers.Image
         Candidate layers to export. Layers without phasor metadata are skipped.
+    viewer : napari.viewer.Viewer, optional
+        Viewer used to open FLIMari's dock widget if it is not open yet.
+        If not provided, a closed FLIMari dock surfaces as a ``RuntimeError``.
 
     Returns
     -------
-    (sent, skipped) : tuple of (list of dict, list of str)
-        The payloads handed to FLIMari and the names of skipped layers.
+    (sent, skipped, opened_dock) : tuple of (list of dict, list of str, bool)
+        The payloads handed to FLIMari, the names of skipped layers, and
+        whether FLIMari's dock widget had to be opened automatically.
 
     Raises
     ------
     FlimariNotAvailable
-        If FLIMari is not installed.
+        If FLIMari is not installed, or its dock could not be opened
+        automatically.
     ValueError
         If none of the layers carry phasor data.
     RuntimeError
-        Propagated from FLIMari's bridge when no FLIMari dock is open to
-        receive the data.
+        Propagated from FLIMari's bridge when no FLIMari dock is open and
+        no ``viewer`` was provided to open one automatically.
     """
     bridge = _import_bridge()
 
@@ -236,8 +298,17 @@ def send_layers_to_flimari(layers: list[Any]) -> tuple[list[dict], list[str]]:
             "No selected layer contains phasor data to send to FLIMari."
         )
 
-    bridge.import_from_napari_phasors(sent)
-    return sent, skipped
+    opened_dock = False
+    try:
+        bridge.import_from_napari_phasors(sent)
+    except RuntimeError:
+        if viewer is None:
+            raise
+        _open_flimari_dock(viewer)
+        opened_dock = True
+        bridge.import_from_napari_phasors(sent)
+
+    return sent, skipped, opened_dock
 
 
 def _safe_int(value: Any, default: int) -> int:

--- a/src/napari_phasors/_flimari.py
+++ b/src/napari_phasors/_flimari.py
@@ -23,13 +23,15 @@ as ``mean * K`` -- no need to re-read or re-transform the raw data files.
 ``K`` is the length of the aggregate decay curve that napari-phasors already
 stores in ``metadata['summed_signal']`` (``np.sum`` of the signal over the
 spatial axes leaves one value per histogram bin). When it is unavailable (for
-example, a processed OME-TIFF from a third party with no summed signal),
-counts cannot be recovered and only the mean intensity is sent -- exactly the
-behaviour FLIMari falls back to today.
+example, an R64/REF or third-party OME-TIFF whose raw signal was never
+stored), ``K`` can instead be recovered from the original raw file via
+:func:`histogram_bins_from_raw_file`. If neither is available, only the mean
+intensity is sent and FLIMari falls back to using it as a counts proxy.
 """
 
 from __future__ import annotations
 
+import os
 from contextlib import suppress
 from typing import Any
 
@@ -128,6 +130,99 @@ def _histogram_bins(metadata: dict) -> int | None:
     return int(arr.shape[-1])
 
 
+def get_layer_histogram_bins(layer: Any) -> int | None:
+    """Return the histogram-bin count ``K`` recorded for ``layer``, else None.
+
+    ``None`` means the layer carries no ``summed_signal`` (e.g. it was loaded
+    from an R64/REF or third-party OME-TIFF), so photon counts cannot be
+    recovered from metadata alone -- the original raw file is needed, see
+    :func:`histogram_bins_from_raw_file`.
+    """
+    metadata = getattr(layer, "metadata", None) or {}
+    return _histogram_bins(metadata)
+
+
+def _means_match(reference: np.ndarray, candidate: np.ndarray) -> bool:
+    """Return whether two mean-intensity images are the same up to rounding."""
+    if reference.shape != candidate.shape:
+        return False
+    return bool(
+        np.allclose(reference, candidate, rtol=1e-2, atol=1e-3, equal_nan=True)
+    )
+
+
+def histogram_bins_from_raw_file(
+    path: str, reference_mean: Any | None = None
+) -> int:
+    """Recover the histogram-bin count ``K`` from an original raw FLIM file.
+
+    Re-reads ``path`` with napari-phasors' raw reader and returns the number
+    of histogram/time bins -- all that is needed to recover total photon
+    counts as ``mean * K``. When ``reference_mean`` is provided, the file is
+    validated against it (matching image shape and intensity) so that
+    assigning the wrong file is caught rather than producing wrong counts.
+
+    Parameters
+    ----------
+    path : str
+        Path to the original raw FLIM file (``.ptu``, ``.fbd``, ``.sdt``, ...).
+    reference_mean : array-like, optional
+        The layer's mean-intensity image (``metadata['original_mean']``) used
+        to confirm the file corresponds to the layer.
+
+    Returns
+    -------
+    int
+        The number of histogram bins ``K``.
+
+    Raises
+    ------
+    ValueError
+        If the file cannot be read, contains no raw histogram data, or does
+        not match ``reference_mean``.
+    """
+    from ._reader import raw_file_reader
+
+    try:
+        layers = raw_file_reader(path)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(
+            f"could not read {os.path.basename(path)}: {exc}"
+        ) from exc
+
+    k: int | None = None
+    means: list[np.ndarray] = []
+    for entry in layers or []:
+        if not (isinstance(entry, (list, tuple)) and len(entry) > 1):
+            continue
+        attrs = entry[1] if isinstance(entry[1], dict) else {}
+        meta = attrs.get("metadata", {})
+        summed = meta.get("summed_signal")
+        if summed is not None:
+            arr = np.asarray(summed)
+            if arr.size:
+                # K is identical across channels of a raw file.
+                k = int(arr.shape[-1])
+        mean = meta.get("original_mean")
+        if mean is not None:
+            means.append(np.asarray(mean, dtype=float))
+
+    if k is None:
+        raise ValueError(
+            f"{os.path.basename(path)} does not contain raw histogram data."
+        )
+
+    if reference_mean is not None:
+        ref = np.asarray(reference_mean, dtype=float)
+        if not any(_means_match(ref, mean) for mean in means):
+            raise ValueError(
+                "the selected file does not match this layer "
+                "(different image shape or intensity)."
+            )
+
+    return k
+
+
 def _filter_value(settings: dict, key: str, default: int) -> int:
     """Read a median-filter parameter from ``settings['filter']``."""
     filter_settings = settings.get("filter")
@@ -161,7 +256,9 @@ def has_phasor_data(layer: Any) -> bool:
     )
 
 
-def build_flimari_dataset(layer: Any) -> dict | None:
+def build_flimari_dataset(
+    layer: Any, histogram_bins: int | None = None
+) -> dict | None:
     """Build a FLIMari import dict from a napari-phasors image layer.
 
     The returned dict follows the schema documented in
@@ -174,6 +271,11 @@ def build_flimari_dataset(layer: Any) -> dict | None:
     layer : napari.layers.Image
         Layer carrying napari-phasors phasor metadata (``G``, ``S``,
         ``G_original``, ``S_original``, ``original_mean``, ...).
+    histogram_bins : int, optional
+        Number of histogram bins ``K`` to use for recovering photon counts.
+        Overrides the value derived from the layer metadata; used when ``K``
+        was recovered from the original raw file for a layer whose metadata
+        lacks ``summed_signal`` (see :func:`histogram_bins_from_raw_file`).
 
     Returns
     -------
@@ -219,7 +321,11 @@ def build_flimari_dataset(layer: Any) -> dict | None:
     if mean_arr is not None and mean_arr.size:
         payload["mean"] = mean_arr
 
-    k = _histogram_bins(metadata)
+    k = (
+        histogram_bins
+        if histogram_bins is not None
+        else _histogram_bins(metadata)
+    )
     threshold = settings.get("threshold")
     threshold_upper = settings.get("threshold_upper")
 
@@ -248,7 +354,9 @@ def build_flimari_dataset(layer: Any) -> dict | None:
 
 
 def send_layers_to_flimari(
-    layers: list[Any], viewer: Any | None = None
+    layers: list[Any],
+    viewer: Any | None = None,
+    histogram_bins: dict[Any, int] | None = None,
 ) -> tuple[list[dict], list[str], bool]:
     """Send phasor layers to a running FLIMari session via its bridge.
 
@@ -264,6 +372,10 @@ def send_layers_to_flimari(
     viewer : napari.viewer.Viewer, optional
         Viewer used to open FLIMari's dock widget if it is not open yet.
         If not provided, a closed FLIMari dock surfaces as a ``RuntimeError``.
+    histogram_bins : dict, optional
+        Mapping of layer to its histogram-bin count ``K``, used to recover
+        photon counts for layers whose metadata lacks ``summed_signal`` (for
+        example, ``K`` recovered from a user-assigned original raw file).
 
     Returns
     -------
@@ -283,11 +395,14 @@ def send_layers_to_flimari(
         no ``viewer`` was provided to open one automatically.
     """
     bridge = _import_bridge()
+    overrides = histogram_bins or {}
 
     sent: list[dict] = []
     skipped: list[str] = []
     for layer in layers:
-        payload = build_flimari_dataset(layer)
+        payload = build_flimari_dataset(
+            layer, histogram_bins=overrides.get(layer)
+        )
         if payload is None:
             skipped.append(str(getattr(layer, "name", "?")))
         else:

--- a/src/napari_phasors/_tests/test_flimari.py
+++ b/src/napari_phasors/_tests/test_flimari.py
@@ -1,5 +1,7 @@
 """Tests for the napari-phasors -> FLIMari interoperability bridge."""
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 from napari.layers import Image
@@ -7,6 +9,7 @@ from napari.layers import Image
 from napari_phasors._flimari import (
     FlimariNotAvailable,
     build_flimari_dataset,
+    has_phasor_data,
     send_layers_to_flimari,
 )
 from napari_phasors._synthetic_generator import (
@@ -32,6 +35,28 @@ class _FakeBridge:
         self.received = None
 
     def import_from_napari_phasors(self, data_list):
+        self.received = data_list
+
+
+class _FlakyBridge:
+    """Bridge stub that reports "not ready" once, then accepts data.
+
+    Mimics FLIMari's real bridge, which raises ``RuntimeError`` from
+    ``import_from_napari_phasors`` until its dock widget has been opened
+    (which registers the import callback).
+    """
+
+    def __init__(self):
+        self.calls = 0
+        self.received = None
+
+    def import_from_napari_phasors(self, data_list):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError(
+                "FLIMari is not ready to receive data. "
+                "Open the FLIMari dock widget first."
+            )
         self.received = data_list
 
 
@@ -126,6 +151,24 @@ def test_build_returns_none_without_phasor_metadata():
     assert build_flimari_dataset(layer) is None
 
 
+def test_has_phasor_data():
+    """has_phasor_data distinguishes phasor layers from derived-analysis ones."""
+    phasor_layer = _phasor_layer()
+    assert has_phasor_data(phasor_layer) is True
+
+    plain_layer = Image(np.zeros((4, 5)), name="plain")
+    assert has_phasor_data(plain_layer) is False
+
+    # A component-analysis fraction layer only carries
+    # 'fraction_data_original', never raw phasor coordinates.
+    component_layer = Image(
+        np.zeros((4, 5)),
+        name="Component 1 Fractions",
+        metadata={"fraction_data_original": np.zeros((4, 5))},
+    )
+    assert has_phasor_data(component_layer) is False
+
+
 def test_send_layers_calls_bridge(monkeypatch):
     """send_layers_to_flimari forwards built payloads to the bridge."""
     import napari_phasors._flimari as flimari_mod
@@ -136,11 +179,32 @@ def test_send_layers_calls_bridge(monkeypatch):
     phasor = _phasor_layer(name="good")
     plain = Image(np.zeros((4, 5)), name="plain")
 
-    sent, skipped = send_layers_to_flimari([phasor, plain])
+    sent, skipped, opened_dock = send_layers_to_flimari([phasor, plain])
 
     assert fake.received is sent
     assert len(sent) == 1
     assert skipped == ["plain"]
+    assert opened_dock is False
+
+
+def test_send_layers_skips_component_analysis_layers(monkeypatch):
+    """Mixing a phasor layer with a component-analysis one only sends the former."""
+    import napari_phasors._flimari as flimari_mod
+
+    fake = _FakeBridge()
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: fake)
+
+    phasor = _phasor_layer(name="good")
+    component_layer = Image(
+        np.zeros((4, 5)),
+        name="Component 1 Fractions",
+        metadata={"fraction_data_original": np.zeros((4, 5))},
+    )
+
+    sent, skipped, _ = send_layers_to_flimari([phasor, component_layer])
+
+    assert len(sent) == 1
+    assert skipped == ["Component 1 Fractions"]
 
 
 def test_send_layers_raises_when_no_phasor_layers(monkeypatch):
@@ -159,3 +223,51 @@ def test_send_layers_raises_when_flimari_missing():
     # FLIMari is not a test dependency, so the real import must fail.
     with pytest.raises(FlimariNotAvailable):
         send_layers_to_flimari([_phasor_layer()])
+
+
+def test_send_layers_opens_flimari_dock_when_not_ready(monkeypatch):
+    """If FLIMari's dock isn't open, it is opened automatically and retried."""
+    import napari_phasors._flimari as flimari_mod
+
+    fake = _FlakyBridge()
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: fake)
+
+    mock_viewer = MagicMock()
+    layer = _phasor_layer()
+
+    sent, skipped, opened_dock = send_layers_to_flimari(
+        [layer], viewer=mock_viewer
+    )
+
+    assert opened_dock is True
+    assert fake.calls == 2
+    assert fake.received is sent
+    assert skipped == []
+    mock_viewer.window.add_plugin_dock_widget.assert_called_once_with(
+        plugin_name="flimari", widget_name="Phasor Analysis"
+    )
+
+
+def test_send_layers_without_viewer_reraises_runtime_error(monkeypatch):
+    """Without a viewer to open the dock with, the original error propagates."""
+    import napari_phasors._flimari as flimari_mod
+
+    fake = _FlakyBridge()
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: fake)
+
+    with pytest.raises(RuntimeError):
+        send_layers_to_flimari([_phasor_layer()])
+
+
+def test_send_layers_raises_if_dock_cannot_be_opened(monkeypatch):
+    """If opening the dock itself fails, a clear FlimariNotAvailable is raised."""
+    import napari_phasors._flimari as flimari_mod
+
+    fake = _FlakyBridge()
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: fake)
+
+    mock_viewer = MagicMock()
+    mock_viewer.window.add_plugin_dock_widget.side_effect = KeyError("flimari")
+
+    with pytest.raises(FlimariNotAvailable):
+        send_layers_to_flimari([_phasor_layer()], viewer=mock_viewer)

--- a/src/napari_phasors/_tests/test_flimari.py
+++ b/src/napari_phasors/_tests/test_flimari.py
@@ -114,6 +114,17 @@ def test_build_caps_harmonics_at_two():
     assert len(payload["calibration_phase"]) == 2
 
 
+def test_build_promotes_single_harmonic_to_leading_axis():
+    """A single-harmonic layer stores 2D G/S; a harmonic axis is added."""
+    layer = _phasor_layer(harmonic=1)
+    assert layer.metadata["G"].ndim == 2
+
+    payload = build_flimari_dataset(layer)
+
+    assert payload["g"].shape == (1, 4, 5)
+    assert payload["s"].shape == (1, 4, 5)
+
+
 def test_build_converts_thresholds_to_counts():
     """Mean-intensity thresholds are scaled to photon-count units by K."""
     layer = _phasor_layer()
@@ -166,6 +177,16 @@ def test_get_layer_histogram_bins():
     layer = _phasor_layer()
     assert get_layer_histogram_bins(layer) == N_TIME_BINS
     del layer.metadata["summed_signal"]
+    assert get_layer_histogram_bins(layer) is None
+
+
+def test_get_layer_histogram_bins_none_for_empty_summed_signal():
+    """An empty or scalar summed_signal is treated as 'unknown', not a bin count."""
+    layer = _phasor_layer()
+    layer.metadata["summed_signal"] = []
+    assert get_layer_histogram_bins(layer) is None
+
+    layer.metadata["summed_signal"] = 5.0
     assert get_layer_histogram_bins(layer) is None
 
 
@@ -296,6 +317,30 @@ def test_send_layers_raises_when_flimari_missing():
     # FLIMari is not a test dependency, so the real import must fail.
     with pytest.raises(FlimariNotAvailable):
         send_layers_to_flimari([_phasor_layer()])
+
+
+def test_import_bridge_returns_module_when_flimari_available(monkeypatch):
+    """_import_bridge returns the real bridge module when FLIMari is installed.
+
+    FLIMari is not a test dependency, so a fake ``flimari.core.bridge``
+    module is injected into ``sys.modules`` to exercise the success path.
+    """
+    import sys
+    import types
+
+    import napari_phasors._flimari as flimari_mod
+
+    fake_bridge = types.ModuleType("flimari.core.bridge")
+    fake_core = types.ModuleType("flimari.core")
+    fake_core.bridge = fake_bridge
+    fake_flimari = types.ModuleType("flimari")
+    fake_flimari.core = fake_core
+
+    monkeypatch.setitem(sys.modules, "flimari", fake_flimari)
+    monkeypatch.setitem(sys.modules, "flimari.core", fake_core)
+    monkeypatch.setitem(sys.modules, "flimari.core.bridge", fake_bridge)
+
+    assert flimari_mod._import_bridge() is fake_bridge
 
 
 def test_send_layers_opens_flimari_dock_when_not_ready(monkeypatch):

--- a/src/napari_phasors/_tests/test_flimari.py
+++ b/src/napari_phasors/_tests/test_flimari.py
@@ -9,7 +9,9 @@ from napari.layers import Image
 from napari_phasors._flimari import (
     FlimariNotAvailable,
     build_flimari_dataset,
+    get_layer_histogram_bins,
     has_phasor_data,
+    histogram_bins_from_raw_file,
     send_layers_to_flimari,
 )
 from napari_phasors._synthetic_generator import (
@@ -143,6 +145,77 @@ def test_build_without_histogram_bins_uses_mean_thresholds():
 
     assert "counts" not in payload
     assert payload["min_count"] == 4
+
+
+def test_build_uses_histogram_bins_override():
+    """An explicit K recovers counts even when the metadata lacks it."""
+    layer = _phasor_layer()
+    del layer.metadata["summed_signal"]
+    assert get_layer_histogram_bins(layer) is None
+
+    payload = build_flimari_dataset(layer, histogram_bins=100)
+
+    assert "counts" in payload
+    np.testing.assert_allclose(
+        payload["counts"], np.rint(layer.metadata["original_mean"] * 100)
+    )
+
+
+def test_get_layer_histogram_bins():
+    """get_layer_histogram_bins reads K from summed_signal, else None."""
+    layer = _phasor_layer()
+    assert get_layer_histogram_bins(layer) == N_TIME_BINS
+    del layer.metadata["summed_signal"]
+    assert get_layer_histogram_bins(layer) is None
+
+
+def test_histogram_bins_from_raw_file(tmp_path):
+    """K is recovered from an original raw file and validated against mean."""
+    import tifffile
+
+    raw = make_raw_flim_data(n_time_bins=64, shape=(4, 5))
+    path = str(tmp_path / "raw.tif")
+    tifffile.imwrite(path, raw)
+
+    # A layer built from the same data has a matching mean-intensity image.
+    layer = make_intensity_layer_with_phasors(raw)
+
+    k = histogram_bins_from_raw_file(
+        path, reference_mean=layer.metadata["original_mean"]
+    )
+    assert k == 64
+
+
+def test_histogram_bins_from_raw_file_rejects_mismatched_file(tmp_path):
+    """A file whose image shape/intensity doesn't match the layer is rejected."""
+    import tifffile
+
+    raw = make_raw_flim_data(n_time_bins=64, shape=(4, 5))
+    path = str(tmp_path / "raw.tif")
+    tifffile.imwrite(path, raw)
+
+    with pytest.raises(ValueError):
+        histogram_bins_from_raw_file(path, reference_mean=np.zeros((10, 10)))
+
+
+def test_send_layers_uses_histogram_bins_override(monkeypatch):
+    """Per-layer K overrides recover counts for layers lacking summed_signal."""
+    import napari_phasors._flimari as flimari_mod
+
+    fake = _FakeBridge()
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: fake)
+
+    layer = _phasor_layer()
+    del layer.metadata["summed_signal"]
+
+    sent, skipped, _ = send_layers_to_flimari(
+        [layer], histogram_bins={layer: 128}
+    )
+
+    assert "counts" in sent[0]
+    np.testing.assert_allclose(
+        sent[0]["counts"], np.rint(layer.metadata["original_mean"] * 128)
+    )
 
 
 def test_build_returns_none_without_phasor_metadata():

--- a/src/napari_phasors/_tests/test_flimari.py
+++ b/src/napari_phasors/_tests/test_flimari.py
@@ -1,0 +1,161 @@
+"""Tests for the napari-phasors -> FLIMari interoperability bridge."""
+
+import numpy as np
+import pytest
+from napari.layers import Image
+
+from napari_phasors._flimari import (
+    FlimariNotAvailable,
+    build_flimari_dataset,
+    send_layers_to_flimari,
+)
+from napari_phasors._synthetic_generator import (
+    make_intensity_layer_with_phasors,
+    make_raw_flim_data,
+)
+
+N_TIME_BINS = 256
+
+
+def _phasor_layer(harmonic=None, name="FLIM data"):
+    """Create an intensity layer with phasor metadata for testing."""
+    raw = make_raw_flim_data(n_time_bins=N_TIME_BINS, shape=(4, 5))
+    return make_intensity_layer_with_phasors(
+        raw, harmonic=harmonic or [1, 2], name=name
+    )
+
+
+class _FakeBridge:
+    """Stand-in for ``flimari.core.bridge`` capturing the received payload."""
+
+    def __init__(self):
+        self.received = None
+
+    def import_from_napari_phasors(self, data_list):
+        self.received = data_list
+
+
+def test_build_recovers_photon_counts():
+    """counts == round(mean * K), where K is the number of histogram bins."""
+    layer = _phasor_layer()
+    payload = build_flimari_dataset(layer)
+
+    expected = np.rint(layer.metadata["original_mean"] * N_TIME_BINS)
+    assert "counts" in payload
+    np.testing.assert_allclose(payload["counts"], expected)
+    # Counts must never be smaller than the mean intensity.
+    assert np.all(payload["counts"] >= payload["mean"] - 1e-6)
+
+
+def test_build_schema_keys_and_shapes():
+    """The payload matches FLIMari's documented schema."""
+    layer = _phasor_layer()
+    payload = build_flimari_dataset(layer)
+
+    for key in (
+        "name",
+        "channel",
+        "g",
+        "s",
+        "g_original",
+        "s_original",
+        "mean",
+        "min_count",
+        "max_count",
+        "filter_size",
+        "filter_repeat",
+    ):
+        assert key in payload
+
+    assert payload["name"] == "FLIM data Intensity Image"
+    # Phasor arrays are [Harmonics, Y, X].
+    assert payload["g"].shape == (2, 4, 5)
+    assert payload["s"].shape == (2, 4, 5)
+    assert payload["mean"].shape == (4, 5)
+    # Identity calibration (napari-phasors already baked calibration into G).
+    assert payload["calibration_phase"] == [0.0, 0.0]
+    assert payload["calibration_modulation"] == [1.0, 1.0]
+
+
+def test_build_caps_harmonics_at_two():
+    """FLIMari requires harmonic [1, 2]; extra harmonics are dropped."""
+    layer = _phasor_layer(harmonic=[1, 2, 3])
+    payload = build_flimari_dataset(layer)
+
+    assert payload["g"].shape[0] == 2
+    assert payload["s"].shape[0] == 2
+    assert len(payload["calibration_phase"]) == 2
+
+
+def test_build_converts_thresholds_to_counts():
+    """Mean-intensity thresholds are scaled to photon-count units by K."""
+    layer = _phasor_layer()
+    layer.metadata["settings"] = {
+        "threshold": 3.0,
+        "threshold_upper": 10.0,
+        "frequency": 40.0,
+        "channel": 1,
+        "filter": {"size": 5, "repeat": 2},
+    }
+
+    payload = build_flimari_dataset(layer)
+
+    assert payload["min_count"] == round(3.0 * N_TIME_BINS)
+    assert payload["max_count"] == round(10.0 * N_TIME_BINS)
+    assert payload["frequency"] == 40.0
+    assert payload["channel"] == 1
+    assert payload["filter_size"] == 5
+    assert payload["filter_repeat"] == 2
+
+
+def test_build_without_histogram_bins_uses_mean_thresholds():
+    """No summed_signal: counts omitted, thresholds stay in mean units."""
+    layer = _phasor_layer()
+    del layer.metadata["summed_signal"]
+    layer.metadata["settings"] = {"threshold": 4.0}
+
+    payload = build_flimari_dataset(layer)
+
+    assert "counts" not in payload
+    assert payload["min_count"] == 4
+
+
+def test_build_returns_none_without_phasor_metadata():
+    """A plain image layer (no phasor features) yields no payload."""
+    layer = Image(np.zeros((4, 5)), name="plain")
+    assert build_flimari_dataset(layer) is None
+
+
+def test_send_layers_calls_bridge(monkeypatch):
+    """send_layers_to_flimari forwards built payloads to the bridge."""
+    import napari_phasors._flimari as flimari_mod
+
+    fake = _FakeBridge()
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: fake)
+
+    phasor = _phasor_layer(name="good")
+    plain = Image(np.zeros((4, 5)), name="plain")
+
+    sent, skipped = send_layers_to_flimari([phasor, plain])
+
+    assert fake.received is sent
+    assert len(sent) == 1
+    assert skipped == ["plain"]
+
+
+def test_send_layers_raises_when_no_phasor_layers(monkeypatch):
+    """A ValueError is raised when nothing has phasor data to send."""
+    import napari_phasors._flimari as flimari_mod
+
+    monkeypatch.setattr(flimari_mod, "_import_bridge", lambda: _FakeBridge())
+    plain = Image(np.zeros((4, 5)), name="plain")
+
+    with pytest.raises(ValueError):
+        send_layers_to_flimari([plain])
+
+
+def test_send_layers_raises_when_flimari_missing():
+    """When FLIMari is not installed, FlimariNotAvailable propagates."""
+    # FLIMari is not a test dependency, so the real import must fail.
+    with pytest.raises(FlimariNotAvailable):
+        send_layers_to_flimari([_phasor_layer()])

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1567,6 +1567,80 @@ def test_writer_widget_flimari_button_requires_phasor_layer(
         assert "Component 1 Fractions" in message
 
 
+def test_writer_widget_flimari_prompts_for_raw_file(make_viewer_model, qtbot):
+    """A phasor layer without summed_signal prompts for the original raw file.
+
+    The recovered histogram-bin count is used to reconstruct photon counts,
+    which are then included in the payload sent to FLIMari.
+    """
+    from unittest.mock import MagicMock
+
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    # Simulate a layer loaded from a processed format without raw histogram.
+    del layer.metadata["summed_signal"]
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+    widget.export_layer_combobox.setCheckedItems([layer.name])
+
+    with (
+        patch(
+            "napari_phasors._widget.QFileDialog.getOpenFileName",
+            return_value=("/fake/original.ptu", ""),
+        ) as mock_dialog,
+        patch(
+            "napari_phasors._flimari.histogram_bins_from_raw_file",
+            return_value=64,
+        ) as mock_bins,
+        patch("napari_phasors._flimari._import_bridge") as mock_import_bridge,
+        patch("napari_phasors._widget.show_info"),
+    ):
+        fake_bridge = MagicMock()
+        mock_import_bridge.return_value = fake_bridge
+
+        widget.flimari_button.click()
+
+        # User was prompted for the raw file for this layer.
+        mock_dialog.assert_called_once()
+        mock_bins.assert_called_once()
+
+        (sent_payloads,) = fake_bridge.import_from_napari_phasors.call_args[0]
+        assert "counts" in sent_payloads[0]
+        np.testing.assert_allclose(
+            sent_payloads[0]["counts"],
+            np.rint(layer.metadata["original_mean"] * 64),
+        )
+
+
+def test_writer_widget_flimari_skips_prompt_when_counts_present(
+    make_viewer_model, qtbot
+):
+    """A layer that already has summed_signal is not prompted for a raw file."""
+    from unittest.mock import MagicMock
+
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+    widget.export_layer_combobox.setCheckedItems([layer.name])
+
+    with (
+        patch(
+            "napari_phasors._widget.QFileDialog.getOpenFileName"
+        ) as mock_dialog,
+        patch("napari_phasors._flimari._import_bridge") as mock_import_bridge,
+        patch("napari_phasors._widget.show_info"),
+    ):
+        mock_import_bridge.return_value = MagicMock()
+        widget.flimari_button.click()
+
+        mock_dialog.assert_not_called()
+
+
 def test_export_labels_layer_as_colored_image(
     make_viewer_model, qtbot, tmp_path
 ):

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1080,6 +1080,8 @@ def test_writer_widget(make_viewer_model, qtbot, tmp_path):
     assert isinstance(main_widget, QWidget)
     # Check init values are empty
     assert main_widget.export_layer_combobox.count() == 0
+    # FLIMari export button is disabled while no layer is selected
+    assert not main_widget.flimari_button.isEnabled()
     # Check error messages if there are no phasor layers
     with patch("napari_phasors._widget.show_error") as mock_show_error:
         main_widget.search_button.click()
@@ -1096,11 +1098,18 @@ def test_writer_widget(make_viewer_model, qtbot, tmp_path):
         main_widget.export_layer_combobox.itemText(0)
         == sample_image_layer.name
     )
+    # Still disabled: layer is present but not checked yet
+    assert not main_widget.flimari_button.isEnabled()
     # Select the layer in the CheckableComboBox
     main_widget.export_layer_combobox.selectAll()
     assert main_widget.export_layer_combobox.checkedItems() == [
         sample_image_layer.name
     ]
+    # FLIMari export button becomes enabled once a layer is checked
+    assert main_widget.flimari_button.isEnabled()
+    main_widget.export_layer_combobox.deselectAll()
+    assert not main_widget.flimari_button.isEnabled()
+    main_widget.export_layer_combobox.selectAll()
 
     # Simulate saving as OME-TIFF
     with (
@@ -1502,6 +1511,60 @@ def test_writer_widget_excludes_labels_layer(make_viewer_model, qtbot):
     ]
     assert "my_image" in items
     assert "my_labels" not in items
+
+
+def test_writer_widget_flimari_button_requires_phasor_layer(
+    make_viewer_model, qtbot
+):
+    """FLIMari button stays disabled unless a *phasor* layer is checked.
+
+    Layers from other analyses (e.g. component analysis fractions) are
+    valid targets for OME-TIFF/CSV export but must not enable the FLIMari
+    export button, since they carry no phasor coordinates to send.
+    """
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    phasor_layer = make_intensity_layer_with_phasors(raw_flim_data)
+    viewer.add_layer(phasor_layer)
+    # Simulate a component-analysis fraction layer: an Image layer with
+    # unrelated metadata and no phasor coordinates.
+    viewer.add_image(
+        np.zeros((5, 5)),
+        name="Component 1 Fractions",
+        metadata={"fraction_data_original": np.zeros((5, 5))},
+    )
+
+    widget = WriterWidget(viewer)
+
+    # Only the non-phasor layer selected: button must stay disabled.
+    widget.export_layer_combobox.setCheckedItems(["Component 1 Fractions"])
+    assert not widget.flimari_button.isEnabled()
+
+    # Adding the phasor layer to the selection enables it.
+    widget.export_layer_combobox.setCheckedItems(
+        ["Component 1 Fractions", phasor_layer.name]
+    )
+    assert widget.flimari_button.isEnabled()
+
+    # Sending only forwards the phasor layer and skips the other one.
+    from unittest.mock import MagicMock
+
+    with (
+        patch("napari_phasors._flimari._import_bridge") as mock_import_bridge,
+        patch("napari_phasors._widget.show_info") as mock_show_info,
+    ):
+        fake_bridge = MagicMock()
+        mock_import_bridge.return_value = fake_bridge
+
+        widget.flimari_button.click()
+
+        fake_bridge.import_from_napari_phasors.assert_called_once()
+        (sent_payloads,) = fake_bridge.import_from_napari_phasors.call_args[0]
+        assert len(sent_payloads) == 1
+        assert sent_payloads[0]["name"] == phasor_layer.name
+        message = mock_show_info.call_args[0][0]
+        assert "Sent 1 layer(s)" in message
+        assert "Component 1 Fractions" in message
 
 
 def test_export_labels_layer_as_colored_image(

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -1641,6 +1641,153 @@ def test_writer_widget_flimari_skips_prompt_when_counts_present(
         mock_dialog.assert_not_called()
 
 
+def test_send_to_flimari_shows_error_when_nothing_selected(
+    make_viewer_model, qtbot
+):
+    """_send_to_flimari guards against being invoked with no selection.
+
+    The button itself is disabled in this state, so the handler is called
+    directly to exercise the guard clause.
+    """
+    viewer = make_viewer_model()
+    widget = WriterWidget(viewer)
+
+    with patch("napari_phasors._widget.show_error") as mock_show_error:
+        widget._send_to_flimari()
+
+    mock_show_error.assert_called_once_with("No layer selected")
+
+
+def test_send_to_flimari_reports_flimari_not_available(
+    make_viewer_model, qtbot
+):
+    """FlimariNotAvailable from the bridge is surfaced via show_error."""
+    from napari_phasors._flimari import FlimariNotAvailable
+
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+    widget.export_layer_combobox.setCheckedItems([layer.name])
+
+    with (
+        patch(
+            "napari_phasors._flimari.send_layers_to_flimari",
+            side_effect=FlimariNotAvailable("FLIMari is not installed."),
+        ),
+        patch("napari_phasors._widget.show_error") as mock_show_error,
+    ):
+        widget._send_to_flimari()
+
+    mock_show_error.assert_called_once_with("FLIMari is not installed.")
+
+
+def test_send_to_flimari_reports_value_error(make_viewer_model, qtbot):
+    """A ValueError from send_layers_to_flimari is surfaced via show_error."""
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+    widget.export_layer_combobox.setCheckedItems([layer.name])
+
+    with (
+        patch(
+            "napari_phasors._flimari.send_layers_to_flimari",
+            side_effect=ValueError("no phasor data to send."),
+        ),
+        patch("napari_phasors._widget.show_error") as mock_show_error,
+    ):
+        widget._send_to_flimari()
+
+    mock_show_error.assert_called_once_with("no phasor data to send.")
+
+
+def test_send_to_flimari_reports_runtime_error(make_viewer_model, qtbot):
+    """A RuntimeError still raised after the dock-open retry is surfaced."""
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+    widget.export_layer_combobox.setCheckedItems([layer.name])
+
+    with (
+        patch(
+            "napari_phasors._flimari.send_layers_to_flimari",
+            side_effect=RuntimeError("FLIMari is not ready to receive data."),
+        ),
+        patch("napari_phasors._widget.show_error") as mock_show_error,
+    ):
+        widget._send_to_flimari()
+
+    mock_show_error.assert_called_once_with(
+        "FLIMari is not ready to receive data."
+    )
+
+
+def test_send_to_flimari_reports_unexpected_error(make_viewer_model, qtbot):
+    """Any other exception is caught and reported with context."""
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+    widget.export_layer_combobox.setCheckedItems([layer.name])
+
+    with (
+        patch(
+            "napari_phasors._flimari.send_layers_to_flimari",
+            side_effect=TypeError("boom"),
+        ),
+        patch("napari_phasors._widget.show_error") as mock_show_error,
+    ):
+        widget._send_to_flimari()
+
+    mock_show_error.assert_called_once_with("Error sending to FLIMari: boom")
+
+
+def test_recover_missing_counts_reports_error_for_bad_raw_file(
+    make_viewer_model, qtbot
+):
+    """A raw file that fails validation is reported and the layer is skipped.
+
+    The layer must then be exported without a histogram-bin override, so it
+    falls back to sending mean intensity as FLIMari's counts proxy.
+    """
+    viewer = make_viewer_model()
+    raw_flim_data = make_raw_flim_data()
+    layer = make_intensity_layer_with_phasors(raw_flim_data)
+    del layer.metadata["summed_signal"]
+    viewer.add_layer(layer)
+
+    widget = WriterWidget(viewer)
+
+    with (
+        patch(
+            "napari_phasors._widget.QFileDialog.getOpenFileName",
+            return_value=("/fake/wrong.ptu", ""),
+        ),
+        patch(
+            "napari_phasors._flimari.histogram_bins_from_raw_file",
+            side_effect=ValueError("the selected file does not match."),
+        ),
+        patch("napari_phasors._widget.show_error") as mock_show_error,
+    ):
+        overrides = widget._recover_missing_counts([layer])
+
+    assert overrides == {}
+    mock_show_error.assert_called_once_with(
+        f"Could not recover photon counts for "
+        f"'{layer.name}': the selected file does not match."
+    )
+
+
 def test_export_labels_layer_as_colored_image(
     make_viewer_model, qtbot, tmp_path
 ):

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2564,14 +2564,34 @@ class WriterWidget(PopoutWindowMixin, QWidget):
         self.search_button.clicked.connect(self._open_file_dialog)
         self.main_layout.addWidget(self.search_button)
 
-        self.flimari_button = QPushButton("Send to FLIMari")
-        self.flimari_button.setToolTip(
-            "Send the selected phasor layer(s) to a running FLIMari session. "
-            "FLIMari must be installed and its dock widget open. Total photon "
-            "counts are recovered from the mean intensity and sent along."
+        self.flimari_section = CollapsibleSection(
+            "FLIMari Interoperability",
+            initially_collapsed=True,
+            text_color="#c7c7c7",
         )
+        flimari_info = QLabel(
+            "Send the selected phasor layer(s) directly to "
+            "<a href=\"https://github.com/GuangchenW/FLIMari\">FLIMari</a>, "
+            "without saving any file. FLIMari must be installed as a "
+            "napari plugin; if its dock widget isn't open yet, it will be "
+            "opened automatically. Since FLIMari works with total photon "
+            "counts rather than mean intensity, the counts are recovered "
+            "automatically from the mean intensity and sent along."
+        )
+        flimari_info.setWordWrap(True)
+        flimari_info.setOpenExternalLinks(True)
+        self.flimari_section.add_widget(flimari_info)
+
+        self.flimari_button = QPushButton("Export Phasor Layer to FLIMARI")
+        self.flimari_button.setEnabled(False)
         self.flimari_button.clicked.connect(self._send_to_flimari)
-        self.main_layout.addWidget(self.flimari_button)
+        self.flimari_section.add_widget(self.flimari_button)
+
+        self.main_layout.addWidget(self.flimari_section)
+
+        self.export_layer_combobox.selectionChanged.connect(
+            self._update_flimari_button_state
+        )
 
         self.viewer.layers.events.inserted.connect(self._populate_combobox)
         self.viewer.layers.events.removed.connect(self._populate_combobox)
@@ -2622,7 +2642,7 @@ class WriterWidget(PopoutWindowMixin, QWidget):
             )
 
     def _send_to_flimari(self):
-        """Send the selected phasor layer(s) to a running FLIMari session."""
+        """Send the selected phasor layer(s) to FLIMari, opening its dock if needed."""
         from ._flimari import FlimariNotAvailable, send_layers_to_flimari
 
         selected_layers = self.export_layer_combobox.checkedItems()
@@ -2637,7 +2657,9 @@ class WriterWidget(PopoutWindowMixin, QWidget):
         ]
 
         try:
-            sent, skipped = send_layers_to_flimari(layers)
+            sent, skipped, opened_dock = send_layers_to_flimari(
+                layers, viewer=self.viewer
+            )
         except FlimariNotAvailable as exc:
             show_error(str(exc))
             return
@@ -2645,17 +2667,38 @@ class WriterWidget(PopoutWindowMixin, QWidget):
             show_error(str(exc))
             return
         except RuntimeError as exc:
-            # FLIMari's bridge raises this when no dock is open to receive data.
+            # Bridge still refused after we tried opening FLIMari's dock.
             show_error(str(exc))
             return
         except Exception as exc:  # noqa: BLE001
             show_error(f"Error sending to FLIMari: {exc}")
             return
 
-        message = f"Sent {len(sent)} layer(s) to FLIMari."
+        message = (
+            f"Opened FLIMari and sent {len(sent)} layer(s) to it."
+            if opened_dock
+            else f"Sent {len(sent)} layer(s) to FLIMari."
+        )
         if skipped:
             message += f" Skipped (no phasor data): {', '.join(skipped)}."
         show_info(message)
+
+    def _update_flimari_button_state(self, event=None):
+        """Enable the FLIMari export button only if a selected layer has phasor data.
+
+        Layers from other analyses (component analysis, FRET, phasor
+        mapping, ...) do not carry raw phasor coordinates, so selecting
+        only those must not enable this button.
+        """
+        from ._flimari import has_phasor_data
+
+        selected_layers = self.export_layer_combobox.checkedItems()
+        can_export = any(
+            name in self.viewer.layers
+            and has_phasor_data(self.viewer.layers[name])
+            for name in selected_layers
+        )
+        self.flimari_button.setEnabled(can_export)
 
     def _update_mask_checkbox_visibility(self, event=None):
         """Show/hide the mask checkbox based on whether any selected layer has a mask."""
@@ -2689,6 +2732,10 @@ class WriterWidget(PopoutWindowMixin, QWidget):
                 layer.events.metadata.disconnect(
                     self._update_mask_checkbox_visibility
                 )
+            with suppress(Exception):
+                layer.events.metadata.disconnect(
+                    self._update_flimari_button_state
+                )
         self._connected_metadata_layers.clear()
 
         for layer in image_layers:
@@ -2696,9 +2743,13 @@ class WriterWidget(PopoutWindowMixin, QWidget):
                 layer.events.metadata.connect(
                     self._update_mask_checkbox_visibility
                 )
+                layer.events.metadata.connect(
+                    self._update_flimari_button_state
+                )
                 self._connected_metadata_layers.add(layer)
 
         self._update_mask_checkbox_visibility()
+        self._update_flimari_button_state()
 
     def closeEvent(self, event):
         """Disconnect viewer signals before the widget is destroyed."""
@@ -2715,6 +2766,10 @@ class WriterWidget(PopoutWindowMixin, QWidget):
                 with suppress(Exception):
                     layer.events.metadata.disconnect(
                         self._update_mask_checkbox_visibility
+                    )
+                with suppress(Exception):
+                    layer.events.metadata.disconnect(
+                        self._update_flimari_button_state
                     )
             self._connected_metadata_layers.clear()
 

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2564,6 +2564,15 @@ class WriterWidget(PopoutWindowMixin, QWidget):
         self.search_button.clicked.connect(self._open_file_dialog)
         self.main_layout.addWidget(self.search_button)
 
+        self.flimari_button = QPushButton("Send to FLIMari")
+        self.flimari_button.setToolTip(
+            "Send the selected phasor layer(s) to a running FLIMari session. "
+            "FLIMari must be installed and its dock widget open. Total photon "
+            "counts are recovered from the mean intensity and sent along."
+        )
+        self.flimari_button.clicked.connect(self._send_to_flimari)
+        self.main_layout.addWidget(self.flimari_button)
+
         self.viewer.layers.events.inserted.connect(self._populate_combobox)
         self.viewer.layers.events.removed.connect(self._populate_combobox)
 
@@ -2611,6 +2620,42 @@ class WriterWidget(PopoutWindowMixin, QWidget):
                 selected_layers,
                 export_masked=export_masked,
             )
+
+    def _send_to_flimari(self):
+        """Send the selected phasor layer(s) to a running FLIMari session."""
+        from ._flimari import FlimariNotAvailable, send_layers_to_flimari
+
+        selected_layers = self.export_layer_combobox.checkedItems()
+        if not selected_layers:
+            show_error("No layer selected")
+            return
+
+        layers = [
+            self.viewer.layers[name]
+            for name in selected_layers
+            if name in self.viewer.layers
+        ]
+
+        try:
+            sent, skipped = send_layers_to_flimari(layers)
+        except FlimariNotAvailable as exc:
+            show_error(str(exc))
+            return
+        except ValueError as exc:
+            show_error(str(exc))
+            return
+        except RuntimeError as exc:
+            # FLIMari's bridge raises this when no dock is open to receive data.
+            show_error(str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001
+            show_error(f"Error sending to FLIMari: {exc}")
+            return
+
+        message = f"Sent {len(sent)} layer(s) to FLIMari."
+        if skipped:
+            message += f" Skipped (no phasor data): {', '.join(skipped)}."
+        show_info(message)
 
     def _update_mask_checkbox_visibility(self, event=None):
         """Show/hide the mask checkbox based on whether any selected layer has a mask."""

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2565,7 +2565,7 @@ class WriterWidget(PopoutWindowMixin, QWidget):
         self.main_layout.addWidget(self.search_button)
 
         self.flimari_section = CollapsibleSection(
-            "FLIMari Interoperability",
+            "Send to FLIMari",
             initially_collapsed=True,
             text_color="#c7c7c7",
         )
@@ -2576,7 +2576,9 @@ class WriterWidget(PopoutWindowMixin, QWidget):
             "napari plugin; if its dock widget isn't open yet, it will be "
             "opened automatically. Since FLIMari works with total photon "
             "counts rather than mean intensity, the counts are recovered "
-            "automatically from the mean intensity and sent along."
+            "automatically. For layers loaded from formats without the raw "
+            "histogram (e.g. R64/REF), you'll be prompted to point to the "
+            "original raw file so the counts can be recovered."
         )
         flimari_info.setWordWrap(True)
         flimari_info.setOpenExternalLinks(True)
@@ -2656,9 +2658,13 @@ class WriterWidget(PopoutWindowMixin, QWidget):
             if name in self.viewer.layers
         ]
 
+        # For phasor layers whose metadata lacks the raw histogram, ask the
+        # user to point to the original raw file so counts can be recovered.
+        histogram_bins = self._recover_missing_counts(layers)
+
         try:
             sent, skipped, opened_dock = send_layers_to_flimari(
-                layers, viewer=self.viewer
+                layers, viewer=self.viewer, histogram_bins=histogram_bins
             )
         except FlimariNotAvailable as exc:
             show_error(str(exc))
@@ -2679,9 +2685,70 @@ class WriterWidget(PopoutWindowMixin, QWidget):
             if opened_dock
             else f"Sent {len(sent)} layer(s) to FLIMari."
         )
+        n_proxy = sum(1 for payload in sent if "counts" not in payload)
+        if n_proxy:
+            message += (
+                f" {n_proxy} sent without photon counts "
+                "(mean intensity used as a proxy)."
+            )
         if skipped:
             message += f" Skipped (no phasor data): {', '.join(skipped)}."
         show_info(message)
+
+    def _recover_missing_counts(self, layers):
+        """Prompt for the original raw file of phasor layers lacking counts.
+
+        Returns a mapping of layer -> histogram-bin count for layers whose
+        photon counts were recovered from a user-assigned raw file. Layers
+        that already carry the info, that the user skips, or whose assigned
+        file does not match are left out (they fall back to mean intensity).
+        """
+        from ._flimari import (
+            get_layer_histogram_bins,
+            has_phasor_data,
+            histogram_bins_from_raw_file,
+        )
+        from ._reader import extension_mapping
+
+        raw_extensions = sorted(extension_mapping["raw"].keys())
+        pattern = " ".join(f"*{ext}" for ext in raw_extensions)
+        file_filter = f"Raw FLIM files ({pattern});;All files (*)"
+
+        overrides = {}
+        for layer in layers:
+            if not has_phasor_data(layer):
+                continue
+            if get_layer_histogram_bins(layer) is not None:
+                continue
+
+            start_dir = ""
+            source = getattr(layer, "source", None)
+            source_path = getattr(source, "path", None) if source else None
+            if source_path:
+                start_dir = os.path.dirname(str(source_path))
+
+            path, _ = QFileDialog.getOpenFileName(
+                self,
+                f"Select original raw file for '{layer.name}' to recover "
+                "photon counts (Cancel to send mean intensity only)",
+                start_dir,
+                file_filter,
+            )
+            if not path:
+                continue
+
+            try:
+                overrides[layer] = histogram_bins_from_raw_file(
+                    path,
+                    reference_mean=layer.metadata.get("original_mean"),
+                )
+            except Exception as exc:  # noqa: BLE001
+                show_error(
+                    f"Could not recover photon counts for "
+                    f"'{layer.name}': {exc}"
+                )
+
+        return overrides
 
     def _update_flimari_button_state(self, event=None):
         """Enable the FLIMari export button only if a selected layer has phasor data.


### PR DESCRIPTION
## Summary

Adds a live, in-session way to export napari-phasors phasor layers to [FLIMari](https://github.com/GuangchenW/FLIMari), a separate napari plugin for phasor-based FLIM analysis.

The two plugins use different intensity conventions: napari-phasors keeps only the *mean* intensity returned by `phasorpy.phasor.phasor_from_signal` (the raw signal is discarded after the phasor transform), while FLIMari filters and thresholds on *total photon counts*. This PR closes that gap without touching FLIMari's own file-reading path and without re-reading any raw data files.

Closes #276 

## How it works

- **No file round-trip.** Export goes through FLIMari's existing live callback bridge, `flimari.core.bridge.import_from_napari_phasors(data_list)`, which builds a `flimari.plugins.phasor.core.external_dataset.ExternalDataset` directly from a list of dicts — no OME-TIFF/CSV is written or read back.
- **Photon counts are recovered exactly, without the raw file, for most formats.** `phasor_from_signal` defines the mean as $F_{DC} = \frac{1}{K}\sum_{k=0}^{K-1} F_k$, i.e. mean = (sum over the histogram axis) / K. So the total per-pixel photon count is simply `mean * K`. `K` is already available from `metadata['summed_signal']` (the aggregate decay curve napari-phasors keeps per layer for raw formats and for its own round-tripped OME-TIFFs), so no raw file needs to be re-read for those.
- **For formats where `summed_signal` was never stored** (R64/REF, IFLI, third-party OME-TIFF — the raw histogram simply isn't in the file), the user is prompted, **per affected layer only**, to point to the original raw file. `K` is recovered by re-reading that file and is validated against the layer's mean intensity (shape + values) before being trusted, so assigning the wrong file is rejected rather than silently producing wrong counts. If the user cancels, or the file doesn't match, that layer falls back to sending mean intensity as a counts proxy — export still succeeds, just without the count upgrade for that layer.
- **Thresholds are converted to the same units.** napari-phasors' `threshold`/`threshold_upper` are defined in mean-intensity units (confirmed via `phasorpy.phasor.phasor_threshold(mean_min=..., mean_max=...)`). They're scaled by `K` before being sent as FLIMari's `min_count`/`max_count`, so masking behavior is consistent between the two plugins.
- **Calibration isn't double-applied.** napari-phasors bakes calibration directly into `G`/`G_original` when applied, so identity calibration coefficients (phase 0, modulation 1) are sent to prevent FLIMari from re-applying it.
- **Only true phasor layers are offered.** Layers produced by other analyses (component analysis, FRET, phasor mapping, ...) don't carry raw phasor coordinates and are excluded automatically, even if selected alongside valid phasor layers — those are just skipped and reported, not sent.
- **FLIMari's dock is opened automatically if needed**, instead of surfacing an error. FLIMari registers its import callback synchronously when its widget is constructed, so opening/docking it and retrying the send is enough — no polling required.

## UI changes

A new **"FLIMari Interoperability"** collapsible section was added to the Export Phasor widget, containing:
- An explanation of what the export does, how counts are recovered, and that a raw-file prompt may appear for some layers.
- An **"Export Phasor Layer to FLIMARI"** button, enabled only when at least one *selected* layer actually has phasor data.
- A per-layer native file dialog (raw-format filter, pre-filled with the layer's source directory when available) that only appears for layers missing `summed_signal`.
- A completion message reporting how many layers were sent, how many had to fall back to mean-intensity-as-counts, and which layers were skipped entirely.

## New module: `src/napari_phasors/_flimari.py`

- `has_phasor_data(layer)` — whether a layer carries the phasor metadata (`G`, `S`, `G_original`, `S_original`) FLIMari needs.
- `get_layer_histogram_bins(layer)` — returns `K` from the layer's metadata, or `None` if it isn't available there.
- `histogram_bins_from_raw_file(path, reference_mean=None)` — recovers `K` by re-reading an original raw file, validating the result against `reference_mean` (rtol 1e-2) so a mismatched file is rejected.
- `build_flimari_dataset(layer, histogram_bins=None)` — builds the FLIMari-schema dict for one layer, including the recovered `counts` key; `histogram_bins` overrides the metadata-derived `K` when it was recovered from a user-assigned raw file.
- `send_layers_to_flimari(layers, viewer=None, histogram_bins=None)` — sends a batch of layers, skipping non-phasor ones, applying any per-layer `K` overrides, and auto-opening FLIMari's dock (via `viewer`) on first send if it isn't open yet. Returns `(sent, skipped, opened_dock)`.

## Testing

- 19 unit tests in `test_flimari.py` covering: photon-count recovery, schema shape/keys, harmonic capping at 2, threshold-to-count conversion (with and without a recoverable `K`), exclusion of non-phasor layers, the dock-not-open → auto-open → retry flow (including "no viewer provided" and "dock can't be opened" edge cases), raw-file `K` recovery, and rejection of a mismatched raw file.
- Widget tests in `test_widget.py` covering the button's enabled/disabled state transitions, that mixed selections only send the phasor layer(s), that the raw-file prompt appears only for layers missing `summed_signal` and its recovered `K` reaches the sent payload, and that layers which already have the data are never prompted.
- All tests pass; `ruff` and `black` clean.

## Follow-up (FLIMari side, not in this PR)

FLIMari's `ExternalDataset` currently does `self.counts = mean` (marked `# HACK` in their source) since there was previously no way to get real counts from napari-phasors. To take advantage of the new `counts` key this PR sends, FLIMari needs a small change:

```python
counts = data.get("counts", None)
self.counts = np.asarray(counts, dtype=float) if counts is not None else mean
...
self.counts_filtered = self.counts.copy()   # was: mean.copy()
self.counts_filtered[~self.mask] = 0