### PR TITLE
Add Code of Conduct and Contributing Guide documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+See the [napari-phasors code of conduct](docs/code_of_conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See the [napari-phasors contributing guide](docs/contributing.md).

--- a/README.md
+++ b/README.md
@@ -72,25 +72,12 @@ Activate the environment :
 
 ## Contributing
 
-Contributions are very welcome. Tests can be run with [tox], please ensure
-the coverage at least stays the same before you submit a pull request.
+Contributions are very welcome. See the [contributing
+guide](CONTRIBUTING.md) for how to set up a development environment, run
+the tests, and submit a pull request.
 
-### Pre-commit Hooks
-
-This project uses [pre-commit](https://pre-commit.com/) to run **black**,
-**isort**, and **ruff** automatically on every commit. To set it up:
-
-```bash
-pip install pre-commit
-pre-commit install
-```
-
-From now on, every `git commit` will auto-format and lint your code before
-the commit goes through. You can also run the hooks manually on all files:
-
-```bash
-pre-commit run --all-files
-```
+This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md); by
+participating, you are expected to uphold it.
 
 ## License
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -27,3 +27,7 @@ parts:
 - caption: API Reference
   chapters:
   - file: api/index
+- caption: Community
+  chapters:
+  - file: contributing
+  - file: code_of_conduct

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,0 +1,131 @@
+# Code of conduct
+
+The napari-phasors project adopts the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html), adopted from the [PhasorPy code of conduct](https://www.phasorpy.org/docs/stable/code_of_conduct/).
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socioeconomic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to [bpannunzio@pasteur.edu.uy](mailto:bpannunzio@pasteur.edu.uy) or any
+[napari-phasors organization member](https://github.com/orgs/napari-phasors/people).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [PhasorPy code of
+conduct](https://www.phasorpy.org/docs/stable/code_of_conduct/), which is
+in turn adapted from the [Contributor
+Covenant](https://www.contributor-covenant.org), version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,145 @@
+# Contributing guide
+
+As a community-maintained project, napari-phasors welcomes contributions in
+the form of bug reports, bug fixes, feature implementations, documentation,
+sample data, and enhancement proposals. This guide explains how to contribute.
+
+The [Code of Conduct](code_of_conduct.md) applies to everyone participating
+in the napari-phasors community.
+
+## Ask for help
+
+To ask questions about using napari-phasors, open a [GitHub
+issue](https://github.com/napari-phasors/napari-phasors/issues).
+
+## Propose enhancements
+
+To suggest a new feature or other improvement, open a [GitHub
+issue](https://github.com/napari-phasors/napari-phasors/issues) describing
+the use case before starting work on a pull request.
+
+## Report bugs
+
+To report a bug, please open a [GitHub
+issue](https://github.com/napari-phasors/napari-phasors/issues) and include:
+
+- A minimal, self-contained script or set of steps reproducing the problem.
+- A traceback, if available.
+- The file(s) needed to reproduce the issue (or a sample file of the same
+  format), if the bug is related to reading or writing data.
+- An explanation of why the current behavior is wrong and what is expected
+  instead.
+- The napari-phasors, napari, and Python versions in use, and how
+  napari-phasors was installed (napari plugin manager, standalone installer,
+  conda/pip, or development version).
+
+## Contribute code or documentation
+
+The source code for napari-phasors is hosted in a GitHub repository at
+<https://github.com/napari-phasors/napari-phasors>.
+
+napari-phasors uses GitHub's [fork and pull collaborative development
+model](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests).
+All contributions should be developed in a personal fork of the repository
+and submitted as [pull
+requests](https://github.com/napari-phasors/napari-phasors/pulls).
+
+### Fork and clone the repository
+
+Fork the repository by pressing the "Fork" button at
+<https://github.com/napari-phasors/napari-phasors>, then clone the personal
+fork:
+
+```bash
+git clone https://github.com/your-user-name/napari-phasors.git
+cd napari-phasors
+git remote add upstream https://github.com/napari-phasors/napari-phasors.git
+```
+
+There are now two remote repositories: `upstream`, which refers to the
+napari-phasors repository, and `origin`, which refers to the personal fork.
+
+### Create a development environment
+
+We recommend using [miniforge](https://conda-forge.org/download/) to create
+an isolated environment, then installing napari-phasors in editable mode
+with its testing dependencies:
+
+```bash
+mamba create -y -n napari-phasors-dev napari pyqt6 python=3.12
+conda activate napari-phasors-dev
+pip install -e ".[testing]"
+```
+
+Verify that the development environment is working by running the tests:
+
+```bash
+pytest -v
+```
+
+### Create a branch
+
+Before implementing any changes, consider opening a [GitHub
+issue](https://github.com/napari-phasors/napari-phasors/issues) to discuss
+the bug fix or feature being worked on.
+
+Synchronize the personal fork with the upstream repository, then create a
+new branch for each bug fix or feature:
+
+```bash
+git checkout main
+git fetch upstream
+git rebase upstream/main
+git push
+git checkout -b my-new-feature
+```
+
+### Set up pre-commit hooks
+
+napari-phasors uses [pre-commit](https://pre-commit.com/) to run **black**,
+**isort**, and **ruff** automatically on every commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+From then on, every `git commit` auto-formats and lints the changed files
+before the commit goes through. The hooks can also be run manually on all
+files:
+
+```bash
+pre-commit run --all-files
+```
+
+### Run the tests
+
+Tests are run with [pytest](https://docs.pytest.org/) and, across the
+supported Python and Qt backend combinations, with
+[tox](https://tox.readthedocs.io/en/latest/):
+
+```bash
+pytest -v --cov=napari_phasors
+tox
+```
+
+Please ensure the test coverage at least stays the same before submitting a
+pull request.
+
+### Submit a pull request
+
+Push the branch to the personal fork and open a [pull
+request](https://github.com/napari-phasors/napari-phasors/pulls) against the
+`main` branch of the upstream repository. Describe the motivation and
+content of the change, and link any related issue.
+
+A maintainer will review the pull request, which may involve requesting
+changes before it is merged. The
+[tests](https://github.com/napari-phasors/napari-phasors/actions/workflows/run-tests.yml)
+and [codecov](https://codecov.io/gh/napari-phasors/napari-phasors) checks
+must pass.
+
+## Share data files
+
+Consider sharing sample datasets for testing and use in tutorials by opening
+a [GitHub issue](https://github.com/napari-phasors/napari-phasors/issues).


### PR DESCRIPTION
## Summary

Adds a Code of Conduct and a Contributing guide to the repository and ReadTheDocs site.

- Adopt the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html), as adapted by [PhasorPy's code of conduct](https://www.phasorpy.org/docs/stable/code_of_conduct/), with the enforcement contact set to bpannunzio@pasteur.edu.uy plus a link to napari-phasors org members.
- Add a dedicated Contributing guide covering asking for help, reporting bugs, forking/cloning, setting up a dev environment, pre-commit hooks, running tests, and submitting a PR — based on this repo's actual tooling (tox, pytest, black/isort/ruff).
- Publish both as pages under a new "Community" section in the ReadTheDocs table of contents.
- Add root-level `CODE_OF_CONDUCT.md` / `CONTRIBUTING.md` pointer files (GitHub's expected locations) linking to the docs pages, so they're picked up in the repo's community profile and PR/issue sidebar.
- Trim the README's "Contributing" section to link to the new guide instead of duplicating the pre-commit instructions, and add a one-line note linking to the Code of Conduct.

## Changes

- `docs/code_of_conduct.md` — full Code of Conduct text (new)
- `docs/contributing.md` — full Contributing guide (new)
- `CODE_OF_CONDUCT.md` — root pointer to `docs/code_of_conduct.md` (new)
- `CONTRIBUTING.md` — root pointer to `docs/contributing.md` (new)
- `docs/_toc.yml` — adds a "Community" section listing Contributing and Code of Conduct
- `README.md` — links to the new guide/code of conduct instead of duplicating content
