### PR TITLE
Reorganize phasor plot layout and add tests for PlotterWidget

### DIFF
--- a/src/napari_phasors/_tests/test_plotter_features.py
+++ b/src/napari_phasors/_tests/test_plotter_features.py
@@ -1720,3 +1720,120 @@ def test_color_settings_and_signal_teardown(
     viewer.add_shapes(np.random.random((2, 2)))
     viewer.add_labels(np.random.randint(0, 2, (10, 10)))
     plotter._disconnect_all_artist_signals()
+
+
+def test_analysis_docks_in_right_area_below_plotter(make_napari_viewer, qtbot):
+    """Analysis docks in the right area (below the plotter); histogram and
+    statistics stay in the bottom area, and the resize path runs cleanly."""
+    from qtpy.QtCore import Qt
+
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+    # Dock the plotter so the "split analysis below plotter" path executes.
+    viewer.window.add_dock_widget(plotter, name="Phasor Plot", area="right")
+    # Fire the dock setup deterministically rather than via the init timer.
+    plotter._analysis_dock_init_timer.stop()
+    plotter._add_analysis_dock_widget()
+
+    qt_window = viewer.window._qt_window
+    assert (
+        qt_window.dockWidgetArea(plotter._analysis_dock)
+        == Qt.RightDockWidgetArea
+    )
+    assert (
+        qt_window.dockWidgetArea(plotter._histogram_dock)
+        == Qt.BottomDockWidgetArea
+    )
+    assert (
+        qt_window.dockWidgetArea(plotter._statistics_dock)
+        == Qt.BottomDockWidgetArea
+    )
+    assert plotter._docks_initialized is True
+
+    # The hosting dock is discoverable via the parent walk.
+    assert plotter._find_plotter_dock() is not None
+
+    # Resize path (right width + minimum bottom height) runs without error.
+    plotter._resize_initial_docks()
+
+
+def test_bottom_corner_reassignment_and_restore(make_napari_viewer, qtbot):
+    """Docking hands the bottom corners to the side areas; closing restores
+    the viewer's original corner ownership."""
+    from qtpy.QtCore import Qt
+
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+    plotter._analysis_dock_init_timer.stop()
+
+    qt_window = viewer.window._qt_window
+    original_left = qt_window.corner(Qt.BottomLeftCorner)
+    original_right = qt_window.corner(Qt.BottomRightCorner)
+
+    plotter._add_analysis_dock_widget()
+
+    # Corners now belong to the left/right dock areas.
+    assert qt_window.corner(Qt.BottomLeftCorner) == Qt.LeftDockWidgetArea
+    assert qt_window.corner(Qt.BottomRightCorner) == Qt.RightDockWidgetArea
+
+    # The originals were captured for later restoration.
+    assert (
+        plotter._original_bottom_corners[Qt.BottomLeftCorner] == original_left
+    )
+    assert (
+        plotter._original_bottom_corners[Qt.BottomRightCorner]
+        == original_right
+    )
+
+    # Capture is idempotent: reassigning again must not overwrite the stored
+    # originals with the already-reassigned values.
+    plotter._assign_bottom_corners_to_side_docks()
+    assert (
+        plotter._original_bottom_corners[Qt.BottomLeftCorner] == original_left
+    )
+
+    # Closing restores the original corner ownership.
+    plotter.close()
+    assert qt_window.corner(Qt.BottomLeftCorner) == original_left
+    assert qt_window.corner(Qt.BottomRightCorner) == original_right
+
+
+def test_show_analysis_dock_readds_to_right_area(make_napari_viewer, qtbot):
+    """Re-opening a destroyed analysis dock re-adds it to the right area."""
+    from qtpy.QtCore import Qt
+
+    viewer = make_napari_viewer()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+    plotter._analysis_dock_init_timer.stop()
+    viewer.window.add_dock_widget(plotter, name="Phasor Plot", area="right")
+
+    # Simulate the dock's C++ object having been destroyed so the re-add
+    # branch (except RuntimeError) runs.
+    destroyed = MagicMock()
+    destroyed.setVisible.side_effect = RuntimeError("wrapped object deleted")
+    plotter._analysis_dock = destroyed
+
+    plotter._show_analysis_dock()
+
+    qt_window = viewer.window._qt_window
+    assert (
+        qt_window.dockWidgetArea(plotter._analysis_dock)
+        == Qt.RightDockWidgetArea
+    )
+
+
+def test_dock_helpers_are_safe_without_window(make_viewer_model):
+    """The corner/split helpers no-op safely when there is no Qt main window."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    # No corners captured yet -> restore is a safe no-op.
+    plotter._restore_bottom_corners()
+    assert not hasattr(plotter, '_original_bottom_corners')
+
+    # No hosting dock -> the parent walk returns None and split returns early.
+    assert plotter._find_plotter_dock() is None
+    plotter._split_analysis_below_plotter()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -24,6 +24,7 @@ from qtpy.QtWidgets import (
     QComboBox,
     QDialog,
     QDialogButtonBox,
+    QDockWidget,
     QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
@@ -2298,26 +2299,34 @@ class PlotterWidget(QWidget):
     def _add_analysis_dock_widget(self):
         """Add the analysis widget and histogram container to the viewer.
 
-        Histogram and statistics use separate dock widgets that are tabified
-        together in the same bottom area, alongside the analysis dock.
+        The analysis tabs dock in the right area, stacked below the plotter,
+        so the left (layer list) and right (plotter/analysis) columns run the
+        full height of the viewer. The histogram and statistics share the
+        bottom area, which is confined to the central column between them.
         """
         if (
             hasattr(self.viewer, 'window')
             and self.viewer.window is not None
             and hasattr(self.viewer.window, '_qt_window')
         ):
-            # Create histogram and analysis first, then split them.
-            # Create statistics after that and tabify only with histogram.
-            self._histogram_dock = self.viewer.window.add_dock_widget(
-                self.histogram_container,
-                name="Histogram",
-                area="bottom",
-            )
+            # Give the bottom area's corners to the left/right dock areas so
+            # the layer list and plotter/analysis columns keep their full
+            # height and the bottom docks are squeezed into the centre column.
+            self._assign_bottom_corners_to_side_docks()
 
-            # Analysis dock — rightmost
+            # Analysis tabs go to the right area, beneath the plotter, so they
+            # extend full height alongside the phasor plot.
             self._analysis_dock = self.viewer.window.add_dock_widget(
                 self.analysis_widget,
                 name="Phasor Analysis",
+                area="right",
+            )
+            self._split_analysis_below_plotter()
+
+            # Histogram and statistics share the bottom (central) column.
+            self._histogram_dock = self.viewer.window.add_dock_widget(
+                self.histogram_container,
+                name="Histogram",
                 area="bottom",
             )
 
@@ -2333,19 +2342,85 @@ class PlotterWidget(QWidget):
             # Defer resizeDocks so it runs after Qt has applied the splits.
             self._dock_resize_timer.start(200)
 
+    def _assign_bottom_corners_to_side_docks(self):
+        """Let the left/right dock areas own the bottom corners.
+
+        By default the bottom dock area spans the full window width, so a
+        bottom-docked histogram sits under the layer list. Handing the bottom
+        corners to the left and right dock areas keeps the layer list (left)
+        and plotter/analysis (right) columns full height and confines the
+        bottom area to the central column.
+        """
+        with contextlib.suppress(AttributeError, RuntimeError):
+            qt_window = self.viewer.window._qt_window
+            # Remember the viewer's original corner ownership once, so it can
+            # be restored when this widget closes (the change is viewer-wide).
+            if not hasattr(self, '_original_bottom_corners'):
+                self._original_bottom_corners = {
+                    Qt.BottomLeftCorner: qt_window.corner(Qt.BottomLeftCorner),
+                    Qt.BottomRightCorner: qt_window.corner(
+                        Qt.BottomRightCorner
+                    ),
+                }
+            qt_window.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
+            qt_window.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
+
+    def _restore_bottom_corners(self):
+        """Restore the viewer's original bottom-corner ownership.
+
+        Undoes :meth:`_assign_bottom_corners_to_side_docks` so closing this
+        widget does not leave the (viewer-wide) corner reassignment in place.
+        """
+        corners = getattr(self, '_original_bottom_corners', None)
+        if not corners:
+            return
+        with contextlib.suppress(AttributeError, RuntimeError):
+            qt_window = self.viewer.window._qt_window
+            for corner, area in corners.items():
+                qt_window.setCorner(corner, area)
+
+    def _find_plotter_dock(self):
+        """Return the QDockWidget that hosts this plotter, or ``None``."""
+        widget = self
+        while widget is not None:
+            parent = widget.parent()
+            if isinstance(parent, QDockWidget):
+                return parent
+            widget = parent
+        return None
+
+    def _split_analysis_below_plotter(self):
+        """Stack the analysis dock directly beneath the plotter dock."""
+        plotter_dock = self._find_plotter_dock()
+        if plotter_dock is None or not hasattr(self, '_analysis_dock'):
+            return
+        with contextlib.suppress(AttributeError, RuntimeError):
+            qt_window = self.viewer.window._qt_window
+            qt_window.splitDockWidget(
+                plotter_dock,
+                self._analysis_dock,
+                Qt.Vertical,
+            )
+
     def _resize_initial_docks(self):
         """Resize docks after delayed split has been applied."""
         if not getattr(self, '_docks_initialized', False):
             return
         with contextlib.suppress(AttributeError, RuntimeError):
             qt_window = self.viewer.window._qt_window
+            # Width of the right column (plotter/analysis).
             qt_window.resizeDocks(
-                [
-                    self._histogram_dock,
-                    self._analysis_dock,
-                ],
-                [600, 500],
+                [self._analysis_dock],
+                [600],
                 Qt.Horizontal,
+            )
+            # Height of the bottom (central) histogram/statistics area.
+            # Request 1 px so Qt clamps it to the dock's minimum height,
+            # keeping the histogram as short as allowed by default.
+            qt_window.resizeDocks(
+                [self._histogram_dock],
+                [1],
+                Qt.Vertical,
             )
 
     def _tabify_histogram_and_statistics_docks(self):
@@ -2363,24 +2438,16 @@ class PlotterWidget(QWidget):
             self._histogram_dock.raise_()
 
     def _enforce_bottom_dock_layout(self):
-        """Keep analysis separate and tabify only histogram/statistics."""
+        """Tabify histogram/statistics in the bottom (central) column.
+
+        The analysis dock lives in the right area, so the bottom area only
+        needs the histogram and statistics tabified together.
+        """
         if not all(
             hasattr(self, name)
-            for name in (
-                '_histogram_dock',
-                '_statistics_dock',
-                '_analysis_dock',
-            )
+            for name in ('_histogram_dock', '_statistics_dock')
         ):
             return
-
-        with contextlib.suppress(AttributeError, RuntimeError):
-            qt_window = self.viewer.window._qt_window
-            qt_window.splitDockWidget(
-                self._histogram_dock,
-                self._analysis_dock,
-                Qt.Horizontal,
-            )
         self._tabify_histogram_and_statistics_docks()
 
     def eventFilter(self, obj, event):
@@ -3661,8 +3728,9 @@ class PlotterWidget(QWidget):
             self._analysis_dock = self.viewer.window.add_dock_widget(
                 self.analysis_widget,
                 name="Phasor Analysis",
-                area="bottom",
+                area="right",
             )
+            self._split_analysis_below_plotter()
         self._enforce_bottom_dock_layout()
         with contextlib.suppress(AttributeError, RuntimeError):
             self._analysis_dock.raise_()
@@ -8339,5 +8407,8 @@ class PlotterWidget(QWidget):
             if tab is not None:
                 with contextlib.suppress(Exception):
                     tab.close()
+
+        # Undo the viewer-wide bottom-corner reassignment made when docking.
+        self._restore_bottom_corners()
 
         super().closeEvent(event)


### PR DESCRIPTION
# Reorder Phasor Plot Widget Layout & Add Dock Tests

## Summary
This PR refactors the dock widget layout in `PlotterWidget` to improve UI organization and vertical space utilization in `napari`. It reassigns window corners to side dock areas, moves the **Phasor Analysis** dock below the plotter in the right column, confines the **Histogram** and **Statistics** docks to a central bottom column, and adds unit tests covering these dock layout behaviors.

---

## Key Changes

### Layout and Dock Organization
* **Right Column Stacking (`right` area):**
  * Moved `_analysis_dock` from the `bottom` dock area to the `right` dock area.
  * Added `_split_analysis_below_plotter()` and `_find_plotter_dock()` to stack the analysis dock vertically directly beneath the Phasor Plot.
  * Updated `_show_analysis_dock()` to ensure re-opened or re-created analysis docks land in the right area.
* **Corner Area Reassignment:**
  * Added `_assign_bottom_corners_to_side_docks()`: Assigns `Qt.BottomLeftCorner` to `Qt.LeftDockWidgetArea` and `Qt.BottomRightCorner` to `Qt.RightDockWidgetArea`.
  * **Result:** The left (layer list) and right (plotter & analysis) side panels now span the full height of the viewer, preventing bottom widgets (Histogram/Statistics) from stretching across the full screen width.
* **Bottom Dock Area Adjustment:**
  * Confined `_histogram_dock` and `_statistics_dock` strictly to the central bottom column between side panels.
  * Adjusted `_resize_initial_docks()` to set initial right-column width (600px) and request minimum height (1px, clamped by Qt) for the bottom histogram dock.
  * Updated `_enforce_bottom_dock_layout()` to tabify only the histogram and statistics docks together.

### Cleanup and Safety
* **Teardown:** Added `_restore_bottom_corners()` called inside `closeEvent()` to revert the viewer's original corner assignments upon widget closure.
* **Error Handling:** Added defensive exception wrapping (`contextlib.suppress`) across helper functions to ensure safe no-ops when running headlessly or without a main Qt window.

---

## Unit Tests

Added unit tests in `src/napari_phasors/_tests/test_plotter_features.py`:

* `test_analysis_docks_in_right_area_below_plotter`: Verifies correct dock area assignment (right vs. bottom) and initial dock resize flow.
* `test_bottom_corner_reassignment_and_restore`: Asserts bottom-corner ownership shift to side panels, idempotent original corner state caching, and restoration on `close()`.
* `test_show_analysis_dock_readds_to_right_area`: Verifies re-opening a deleted analysis dock re-adds it correctly to the right area.
* `test_dock_helpers_are_safe_without_window`: Ensures helper methods execute safely without throwing exceptions in windowless environments.