### PR TITLE
Enhance MaskAssignmentDialog to sync combo with layer selections

### DIFF
--- a/src/napari_phasors/_tests/test_plotter_masks.py
+++ b/src/napari_phasors/_tests/test_plotter_masks.py
@@ -306,6 +306,106 @@ def test_mask_assignment_dialog_apply_all(make_viewer_model):
     assert assignments["layer_B"] == "mask_2"
 
 
+def test_mask_assignment_dialog_apply_all_defaults_to_placeholder(
+    make_viewer_model,
+):
+    """'Set all to' defaults to 'Select ...' when layers have differing masks."""
+    from napari_phasors.plotter import MaskAssignmentDialog
+
+    image_names = ["layer_A", "layer_B"]
+    mask_names = ["mask_1", "mask_2"]
+    current = {"layer_A": "mask_1", "layer_B": "None"}
+
+    dialog = MaskAssignmentDialog(
+        image_layer_names=image_names,
+        mask_layer_names=mask_names,
+        current_assignments=current,
+        parent=None,
+    )
+
+    assert dialog._apply_all_combo.currentText() == "Select ..."
+    # Selecting the placeholder must not clobber the per-layer assignments.
+    assignments = dialog.get_assignments()
+    assert assignments["layer_A"] == "mask_1"
+    assert assignments["layer_B"] == "None"
+
+    dialog.close()
+
+
+def test_mask_assignment_dialog_apply_all_defaults_to_common_mask(
+    make_viewer_model,
+):
+    """'Set all to' defaults to the shared mask when all layers match."""
+    from napari_phasors.plotter import MaskAssignmentDialog
+
+    image_names = ["layer_A", "layer_B"]
+    mask_names = ["mask_1", "mask_2"]
+    current = {"layer_A": "mask_1", "layer_B": "mask_1"}
+
+    dialog = MaskAssignmentDialog(
+        image_layer_names=image_names,
+        mask_layer_names=mask_names,
+        current_assignments=current,
+        parent=None,
+    )
+
+    assert dialog._apply_all_combo.currentText() == "mask_1"
+
+    dialog.close()
+
+
+def test_mask_assignment_dialog_apply_all_updates_on_per_layer_change(
+    make_viewer_model,
+):
+    """'Set all to' updates live as per-layer mask combos are edited."""
+    from napari_phasors.plotter import MaskAssignmentDialog
+
+    image_names = ["layer_A", "layer_B"]
+    mask_names = ["mask_1", "mask_2"]
+    current = {"layer_A": "mask_1", "layer_B": "mask_1"}
+
+    dialog = MaskAssignmentDialog(
+        image_layer_names=image_names,
+        mask_layer_names=mask_names,
+        current_assignments=current,
+        parent=None,
+    )
+
+    # Starts common, so "Set all to" reflects the shared mask.
+    assert dialog._apply_all_combo.currentText() == "mask_1"
+
+    # Diverging one layer's mask should fall back to the placeholder.
+    dialog._combos["layer_B"].setCurrentText("mask_2")
+    assert dialog._apply_all_combo.currentText() == "Select ..."
+
+    # Making them match again should restore the shared value automatically.
+    dialog._combos["layer_B"].setCurrentText("mask_1")
+    assert dialog._apply_all_combo.currentText() == "mask_1"
+
+    dialog.close()
+
+
+def test_mask_assignment_dialog_apply_all_differing_masks_ignores_stale_choice(
+    make_viewer_model,
+):
+    """Differing per-layer masks always show 'Select ...', never a stale value."""
+    from napari_phasors.plotter import MaskAssignmentDialog
+
+    image_names = ["layer_A", "layer_B"]
+    mask_names = ["mask_1", "mask_2"]
+    current = {"layer_A": "mask_1", "layer_B": "mask_2"}
+
+    dialog = MaskAssignmentDialog(
+        image_layer_names=image_names,
+        mask_layer_names=mask_names,
+        current_assignments=current,
+        parent=None,
+    )
+
+    assert dialog._apply_all_combo.currentText() == "Select ..."
+    dialog.close()
+
+
 def test_apply_mask_assignments_different_masks_per_layer(make_viewer_model):
     """Test that _apply_mask_assignments applies distinct masks to each layer."""
     viewer = make_viewer_model()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -444,6 +444,7 @@ class MaskAssignmentDialog(QDialog):
                     lc.setVisible(False)
 
             combo.currentTextChanged.connect(_on_mask_changed)
+            combo.currentTextChanged.connect(self._sync_apply_all_combo)
             # Initialize label combobox state
             _on_mask_changed(combo.currentText())
 
@@ -456,7 +457,13 @@ class MaskAssignmentDialog(QDialog):
         apply_all_layout = QHBoxLayout()
         apply_all_layout.addWidget(QLabel("Set all to:"))
         self._apply_all_combo = QComboBox()
-        self._apply_all_combo.addItems(mask_options)
+        apply_all_options = ["Select ..."] + mask_options
+        self._apply_all_combo.addItems(apply_all_options)
+        # Default to the common mask if all selected layers share one;
+        # otherwise (including when layers have differing masks) show the
+        # placeholder rather than any stale value.
+        self._sync_apply_all_combo()
+
         self._apply_all_combo.currentTextChanged.connect(
             self._on_apply_all_changed
         )
@@ -478,8 +485,19 @@ class MaskAssignmentDialog(QDialog):
     def _apply_to_all(self):
         """Set all combos to the same mask layer."""
         mask = self._apply_all_combo.currentText()
+        if mask == "Select ...":
+            return
         for combo in self._combos.values():
             combo.setCurrentText(mask)
+
+    def _sync_apply_all_combo(self, *_):
+        """Reflect the shared per-layer mask (or lack thereof) in "Set all to"."""
+        values = {combo.currentText() for combo in self._combos.values()}
+        common = next(iter(values)) if len(values) == 1 else "Select ..."
+        if self._apply_all_combo.currentText() != common:
+            self._apply_all_combo.blockSignals(True)
+            self._apply_all_combo.setCurrentText(common)
+            self._apply_all_combo.blockSignals(False)
 
     def get_assignments(self):
         """Return the mask assignments as a dict.


### PR DESCRIPTION
## Summary

Fixes the "Assign Masks..." dialog's **Set all to** combobox so it defaults to a usable placeholder and always reflects the actual per-layer mask state, instead of defaulting to (or getting stuck on) `None`.

Fixes #332

- Added a `Select ...` placeholder as the default value for the **Set all to** combobox, so it no longer defaults to `None` and accidentally resets every layer's mask when left untouched.
- If all selected image layers already share the same assigned mask (or are all unmasked), the combobox now defaults to that shared value instead of the placeholder.
- The combobox now updates **live**: editing any individual per-layer mask combo re-evaluates whether all layers still match, switching to the shared mask when they agree, or back to `Select ...` the moment they diverge — it never shows a stale value.
- Selecting `Select ...` is a no-op and won't overwrite any per-layer assignments.