### PR TITLE
Enhance colormap handling and improve analysis tab widgets

### DIFF
--- a/docs/guides/phasor_mapping.md
+++ b/docs/guides/phasor_mapping.md
@@ -40,7 +40,7 @@ from the calibration tab when calibration is applied).
 
 These modes derive the polar coordinates of the phasor directly with no
 frequency input required.  A **Colormap** drop-down lets you choose the
-colormap for the output layer; the default colormap for Phase is *hsv* and
+colormap for the output layer; the default colormap for Phase is *jet* and
 for Modulation is *viridis*.
 
 An optional **Apply colormap to 2D Histogram** checkbox, when enabled,

--- a/src/napari_phasors/__init__.py
+++ b/src/napari_phasors/__init__.py
@@ -10,9 +10,12 @@ from ._sample_data import (
     embryo_FLIM_sample_data,
     paramecium_HSI_sample_data,
 )
+from ._utils import register_extra_colormaps
 from ._widget import PhasorTransform, WriterWidget
 from ._writer import export_layer_as_csv, export_layer_as_image, write_ome_tiff
 from .plotter import PlotterWidget
+
+register_extra_colormaps()
 
 __all__ = (
     "napari_get_reader",

--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -257,6 +257,21 @@ DEFAULT_CURSOR_COLORS = [
 ]
 
 
+@contextlib.contextmanager
+def _pipeline_step(step_name):
+    """Annotate any error with the analysis step (tab) that raised it.
+
+    Batch failures are otherwise reported with only the file name and a bare
+    exception message, which does not say which enabled analysis (Calibration,
+    Filter, Components, Phasor Mapping, FRET, Selection) actually failed. This
+    re-raises with that context so the user knows where to look.
+    """
+    try:
+        yield
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"{step_name} failed: {exc}") from exc
+
+
 def apply_pipeline(layer, pipeline):
     """Apply ``pipeline`` to ``layer`` in place and return extra output layers.
 
@@ -276,33 +291,41 @@ def apply_pipeline(layer, pipeline):
     extra_layers = []
 
     if pipeline.calibration is not None:
-        apply_calibration_correction(
-            layer,
-            pipeline.calibration["phi_zero"],
-            pipeline.calibration["mod_zero"],
-        )
+        with _pipeline_step("Calibration"):
+            apply_calibration_correction(
+                layer,
+                pipeline.calibration["phi_zero"],
+                pipeline.calibration["mod_zero"],
+                calibration_harmonics=pipeline.calibration.get("harmonics"),
+            )
 
     if pipeline.filter is not None:
-        apply_filter_and_threshold(layer, **pipeline.filter)
+        with _pipeline_step("Filter / Threshold"):
+            apply_filter_and_threshold(layer, **pipeline.filter)
 
     if pipeline.mask is not None:
-        _apply_image_mask(
-            layer, pipeline.mask["array"], pipeline.mask["invert"]
-        )
+        with _pipeline_step("Image mask"):
+            _apply_image_mask(
+                layer, pipeline.mask["array"], pipeline.mask["invert"]
+            )
 
     if pipeline.components is not None:
-        extra_layers.extend(
-            _apply_component_fraction(layer, pipeline.components)
-        )
+        with _pipeline_step("Components"):
+            extra_layers.extend(
+                _apply_component_fraction(layer, pipeline.components)
+            )
 
     if pipeline.mapping is not None:
-        extra_layers.extend(_apply_phasor_mapping(layer, pipeline.mapping))
+        with _pipeline_step("Phasor Mapping"):
+            extra_layers.extend(_apply_phasor_mapping(layer, pipeline.mapping))
 
     if pipeline.fret is not None:
-        extra_layers.extend(_apply_fret(layer, pipeline.fret))
+        with _pipeline_step("FRET"):
+            extra_layers.extend(_apply_fret(layer, pipeline.fret))
 
     if pipeline.selection is not None:
-        extra_layers.extend(_apply_selection(layer, pipeline.selection))
+        with _pipeline_step("Selection"):
+            extra_layers.extend(_apply_selection(layer, pipeline.selection))
 
     return extra_layers
 
@@ -2661,7 +2684,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         mesh_container.setLayout(mesh_row)
         top_form.addRow("Mesh overlay:", mesh_container)
 
-        self.mapping_mesh_colormap_combo = self._make_colormap_combo("hsv")
+        self.mapping_mesh_colormap_combo = self._make_colormap_combo("jet")
         top_form.addRow(
             "Mesh/color colormap:", self.mapping_mesh_colormap_combo
         )
@@ -4481,9 +4504,15 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         else:
             name = dialog.selected_layer()
             if name and name in self.viewer.layers:
-                settings = dict(
-                    self.viewer.layers[name].metadata.get("settings", {})
-                )
+                layer_metadata = self.viewer.layers[name].metadata
+                settings = dict(layer_metadata.get("settings", {}))
+                # Harmonics live on the layer, not in its settings dict; expose
+                # them so a copied calibration can be matched to targets by
+                # harmonic value.
+                if layer_metadata.get("harmonics") is not None:
+                    settings.setdefault(
+                        "harmonics", layer_metadata["harmonics"]
+                    )
         if not settings:
             show_error("No settings found in the selected source.")
             return
@@ -4583,6 +4612,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             self._copied_calibration = {
                 "phi_zero": np.asarray(settings["calibration_phase"]),
                 "mod_zero": np.asarray(settings["calibration_modulation"]),
+                "harmonics": settings.get("harmonics"),
             }
             self.calibration_group.setChecked(True)
             index = self.calib_source_combo.findData("copied")
@@ -4788,6 +4818,41 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
 
     def _apply_component_settings_to_ui(self, settings):
         component_analysis = settings.get("component_analysis") or {}
+
+        # Copy the persisted phasor-plot line / fraction-histogram overlay
+        # style so an exported plot matches what was configured interactively.
+        # User edits are saved under ``two_component_line_settings`` (older
+        # metadata used ``line_settings``).
+        line_settings = (
+            component_analysis.get("two_component_line_settings")
+            or component_analysis.get("line_settings")
+            or {}
+        )
+        for key in (
+            "show_colormap_line",
+            "show_component_dots",
+            "line_offset",
+            "line_width",
+            "line_alpha",
+            "default_component_color",
+            "show_fraction_histogram",
+            "histogram_overlay_height",
+            "histogram_offset",
+            "histogram_alpha",
+        ):
+            if key in line_settings:
+                self._component_line_style[key] = line_settings[key]
+
+        # Same for the component label font style.
+        label_settings = (
+            component_analysis.get("two_components_label_settings")
+            or component_analysis.get("label_settings")
+            or {}
+        )
+        for key in ("fontsize", "bold", "italic", "color"):
+            if key in label_settings:
+                self._component_label_style[key] = label_settings[key]
+
         components = component_analysis.get("components") or {}
         if not components:
             return
@@ -4824,6 +4889,17 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         self._set_component_rows(parsed)
         self._set_component_harmonic_coords(per_harmonic)
         self.components_group.setChecked(True)
+
+        # Restore the analysis type. Rebuilding the rows transiently drops the
+        # count below 2, which forces the combo off "Linear Projection"; if the
+        # source used Linear Projection, that would otherwise silently switch
+        # the export to a Component Fit and drop the colormap line / fraction
+        # histogram overlay (both Linear-Projection-only).
+        analysis_type = component_analysis.get("analysis_type")
+        if analysis_type:
+            index = self.analysis_type_combo.findText(analysis_type)
+            if index >= 0:
+                self.analysis_type_combo.setCurrentIndex(index)
 
     # -- Pipeline building -------------------------------------------------
 
@@ -5084,7 +5160,13 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             phi_zero, mod_zero = compute_calibration_parameters(
                 reference, frequency, lifetime
             )
-            return {"*": {"phi_zero": phi_zero, "mod_zero": mod_zero}}
+            return {
+                "*": {
+                    "phi_zero": phi_zero,
+                    "mod_zero": mod_zero,
+                    "harmonics": reference.metadata.get("harmonics"),
+                }
+            }
 
         # Per-subfolder references.
         result = {}
@@ -5099,7 +5181,11 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             phi_zero, mod_zero = compute_calibration_parameters(
                 reference, frequency, lifetime
             )
-            result[key] = {"phi_zero": phi_zero, "mod_zero": mod_zero}
+            result[key] = {
+                "phi_zero": phi_zero,
+                "mod_zero": mod_zero,
+                "harmonics": reference.metadata.get("harmonics"),
+            }
         if not result:
             raise ValueError(
                 "No subfolders found to assign references. Scan a folder and "
@@ -5408,9 +5494,12 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         self.progress_bar.setVisible(False)
         summary = f"Batch complete: {processed}/{len(files)} files processed."
         if failed:
-            names = ", ".join(name for name, _ in failed)
-            summary += f" Failed: {names}."
-            show_error(summary)
+            summary += f" {len(failed)} failed."
+            # Show which file failed and at which step (e.g. "Components
+            # failed: ...") so the user knows which tab to fix, rather than a
+            # bare list of file names.
+            details = "\n".join(f"  • {name}: {msg}" for name, msg in failed)
+            show_error(f"{summary}\n{details}")
         else:
             show_info(summary)
         self.status_label.setText(summary)
@@ -6873,7 +6962,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             "kind": "mapping",
             "color_by": mapping.get("color_by", "None"),
             "mesh": None,
-            "mesh_colormap": mapping.get("mesh_colormap", "hsv"),
+            "mesh_colormap": mapping.get("mesh_colormap", "jet"),
             "mesh_alpha": mapping.get("mesh_alpha", 0.45),
             "mesh_phase_range": mapping.get("mesh_phase_range"),
             "mesh_modulation_range": mapping.get("mesh_modulation_range"),
@@ -7489,7 +7578,7 @@ def _save_phasor_plot_png(
         _draw_phase_modulation_mesh(
             plot,
             mapping_overlay["mesh"],
-            mapping_overlay.get("mesh_colormap") or "hsv",
+            mapping_overlay.get("mesh_colormap") or "jet",
             mapping_overlay.get("mesh_alpha", 0.45),
             display.get("semi_circle", True),
             phase_range=mapping_overlay.get("mesh_phase_range"),
@@ -7515,7 +7604,7 @@ def _save_phasor_plot_png(
             phase, modulation = phasor_to_polar(real, imag)
         color_by = mapping_overlay["color_by"]
         metric = phase if color_by == "Phase" else modulation
-        metric_cmap = mapping_overlay.get("mesh_colormap") or "hsv"
+        metric_cmap = mapping_overlay.get("mesh_colormap") or "jet"
         # Use the same color range as the phase/modulation mesh so the colored
         # data and the mesh represent identical values with identical colors.
         metric_range = (
@@ -7814,9 +7903,9 @@ def _color_plot_by_metric(
 
     resolved = cmap
     if resolved is None or isinstance(resolved, str):
-        resolved = resolve_colormap_by_name(resolved or "hsv")
+        resolved = resolve_colormap_by_name(resolved or "jet")
     if resolved is None:
-        resolved = resolve_colormap_by_name("hsv")
+        resolved = resolve_colormap_by_name("jet")
 
     vmin = vmax = None
     if value_range is not None and value_range[0] < value_range[1]:
@@ -7963,7 +8052,7 @@ def _save_grouped_overlay_plot(
         _draw_phase_modulation_mesh(
             plot,
             mapping_overlay["mesh"],
-            mapping_overlay.get("mesh_colormap") or "hsv",
+            mapping_overlay.get("mesh_colormap") or "jet",
             mapping_overlay.get("mesh_alpha", 0.45),
             display.get("semi_circle", True),
             phase_range=mapping_overlay.get("mesh_phase_range"),
@@ -8051,7 +8140,7 @@ def _save_combined_contour(
         _draw_phase_modulation_mesh(
             plot,
             mapping_overlay["mesh"],
-            mapping_overlay.get("mesh_colormap") or "hsv",
+            mapping_overlay.get("mesh_colormap") or "jet",
             mapping_overlay.get("mesh_alpha", 0.45),
             display.get("semi_circle", True),
             phase_range=mapping_overlay.get("mesh_phase_range"),

--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -980,6 +980,15 @@ def default_component_line_style():
         "line_width": 3.0,
         "line_alpha": 1.0,
         "default_component_color": "dimgray",
+        # Power-law gamma applied to the colormap line / fraction-histogram
+        # gradient, mirroring the fraction layer's ``gamma`` in the tab.
+        "colormap_gamma": 1.0,
+        # Fraction histogram overlay (Linear Projection only), mirroring the
+        # interactive Components tab.
+        "show_fraction_histogram": False,
+        "histogram_overlay_height": 0.3,
+        "histogram_offset": 0.0,
+        "histogram_alpha": 0.75,
     }
 
 
@@ -4137,6 +4146,17 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         alpha_spin.setValue(style["line_alpha"])
         form.addRow("Line alpha:", alpha_spin)
 
+        gamma_spin = QDoubleSpinBox()
+        gamma_spin.setRange(0.01, 10.0)
+        gamma_spin.setSingleStep(0.05)
+        gamma_spin.setDecimals(2)
+        gamma_spin.setValue(style.get("colormap_gamma", 1.0))
+        gamma_spin.setToolTip(
+            "Power-law gamma applied to the colormap line and fraction "
+            "histogram gradient, matching the fraction layer's gamma."
+        )
+        form.addRow("Colormap gamma:", gamma_spin)
+
         color_button = ColorButton(QColor(style["default_component_color"]))
         color_row = QHBoxLayout()
         color_row.addWidget(color_button)
@@ -4145,6 +4165,44 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         color_container.setLayout(color_row)
         form.addRow("Default line color:", color_container)
         vbox.addLayout(form)
+
+        # Fraction histogram overlay (Linear Projection, 2 components).
+        hist_group = QGroupBox("Fraction histogram overlay")
+        hist_form = QFormLayout(hist_group)
+        hist_cb = QCheckBox("Overlay fraction histogram on the line")
+        hist_cb.setChecked(style.get("show_fraction_histogram", False))
+        hist_cb.setToolTip(
+            "Overlay the first component's fraction histogram along the line "
+            "joining the two components, colored with the line's colormap. "
+            "Applies to a two-component Linear Projection."
+        )
+        hist_form.addRow(hist_cb)
+
+        hist_height_spin = QDoubleSpinBox()
+        hist_height_spin.setRange(0.05, 1.0)
+        hist_height_spin.setSingleStep(0.05)
+        hist_height_spin.setDecimals(2)
+        hist_height_spin.setValue(style.get("histogram_overlay_height", 0.3))
+        hist_form.addRow("Histogram height:", hist_height_spin)
+
+        hist_offset_spin = QDoubleSpinBox()
+        hist_offset_spin.setRange(-1.0, 1.0)
+        hist_offset_spin.setSingleStep(0.01)
+        hist_offset_spin.setDecimals(3)
+        hist_offset_spin.setValue(style.get("histogram_offset", 0.0))
+        hist_offset_spin.setToolTip(
+            "Shift the histogram relative to the line. Positive keeps it on "
+            "one side; negative flips it to the other side."
+        )
+        hist_form.addRow("Histogram offset:", hist_offset_spin)
+
+        hist_transp_spin = QDoubleSpinBox()
+        hist_transp_spin.setRange(0.0, 1.0)
+        hist_transp_spin.setSingleStep(0.05)
+        hist_transp_spin.setDecimals(2)
+        hist_transp_spin.setValue(1.0 - style.get("histogram_alpha", 0.75))
+        hist_form.addRow("Histogram transparency:", hist_transp_spin)
+        vbox.addWidget(hist_group)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
@@ -4160,7 +4218,12 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
                 "line_offset": offset_spin.value(),
                 "line_width": width_spin.value(),
                 "line_alpha": alpha_spin.value(),
+                "colormap_gamma": gamma_spin.value(),
                 "default_component_color": color_button.color().name(),
+                "show_fraction_histogram": hist_cb.isChecked(),
+                "histogram_overlay_height": hist_height_spin.value(),
+                "histogram_offset": hist_offset_spin.value(),
+                "histogram_alpha": 1.0 - hist_transp_spin.value(),
             }
 
     def _open_component_label_style_dialog(self):
@@ -6849,15 +6912,59 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             if display.get("show_center") and mean is not None:
                 _, center_real, center_imag = phasor_center(mean, real, imag)
                 center = (float(center_real), float(center_imag))
+            plot_overlay = self._components_overlay_with_fraction_data(
+                overlay, real, imag
+            )
             _save_phasor_plot_png(
                 real,
                 imag,
                 display,
-                overlay,
+                plot_overlay,
                 f"{base_out}_{suffix}_H{int(harmonic)}.png",
                 center=center,
                 dpi=self._export_dpi(),
             )
+
+    @staticmethod
+    def _components_overlay_with_fraction_data(overlay, real, imag):
+        """Attach the first-component fraction data to a components overlay.
+
+        The fraction histogram overlay (Linear Projection) needs the per-pixel
+        first-component fraction for the harmonic being plotted. This is
+        computed here from the plotted ``real``/``imag`` and the component
+        locations, then returned in a shallow copy of ``overlay`` so the
+        original (shared across harmonics) is left untouched. Non-component or
+        non-linear overlays are returned unchanged.
+        """
+        if overlay is None or overlay.get("kind") != "components":
+            return overlay
+        components = overlay.get("components") or {}
+        line_style = components.get("line_style") or {}
+        if not line_style.get("show_fraction_histogram"):
+            return overlay
+        if components.get("analysis_type") != "linear":
+            return overlay
+        component_real = components.get("component_real")
+        component_imag = components.get("component_imag")
+        if component_real is None or component_imag is None:
+            return overlay
+        component_real = np.asarray(component_real)
+        component_imag = np.asarray(component_imag)
+        if component_real.ndim > 1:
+            component_real = component_real[0]
+            component_imag = component_imag[0]
+        try:
+            fraction = phasor_component_fraction(
+                np.asarray(real),
+                np.asarray(imag),
+                component_real,
+                component_imag,
+            )
+        except Exception:  # noqa: BLE001 - skip overlay if it can't compute
+            return overlay
+        new_overlay = dict(overlay)
+        new_overlay["fraction_data"] = np.asarray(fraction, dtype=float)
+        return new_overlay
 
     # -- Signal export outputs ---------------------------------------------
 
@@ -7608,6 +7715,7 @@ def _add_phasor_overlay(plot, overlay):
             ),
             "fractions_colormap": fractions_colormap,
             "colormap_contrast_limits": contrast,
+            "colormap_gamma": line_style.get("colormap_gamma", 1.0),
             "label_fontsize": label_style.get("fontsize", 10),
             "label_fontweight": (
                 "bold" if label_style.get("bold") else "normal"
@@ -7617,6 +7725,17 @@ def _add_phasor_overlay(plot, overlay):
             ),
             "label_color": label_style.get("color"),
             "show_labels": label_style.get("show_labels", False),
+            # Fraction histogram overlay (Linear Projection); the fraction data
+            # is injected per-harmonic by ``_render_phasor_plot``.
+            "show_fraction_histogram": line_style.get(
+                "show_fraction_histogram", False
+            ),
+            "histogram_overlay_height": line_style.get(
+                "histogram_overlay_height", 0.3
+            ),
+            "histogram_offset": line_style.get("histogram_offset", 0.0),
+            "histogram_alpha": line_style.get("histogram_alpha", 0.75),
+            "fraction_data": overlay.get("fraction_data"),
         }
         # Multi-harmonic fits store 2-D component arrays; the overlay draws a
         # single harmonic, so use the primary harmonic's locations.

--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -7584,6 +7584,7 @@ def _save_phasor_plot_png(
             phase_range=mapping_overlay.get("mesh_phase_range"),
             modulation_range=mapping_overlay.get("mesh_modulation_range"),
             clip_semicircle=mapping_overlay.get("mesh_clip_semicircle"),
+            dpi=dpi,
         )
 
     plot_type = display.get("plot_type", "Histogram")
@@ -7734,6 +7735,7 @@ def _draw_phase_modulation_mesh(
     phase_range=None,
     modulation_range=None,
     clip_semicircle=None,
+    dpi=300,
 ):
     """Draw a phase or modulation colored field behind the phasor data.
 
@@ -7748,9 +7750,7 @@ def _draw_phase_modulation_mesh(
 
     if clip_semicircle is None:
         clip_semicircle = semicircle
-    # Use a fine grid for the exported mesh: at the default 300 the edges look
-    # coarse / "shadowed" (the smoothed alpha halo spans several cells), and a
-    # zoomed crop magnifies it. A high resolution keeps the edges crisp.
+    plot.fig.set_dpi(dpi)
     draw_phasor_mesh(
         plot.ax,
         kind,
@@ -8058,6 +8058,7 @@ def _save_grouped_overlay_plot(
             phase_range=mapping_overlay.get("mesh_phase_range"),
             modulation_range=mapping_overlay.get("mesh_modulation_range"),
             clip_semicircle=mapping_overlay.get("mesh_clip_semicircle"),
+            dpi=dpi,
         )
 
     marker_size = display.get("marker_size", 5)
@@ -8146,6 +8147,7 @@ def _save_combined_contour(
             phase_range=mapping_overlay.get("mesh_phase_range"),
             modulation_range=mapping_overlay.get("mesh_modulation_range"),
             clip_semicircle=mapping_overlay.get("mesh_clip_semicircle"),
+            dpi=dpi,
         )
 
     handles = []

--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -1015,7 +1015,7 @@ def default_group_config():
         "contour_layer_styles": {},  # filename -> {mode, colormap, color}
         "contour_group_styles": {},  # gid -> {mode, colormap, color}
         "contour_merged_style": "colormap",
-        "contour_merged_colormap": "turbo",
+        "contour_merged_colormap": "jet",
         "contour_merged_color": None,
     }
 
@@ -1412,7 +1412,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         toggle.setChecked(True)
         return toggle
 
-    def _make_colormap_combo(self, default="turbo"):
+    def _make_colormap_combo(self, default="jet"):
         """Return a combobox populated with napari colormap names + icons."""
         combo = QComboBox()
         populate_colormap_combobox(
@@ -2581,7 +2581,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         )
         output_form.addRow("Harmonic:", self.mapping_harmonic_spin)
 
-        self.mapping_colormap_combo = self._make_colormap_combo("turbo")
+        self.mapping_colormap_combo = self._make_colormap_combo("jet")
         self.mapping_colormap_combo.setToolTip(
             "Colormap applied to the exported mapped images."
         )
@@ -3552,7 +3552,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         form.addRow("Plot type:", type_combo)
 
         colormap_label = QLabel("Colormap:")
-        colormap_combo = self._make_colormap_combo("turbo")
+        colormap_combo = self._make_colormap_combo("jet")
         colormap_combo.setToolTip("Colormap used for the phasor-plot density.")
         form.addRow(colormap_label, colormap_combo)
 
@@ -3791,7 +3791,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             groups_only=True,
             display_mode="Grouped",
             show_legend=cfg.get("show_legend", True),
-            merged_colormap=cfg.get("contour_merged_colormap", "turbo"),
+            merged_colormap=cfg.get("contour_merged_colormap", "jet"),
             layer_labels=names,
             group_assignments=cfg.get("assignments", {}),
             group_colors=cfg.get("group_colors", {}),
@@ -3868,7 +3868,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             "Type a lifetime (ns) and press Enter to set G/S from it."
         )
 
-        colormap_combo = self._make_colormap_combo("turbo")
+        colormap_combo = self._make_colormap_combo("jet")
         colormap_combo.setMaximumWidth(120)
         colormap_combo.setToolTip("Colormap for this component's fraction.")
 
@@ -4939,7 +4939,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             # Color ramp + limits driving the colormap line and colormap-end
             # dot colors (derived from the first component's colormap).
             "fractions_colormap": _colormap_color_list(
-                colormaps[0] if colormaps else "turbo"
+                colormaps[0] if colormaps else "jet"
             ),
             "colormap_contrast_limits": contrast or (0.0, 1.0),
         }
@@ -6470,7 +6470,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             if mode == "Merged":
                 styles[key] = {
                     "mode": cfg.get("contour_merged_style", "colormap"),
-                    "colormap": cfg.get("contour_merged_colormap", "turbo"),
+                    "colormap": cfg.get("contour_merged_colormap", "jet"),
                     "color": cfg.get("contour_merged_color"),
                 }
             elif mode == "Individual layers":
@@ -6719,7 +6719,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             "log_scale": controls["log"].isChecked(),
             "white_background": self.plot_white_bg_checkbox.isChecked(),
             "show_legend": self.plot_legend_checkbox.isChecked(),
-            "colormap": controls["colormap"].currentText() or "turbo",
+            "colormap": controls["colormap"].currentText() or "jet",
             "bins": controls["bins"].value(),
             "contour_levels": controls["levels"].value(),
             "contour_linewidth": controls["linewidth"].value(),

--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -73,6 +73,31 @@ except (AttributeError, ImportError, TypeError):
     pass
 
 
+# Same PySide6/shiboken wrapper-corruption bug as above, hitting matplotlib's
+# Qt canvas this time: `FigureCanvasQT.showEvent` does
+# `self.window().windowHandle()`, which should be a QWindow, to wire up
+# HiDPI pixel-ratio signals. Under teardown-time address reuse this can come
+# back as a stale QWidgetItem instead, so `.installEventFilter(self)` raises
+# `AttributeError: 'QWidgetItem' object has no attribute 'installEventFilter'`.
+# Only reproduces with PySide6 (not PyQt), during Qt event-loop teardown.
+# The pixel-ratio wiring is cosmetic, so skip it on failure rather than
+# aborting the surrounding show()/event handling.
+try:
+    from matplotlib.backends.backend_qt import FigureCanvasQT
+
+    _orig_FigureCanvasQT_showEvent = FigureCanvasQT.showEvent
+
+    def _safe_showEvent(self, event):
+        try:
+            return _orig_FigureCanvasQT_showEvent(self, event)
+        except AttributeError:
+            return None
+
+    FigureCanvasQT.showEvent = _safe_showEvent
+except (AttributeError, ImportError, TypeError):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def _ensure_qapp(qapp):
     """Guarantee a QApplication exists for every test.

--- a/src/napari_phasors/_tests/test_batch_analysis.py
+++ b/src/napari_phasors/_tests/test_batch_analysis.py
@@ -1728,6 +1728,124 @@ def test_run_batch_components_plot_with_style(
     assert any("_components_phasor_H1.png" in name for name in plots)
 
 
+def test_default_component_line_style_has_histogram_keys():
+    """The batch line style exposes the fraction histogram overlay controls."""
+    from napari_phasors._batch_analysis import default_component_line_style
+
+    style = default_component_line_style()
+    assert style["show_fraction_histogram"] is False
+    assert style["histogram_overlay_height"] == 0.3
+    assert style["histogram_offset"] == 0.0
+    assert style["histogram_alpha"] == 0.75
+
+
+def test_components_overlay_injects_fraction_data():
+    """Fraction data is computed and attached only for linear projections with
+    the histogram overlay enabled."""
+    rng = np.random.default_rng(0)
+    real = rng.uniform(0.2, 0.8, 500)
+    imag = rng.uniform(0.1, 0.5, 500)
+    base = {
+        "kind": "components",
+        "components": {
+            "analysis_type": "linear",
+            "component_real": [0.2, 0.8],
+            "component_imag": [0.1, 0.5],
+            "line_style": {"show_fraction_histogram": True},
+        },
+    }
+    out = BatchAnalysisWidget._components_overlay_with_fraction_data(
+        base, real, imag
+    )
+    assert "fraction_data" in out
+    assert out["fraction_data"].shape == real.shape
+    # The original overlay is not mutated.
+    assert "fraction_data" not in base
+
+    # Disabled overlay -> unchanged (no fraction data attached).
+    base["components"]["line_style"]["show_fraction_histogram"] = False
+    assert (
+        "fraction_data"
+        not in BatchAnalysisWidget._components_overlay_with_fraction_data(
+            base, real, imag
+        )
+    )
+
+
+def test_draw_fraction_histogram_overlay_shared_helper():
+    """The shared overlay helper draws a single gradient image artist."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.image import AxesImage
+
+    from napari_phasors.components_tab import (
+        draw_fraction_histogram_overlay,
+    )
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(-0.05, 1.05)
+    ax.set_ylim(-0.05, 0.7)
+    rng = np.random.default_rng(1)
+    values = np.clip(rng.normal(0.4, 0.15, 5000), 0, 1)
+    ramp = plt.get_cmap("jet")(np.linspace(0, 1, 256))
+
+    artists = draw_fraction_histogram_overlay(
+        ax, 0.2, 0.1, 0.8, 0.5, values, ramp, height=0.3
+    )
+    assert artists is not None
+    assert len(artists) == 1
+    assert isinstance(artists[0], AxesImage)
+
+    # Empty data draws nothing.
+    assert (
+        draw_fraction_histogram_overlay(
+            ax, 0.2, 0.1, 0.8, 0.5, np.array([]), ramp
+        )
+        is None
+    )
+    plt.close(fig)
+
+
+def test_run_batch_components_plot_with_fraction_histogram(
+    qtbot, make_viewer_model, tmp_path
+):
+    """End-to-end: the fraction histogram overlay renders in a batch export."""
+    in_root = tmp_path / "in"
+    in_root.mkdir()
+    out_root = tmp_path / "out"
+    out_root.mkdir()
+    write_ome_tiff(
+        str(in_root / "a.ome.tif"), _make_phasor_layer(name="a", harmonic=[1])
+    )
+
+    widget = BatchAnalysisWidget(make_viewer_model())
+    qtbot.addWidget(widget)
+    widget._input_folder = str(in_root)
+    widget._rescan()
+    idx = widget.format_combobox.findData(".ome.tif")
+    widget.format_combobox.setCurrentIndex(idx)
+    widget.harmonics_edit.setText("1")
+    widget._export_folder = str(out_root)
+    widget.export_ometiff_checkbox.setChecked(False)
+
+    widget.components_group.setChecked(True)
+    widget.components_plot_toggle.setChecked(True)
+    widget._component_line_style["show_colormap_line"] = True
+    widget._component_line_style["show_fraction_histogram"] = True
+    widget._component_line_style["histogram_overlay_height"] = 0.4
+    widget._component_rows[0]["g"].setText("0.8")
+    widget._component_rows[0]["s"].setText("0.3")
+    widget._component_rows[1]["g"].setText("0.2")
+    widget._component_rows[1]["s"].setText("0.3")
+
+    widget.run_batch()
+
+    plots = {p.name for p in out_root.rglob("*.png")}
+    assert any("_components_phasor_H1.png" in name for name in plots)
+
+
 def test_combined_merged_histogram_exported(
     qtbot, make_viewer_model, tmp_path
 ):
@@ -2434,6 +2552,27 @@ def test_histogram_csv_respects_value_range(tmp_path):
     assert sum(counts) == 3
 
 
+def test_compute_stats_center_of_mass_from_raw_histogram():
+    """Batch statistics compute the center of mass from the raw histogram."""
+    from napari_phasors._batch_analysis import _compute_stats
+
+    rng = np.random.default_rng(1)
+    data = np.concatenate(
+        [rng.normal(2.0, 0.3, 5000), rng.normal(5.0, 0.5, 1500)]
+    )
+    bins = 100
+    stats = _compute_stats(data, bins)
+
+    counts, edges = np.histogram(data, bins=bins)
+    centers = (edges[:-1] + edges[1:]) / 2.0
+    expected_com = float(np.average(centers, weights=counts))
+
+    assert np.isclose(stats["com"], expected_com)
+    assert stats["n"] == data.size
+    # Mean is the raw arithmetic mean (unbinned), distinct from the binned COM.
+    assert np.isclose(stats["mean"], float(np.mean(data)))
+
+
 def test_output_controls_unified(qtbot, make_viewer_model):
     """Each analysis tab exposes one Outputs section with format comboboxes."""
     widget = BatchAnalysisWidget(make_viewer_model())
@@ -2984,6 +3123,55 @@ def test_draw_components_overlay_two_with_colormap_line():
     )
     assert ax.collections
     plt.close(fig)
+
+
+def test_draw_components_overlay_gamma_uses_power_norm():
+    """A non-unity export gamma renders the gradient line through a PowerNorm."""
+    from matplotlib.colors import PowerNorm
+
+    from napari_phasors.components_tab import draw_components_overlay
+
+    plt, fig, ax = _agg_axes()
+
+    # Gamma of 1.0 keeps a plain linear normalisation.
+    draw_components_overlay(
+        ax,
+        [0.2, 0.8],
+        [0.3, 0.4],
+        analysis_type="Linear Projection",
+        settings={
+            "show_colormap_line": True,
+            "fractions_colormap": ["#000000", "#ffffff"],
+            "colormap_contrast_limits": (0.0, 1.0),
+            "colormap_gamma": 1.0,
+        },
+    )
+    assert not isinstance(ax.collections[-1].norm, PowerNorm)
+
+    # A non-unity gamma switches the gradient line to a matching PowerNorm.
+    draw_components_overlay(
+        ax,
+        [0.2, 0.8],
+        [0.3, 0.4],
+        analysis_type="Linear Projection",
+        settings={
+            "show_colormap_line": True,
+            "fractions_colormap": ["#000000", "#ffffff"],
+            "colormap_contrast_limits": (0.0, 1.0),
+            "colormap_gamma": 0.4,
+        },
+    )
+    norm = ax.collections[-1].norm
+    assert isinstance(norm, PowerNorm)
+    assert norm.gamma == 0.4
+    plt.close(fig)
+
+
+def test_default_component_line_style_exposes_colormap_gamma():
+    """The batch line style exposes the colormap gamma control (default 1.0)."""
+    from napari_phasors._batch_analysis import default_component_line_style
+
+    assert default_component_line_style()["colormap_gamma"] == 1.0
 
 
 def test_draw_components_overlay_plain_line_and_polygon():

--- a/src/napari_phasors/_tests/test_batch_analysis.py
+++ b/src/napari_phasors/_tests/test_batch_analysis.py
@@ -279,6 +279,97 @@ def test_calibration_same_for_all(qtbot, make_viewer_model):
     assert not np.array_equal(before, target.metadata["G"])
 
 
+def _make_single_harmonic_layer():
+    from napari.layers import Image
+
+    layer = Image(np.zeros((4, 4)), name="single_harmonic")
+    layer.metadata.update(
+        {
+            "harmonics": [1],
+            "G_original": np.full((1, 4, 4), 0.5),
+            "S_original": np.full((1, 4, 4), 0.3),
+            "G": np.full((1, 4, 4), 0.5),
+            "S": np.full((1, 4, 4), 0.3),
+        }
+    )
+    return layer
+
+
+def test_apply_calibration_correction_reports_harmonic_mismatch():
+    """A calibration with a different harmonic count fails with a clear error.
+
+    Regression: previously this surfaced as a cryptic numpy broadcasting error
+    ("operands could not be broadcast together with shapes ...").
+    """
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = _make_single_harmonic_layer()
+    with pytest.raises(ValueError, match=r"calibration has 2 harmonic"):
+        apply_calibration_correction(
+            layer, np.array([0.1, 0.2]), np.array([1.0, 1.1])
+        )
+
+
+def test_apply_calibration_correction_single_harmonic_array():
+    """A matching single-harmonic (length-1) calibration array applies cleanly."""
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = _make_single_harmonic_layer()
+    apply_calibration_correction(layer, np.array([0.1]), np.array([1.0]))
+    assert layer.metadata["settings"]["calibrated"] is True
+    assert layer.metadata["G"].shape == (1, 4, 4)
+
+
+def _make_two_harmonic_layer():
+    from napari.layers import Image
+
+    layer = Image(np.zeros((4, 4)), name="two_harmonic")
+    layer.metadata.update(
+        {
+            "harmonics": [1, 2],
+            "G_original": np.full((2, 4, 4), 0.5),
+            "S_original": np.full((2, 4, 4), 0.3),
+            "G": np.full((2, 4, 4), 0.5),
+            "S": np.full((2, 4, 4), 0.3),
+        }
+    )
+    return layer
+
+
+def test_apply_calibration_uses_matching_harmonic_subset():
+    """A [1, 2] calibration applied to a [1] file uses only harmonic 1."""
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = _make_single_harmonic_layer()
+    apply_calibration_correction(
+        layer,
+        np.array([0.1, 0.9]),
+        np.array([1.0, 2.0]),
+        calibration_harmonics=[1, 2],
+    )
+    assert layer.metadata["settings"]["calibrated"] is True
+    # Only the harmonic-1 correction is kept/stored, not the harmonic-2 one.
+    assert layer.metadata["settings"]["calibration_phase"] == [0.1]
+    assert layer.metadata["settings"]["calibration_modulation"] == [1.0]
+    assert layer.metadata["G"].shape == (1, 4, 4)
+
+
+def test_apply_calibration_errors_on_uncovered_harmonic():
+    """A file needing a harmonic the calibration lacks raises a clear error."""
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = _make_two_harmonic_layer()
+    with pytest.raises(
+        ValueError, match=r"does not include harmonic\(s\) \[2\]"
+    ):
+        apply_calibration_correction(
+            layer,
+            np.array([0.1]),
+            np.array([1.0]),
+            calibration_harmonics=[1],
+        )
+
+
 def test_calibration_per_subfolder(qtbot, make_viewer_model, tmp_path):
     in_root = tmp_path / "in"
     (in_root / "cond1").mkdir(parents=True)
@@ -3172,6 +3263,135 @@ def test_default_component_line_style_exposes_colormap_gamma():
     from napari_phasors._batch_analysis import default_component_line_style
 
     assert default_component_line_style()["colormap_gamma"] == 1.0
+
+
+def test_apply_component_settings_copies_line_and_overlay_style(
+    qtbot, make_viewer_model
+):
+    """Copying settings applies the persisted line / histogram overlay style.
+
+    Regression: the exported phasor plot ignored the interactively configured
+    line and fraction-histogram overlay because ``_apply_component_settings_to_ui``
+    only read the component coordinates, not ``two_component_line_settings``.
+    """
+    widget = BatchAnalysisWidget(make_viewer_model())
+    qtbot.addWidget(widget)
+
+    settings = {
+        "component_analysis": {
+            "components": {
+                "0": {
+                    "name": "C1",
+                    "gs_harmonics": {"1": {"g": 0.2, "s": 0.3}},
+                },
+                "1": {
+                    "name": "C2",
+                    "gs_harmonics": {"1": {"g": 0.7, "s": 0.4}},
+                },
+            },
+            "two_component_line_settings": {
+                "show_colormap_line": True,
+                "show_component_dots": False,
+                "line_offset": 0.09,
+                "line_width": 5.5,
+                "line_alpha": 0.7,
+                "default_component_color": "#abcdef",
+                "show_fraction_histogram": True,
+                "histogram_overlay_height": 0.44,
+                "histogram_offset": -0.2,
+                "histogram_alpha": 0.6,
+            },
+            "two_components_label_settings": {
+                "fontsize": 18,
+                "bold": True,
+                "italic": True,
+                "color": "red",
+            },
+        }
+    }
+
+    widget._apply_settings_to_ui(settings)
+
+    style = widget._component_line_style
+    assert style["show_component_dots"] is False
+    assert style["line_offset"] == 0.09
+    assert style["line_width"] == 5.5
+    assert style["line_alpha"] == 0.7
+    assert style["default_component_color"] == "#abcdef"
+    assert style["show_fraction_histogram"] is True
+    assert style["histogram_overlay_height"] == 0.44
+    assert style["histogram_offset"] == -0.2
+    assert style["histogram_alpha"] == 0.6
+
+    label_style = widget._component_label_style
+    assert label_style["fontsize"] == 18
+    assert label_style["bold"] is True
+    assert label_style["italic"] is True
+    assert label_style["color"] == "red"
+
+
+def test_apply_component_settings_restores_linear_projection_type(
+    qtbot, make_viewer_model
+):
+    """Copying a Linear Projection keeps the exported colormap line / histogram.
+
+    Regression: rebuilding the component rows dropped the analysis type back to
+    "Component Fit", so ``_collect_components`` produced a "fit" config and
+    ``draw_components_overlay`` skipped the (Linear-Projection-only) colormap
+    line and fraction-histogram overlay even with their checkboxes on.
+    """
+    widget = BatchAnalysisWidget(make_viewer_model())
+    qtbot.addWidget(widget)
+
+    settings = {
+        "component_analysis": {
+            "analysis_type": "Linear Projection",
+            "components": {
+                "0": {
+                    "name": "A",
+                    "gs_harmonics": {"1": {"g": 0.8, "s": 0.3}},
+                },
+                "1": {
+                    "name": "B",
+                    "gs_harmonics": {"1": {"g": 0.2, "s": 0.3}},
+                },
+            },
+            "two_component_line_settings": {
+                "show_colormap_line": True,
+                "show_fraction_histogram": True,
+            },
+        }
+    }
+
+    widget._apply_settings_to_ui(settings)
+
+    assert widget.analysis_type_combo.currentText() == "Linear Projection"
+    config = widget.build_pipeline([1]).components
+    assert config["analysis_type"] == "linear"
+
+
+def test_pipeline_step_annotates_error_with_step_name():
+    """A failing step is re-raised with the analysis (tab) name for context."""
+    from napari_phasors._batch_analysis import _pipeline_step
+
+    with pytest.raises(RuntimeError, match=r"Components failed: boom"):
+        with _pipeline_step("Components"):
+            raise ValueError("boom")
+
+
+def test_apply_pipeline_reports_which_step_failed(monkeypatch):
+    """``apply_pipeline`` surfaces which enabled step raised, not a bare error."""
+    from napari_phasors import _batch_analysis as ba
+
+    pipeline = ba.BatchPipeline(fret={"donor_lifetime": 3.0})
+
+    def boom(*args, **kwargs):
+        raise ValueError("kaboom")
+
+    monkeypatch.setattr(ba, "_apply_fret", boom)
+
+    with pytest.raises(RuntimeError, match=r"FRET failed: kaboom"):
+        ba.apply_pipeline(object(), pipeline)
 
 
 def test_draw_components_overlay_plain_line_and_polygon():

--- a/src/napari_phasors/_tests/test_batch_analysis.py
+++ b/src/napari_phasors/_tests/test_batch_analysis.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -352,6 +353,72 @@ def test_apply_calibration_uses_matching_harmonic_subset():
     assert layer.metadata["settings"]["calibration_phase"] == [0.1]
     assert layer.metadata["settings"]["calibration_modulation"] == [1.0]
     assert layer.metadata["G"].shape == (1, 4, 4)
+
+
+def test_normalize_harmonics_keeps_non_convertible_values():
+    """Values that can't become plain ints are kept as-is instead of raising."""
+    from napari_phasors._utils import _normalize_harmonics
+
+    assert _normalize_harmonics([1, 2]) == [1, 2]
+    assert all(isinstance(v, int) for v in _normalize_harmonics([1, 2]))
+    # A non-numeric value hits the except branch and is passed through.
+    assert _normalize_harmonics(["a"]) == ["a"]
+
+
+def test_apply_calibration_falls_back_to_positional_when_harmonics_mismatch():
+    """A calibration_harmonics list of the wrong length is ignored.
+
+    When the number of calibration_harmonics labels doesn't match the number
+    of phi_zero/mod_zero values, the labels are untrustworthy, so the
+    correction falls back to positional matching instead.
+    """
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = _make_two_harmonic_layer()
+    # 3 harmonic labels but only 2 calibration values: labels are dropped and
+    # the 2 values are matched positionally against the layer's 2 harmonics.
+    apply_calibration_correction(
+        layer,
+        np.array([0.1, 0.2]),
+        np.array([1.0, 1.1]),
+        calibration_harmonics=[1, 2, 3],
+    )
+    assert layer.metadata["settings"]["calibrated"] is True
+    assert layer.metadata["settings"]["calibration_phase"] == [0.1, 0.2]
+
+
+def test_apply_calibration_scalar_single_harmonic():
+    """A scalar (non-array) phi_zero/mod_zero calibrates a single-harmonic layer."""
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = _make_single_harmonic_layer()
+    apply_calibration_correction(layer, 0.1, 1.0)
+    assert layer.metadata["settings"]["calibrated"] is True
+    assert layer.metadata["settings"]["calibration_phase"] == 0.1
+    assert layer.metadata["settings"]["calibration_modulation"] == 1.0
+
+
+def test_apply_calibration_multi_harmonic_without_spatial_dims():
+    """Multi-harmonic calibration on a layer whose G/S have no spatial dims."""
+    from napari.layers import Image
+
+    from napari_phasors._utils import apply_calibration_correction
+
+    layer = Image(np.zeros((4, 4)), name="no_spatial_dims")
+    layer.metadata.update(
+        {
+            "harmonics": [1, 2],
+            "G_original": np.array([0.5, 0.6]),
+            "S_original": np.array([0.3, 0.4]),
+            "G": np.array([0.5, 0.6]),
+            "S": np.array([0.3, 0.4]),
+        }
+    )
+    apply_calibration_correction(
+        layer, np.array([0.1, 0.2]), np.array([1.0, 1.1])
+    )
+    assert layer.metadata["settings"]["calibrated"] is True
+    assert layer.metadata["G"].shape == (2,)
 
 
 def test_apply_calibration_errors_on_uncovered_harmonic():
@@ -4012,3 +4079,314 @@ def test_signal_export_csv_only(qtbot, make_viewer_model, tmp_path):
     assert header[0] == "bin"
     assert any("mean" in h for h in header)
     assert any("std" in h for h in header)
+
+
+# -- Copy settings dialog wiring --------------------------------------------
+
+
+def test_on_copy_settings_shows_error_when_file_read_fails(
+    qtbot, make_viewer_model, monkeypatch
+):
+    """A file chosen in the Copy Settings dialog that fails to parse
+    surfaces the read error via ``show_error`` (rather than raising)."""
+    from qtpy.QtWidgets import QDialog
+
+    widget = BatchAnalysisWidget(make_viewer_model())
+    qtbot.addWidget(widget)
+
+    class _FakeCopyDialog:
+        def __init__(self, layer_names, parent=None):
+            pass
+
+        def exec_(self):
+            return QDialog.Accepted
+
+        def selected_file(self):
+            return "/tmp/bad_settings.ome.tif"
+
+        def selected_layer(self):
+            return None
+
+    monkeypatch.setattr(
+        "napari_phasors._batch_analysis.CopySettingsDialog", _FakeCopyDialog
+    )
+
+    def _raise(path):
+        raise ValueError("bad tiff")
+
+    monkeypatch.setattr(
+        "napari_phasors._batch_analysis.read_ome_tiff_settings", _raise
+    )
+
+    with patch("napari_phasors._batch_analysis.show_error") as mock_show_error:
+        widget._on_copy_settings()
+
+    mock_show_error.assert_called_once_with(
+        "Could not read settings: bad tiff"
+    )
+
+
+def test_on_copy_settings_from_layer_includes_harmonics(
+    qtbot, make_viewer_model, monkeypatch
+):
+    """Copying from a layer (no file chosen) folds the layer's harmonics
+    into the settings dict passed on to the UI."""
+    from qtpy.QtWidgets import QDialog
+
+    viewer = make_viewer_model()
+    widget = BatchAnalysisWidget(viewer)
+    qtbot.addWidget(widget)
+
+    layer = _make_phasor_layer(name="Source", harmonic=[1, 2])
+    viewer.add_layer(layer)
+    assert layer.metadata.get("harmonics") is not None
+
+    class _FakeCopyDialog:
+        def __init__(self, layer_names, parent=None):
+            pass
+
+        def exec_(self):
+            return QDialog.Accepted
+
+        def selected_file(self):
+            return ""
+
+        def selected_layer(self):
+            return layer.name
+
+    monkeypatch.setattr(
+        "napari_phasors._batch_analysis.CopySettingsDialog", _FakeCopyDialog
+    )
+
+    captured = {}
+
+    def _fake_apply(settings):
+        captured["settings"] = settings
+
+    monkeypatch.setattr(widget, "_apply_settings_to_ui", _fake_apply)
+
+    widget._on_copy_settings()
+
+    assert captured["settings"]["harmonics"] == layer.metadata["harmonics"]
+
+
+# -- End-of-batch summary reporting -----------------------------------------
+
+
+def test_run_batch_reports_failed_files_via_show_error(
+    qtbot, make_viewer_model, tmp_path, monkeypatch
+):
+    """A file that errors during read/compute is collected into ``failed``
+    and reported (with its name and error message) via ``show_error`` in the
+    end-of-batch summary, alongside the successfully processed count."""
+    in_root = tmp_path / "in"
+    in_root.mkdir()
+    out_root = tmp_path / "out"
+    out_root.mkdir()
+
+    write_ome_tiff(
+        str(in_root / "good.ome.tif"), _make_phasor_layer(name="good")
+    )
+    write_ome_tiff(
+        str(in_root / "bad.ome.tif"), _make_phasor_layer(name="bad")
+    )
+
+    widget = BatchAnalysisWidget(make_viewer_model())
+    qtbot.addWidget(widget)
+    widget._input_folder = str(in_root)
+    widget._rescan()
+    idx = widget.format_combobox.findData(".ome.tif")
+    widget.format_combobox.setCurrentIndex(idx)
+    widget._export_folder = str(out_root)
+    widget.export_ometiff_checkbox.setChecked(True)
+
+    original = BatchAnalysisWidget._read_compute_file
+
+    def flaky_read_compute(self, path, *args, **kwargs):
+        if os.path.basename(path) == "bad.ome.tif":
+            raise RuntimeError("boom")
+        return original(self, path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        BatchAnalysisWidget, "_read_compute_file", flaky_read_compute
+    )
+
+    with patch("napari_phasors._batch_analysis.show_error") as mock_show_error:
+        widget.run_batch()
+
+    mock_show_error.assert_called_once()
+    message = mock_show_error.call_args[0][0]
+    assert "Batch complete: 1/2 files processed." in message
+    assert "1 failed." in message
+    assert "bad.ome.tif: boom" in message
+    assert (out_root / "OME-TIFF" / "good.ome.tif").exists()
+
+
+# -- Component-fraction overlay edge cases ----------------------------------
+
+
+def test_components_overlay_returns_original_when_component_coords_missing():
+    """No component_real/component_imag in the overlay leaves it unchanged."""
+    real = np.array([0.3, 0.5])
+    imag = np.array([0.2, 0.4])
+    overlay = {
+        "kind": "components",
+        "components": {
+            "analysis_type": "linear",
+            "line_style": {"show_fraction_histogram": True},
+        },
+    }
+    out = BatchAnalysisWidget._components_overlay_with_fraction_data(
+        overlay, real, imag
+    )
+    assert out is overlay
+    assert "fraction_data" not in out
+
+
+def test_components_overlay_squeezes_multi_dim_component_arrays():
+    """A ``(1, N)``-shaped component real/imag pair (as produced by some
+    component-fit paths) is squeezed to 1-D before the fraction is computed."""
+    rng = np.random.default_rng(1)
+    real = rng.uniform(0.2, 0.8, 200)
+    imag = rng.uniform(0.1, 0.5, 200)
+    overlay = {
+        "kind": "components",
+        "components": {
+            "analysis_type": "linear",
+            "component_real": [[0.2, 0.8]],
+            "component_imag": [[0.1, 0.5]],
+            "line_style": {"show_fraction_histogram": True},
+        },
+    }
+    out = BatchAnalysisWidget._components_overlay_with_fraction_data(
+        overlay, real, imag
+    )
+    assert out["fraction_data"].shape == real.shape
+    assert np.asarray(out["fraction_data"], dtype=float).dtype == np.float64
+
+
+def test_components_overlay_returns_original_when_fraction_computation_fails(
+    monkeypatch,
+):
+    """If ``phasor_component_fraction`` raises, the overlay is returned
+    unchanged instead of propagating the exception."""
+    import napari_phasors._batch_analysis as ba
+
+    real = np.array([0.3, 0.5])
+    imag = np.array([0.2, 0.4])
+    overlay = {
+        "kind": "components",
+        "components": {
+            "analysis_type": "linear",
+            "component_real": [0.2, 0.8],
+            "component_imag": [0.1, 0.5],
+            "line_style": {"show_fraction_histogram": True},
+        },
+    }
+
+    def _raise(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ba, "phasor_component_fraction", _raise)
+
+    out = ba.BatchAnalysisWidget._components_overlay_with_fraction_data(
+        overlay, real, imag
+    )
+
+    assert out is overlay
+    assert "fraction_data" not in out
+
+
+# -- Mapping-overlay coloring (Phase / Modulation) --------------------------
+
+
+def test_save_phasor_plot_png_colors_by_modulation(tmp_path, monkeypatch):
+    """A mapping overlay with ``color_by == "Modulation"`` colors the exported
+    plot by the modulation metric (not phase)."""
+    from phasorpy.phasor import phasor_to_polar
+
+    import napari_phasors._batch_analysis as ba
+
+    rng = np.random.default_rng(2)
+    real = rng.uniform(-0.4, 0.9, 300)
+    imag = rng.uniform(-0.4, 0.9, 300)
+
+    captured = {}
+
+    def _fake_color_plot_by_metric(
+        plot, real_, imag_, metric, cmap, display, plot_type, value_range=None
+    ):
+        captured["metric"] = metric
+
+    monkeypatch.setattr(
+        ba, "_color_plot_by_metric", _fake_color_plot_by_metric
+    )
+
+    display = {"plot_type": "Scatter", "semi_circle": True}
+    overlay = {"kind": "mapping", "color_by": "Modulation"}
+
+    ba._save_phasor_plot_png(
+        real, imag, display, overlay, str(tmp_path / "out.png")
+    )
+
+    _, expected_modulation = phasor_to_polar(real, imag)
+    assert "metric" in captured
+    np.testing.assert_allclose(captured["metric"], expected_modulation)
+
+
+class _FakeMetricAx:
+    """Minimal stand-in for ``PhasorPlot.ax`` that records ``scatter`` kwargs."""
+
+    def scatter(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeMetricPlot:
+    def __init__(self):
+        self.ax = _FakeMetricAx()
+
+
+def test_color_plot_by_metric_resolves_default_colormap_when_cmap_is_none():
+    """A ``None`` colormap resolves to the "jet" default rather than being
+    passed through as-is."""
+    import napari_phasors._batch_analysis as ba
+
+    plot = _FakeMetricPlot()
+    real = np.array([0.1, 0.2, 0.3])
+    imag = np.array([0.1, 0.2, 0.3])
+    metric = np.array([10.0, 20.0, 30.0])
+
+    ba._color_plot_by_metric(plot, real, imag, metric, None, {}, "Scatter")
+
+    assert plot.ax.kwargs["cmap"] is not None
+
+
+def test_color_plot_by_metric_falls_back_to_jet_when_resolution_fails(
+    monkeypatch,
+):
+    """If resolving the requested colormap name returns ``None``, the
+    function falls back to resolving "jet" instead of leaving ``cmap=None``."""
+    import napari_phasors._batch_analysis as ba
+
+    real_resolve = ba.resolve_colormap_by_name
+    calls = {"n": 0}
+
+    def flaky_resolve(name):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return real_resolve(name)
+
+    monkeypatch.setattr(ba, "resolve_colormap_by_name", flaky_resolve)
+
+    plot = _FakeMetricPlot()
+    real = np.array([0.1, 0.2, 0.3])
+    imag = np.array([0.1, 0.2, 0.3])
+    metric = np.array([10.0, 20.0, 30.0])
+
+    ba._color_plot_by_metric(
+        plot, real, imag, metric, "viridis", {}, "Scatter"
+    )
+
+    assert calls["n"] == 2
+    assert plot.ax.kwargs["cmap"] is not None

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -2424,12 +2424,12 @@ def test_center_fill_slider_paint_event_zero_span(qtbot):
     qtbot.addWidget(slider)
     slider.setMinimum(0)
     slider.setMaximum(0)
+    slider.resize(100, 20)
 
-    slider.show()
-    # Forces a synchronous call to paintEvent; the span==0 guard must return
-    # early without error.
-    slider.repaint()
-    slider.close()
+    # QWidget.grab() forces a synchronous paint (unlike repaint(), which
+    # only schedules one on the offscreen platform used in tests); the
+    # span==0 guard must return early without error.
+    slider.grab()
 
 
 def test_restore_fraction_layer_colormaps_applies_gamma(

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -1,11 +1,20 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import LineCollection
+from napari.layers import Image
 from phasorpy.component import phasor_component_fraction
 from phasorpy.lifetime import phasor_from_lifetime
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QColorDialog
 
 from napari_phasors._tests.test_plotter import create_image_layer_with_phasors
+from napari_phasors.components_tab import (
+    CenterFillSlider,
+    draw_components_overlay,
+    draw_fraction_histogram_overlay,
+)
 from napari_phasors.plotter import PlotterWidget
 
 
@@ -2407,3 +2416,576 @@ def test_components_widget_fraction_histogram_offset_flips_side(
 
     # Flipping the sign puts the apex on the opposite side of the line.
     assert not np.allclose(pos_apex, neg_apex)
+
+
+def test_center_fill_slider_paint_event_zero_span(qtbot):
+    """paintEvent should no-op (not raise) when minimum == maximum."""
+    slider = CenterFillSlider()
+    qtbot.addWidget(slider)
+    slider.setMinimum(0)
+    slider.setMaximum(0)
+
+    slider.show()
+    # Forces a synchronous call to paintEvent; the span==0 guard must return
+    # early without error.
+    slider.repaint()
+    slider.close()
+
+
+def test_restore_fraction_layer_colormaps_applies_gamma(
+    make_viewer_model, qtbot
+):
+    """Saved settings with a non-None gamma are applied to the fraction
+    layer by ``_restore_fraction_layer_colormaps``."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    assert comp.comp1_fractions_layer is not None
+
+    settings = {
+        "components": {
+            "0": {
+                "name": "Component 1",
+                "gs_harmonics": {
+                    "1": {
+                        "colormap_name": "viridis",
+                        "gamma": 2.0,
+                    }
+                },
+            }
+        }
+    }
+    comp._restore_fraction_layer_colormaps(settings, "1")
+
+    assert comp.comp1_fractions_layer.gamma == 2.0
+
+
+def test_on_color_button_clicked_updates_color_and_metadata(
+    make_viewer_model, qtbot
+):
+    """Picking a valid color from the dialog updates the button, the stored
+    default color, and the persisted metadata setting."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    comp._open_plot_settings_dialog()
+
+    with patch.object(
+        QColorDialog, "getColor", return_value=QColor("#ff0000")
+    ):
+        comp._on_color_button_clicked()
+
+    assert comp.default_component_color == "#ff0000"
+    settings = layer.metadata["settings"]["component_analysis"]
+    assert (
+        settings["two_component_line_settings"]["default_component_color"]
+        == "#ff0000"
+    )
+
+
+def _is_connected(emitter, bound_method):
+    """Check whether ``bound_method`` is connected to a napari ``emitter``.
+
+    Napari event emitters store callbacks for bound methods as
+    ``(weakref_to_instance, method_name)`` tuples rather than the bound
+    method object itself, so a plain ``in`` check does not work.
+    """
+    for cb in emitter.callbacks:
+        if (
+            isinstance(cb, tuple)
+            and cb[0]() is bound_method.__self__
+            and cb[1] == bound_method.__name__
+        ):
+            return True
+        if cb is bound_method:
+            return True
+    return False
+
+
+def test_apply_saved_colormap_settings_exception_reconnects_gamma(
+    make_viewer_model, qtbot
+):
+    """When applying saved colormap settings raises, the except-branch must
+    still reconnect the colormap/contrast_limits/gamma events."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    assert comp.comp1_fractions_layer is not None
+
+    # An invalid colormap name raises inside the try block, forcing the
+    # except branch (which re-connects the events) to run.
+    comp._saved_colormap_name = "not_a_real_colormap_xyz"
+    comp._saved_colormap_colors = None
+    comp._saved_contrast_limits = (0.0, 1.0)
+
+    comp._apply_saved_colormap_settings()
+
+    assert _is_connected(
+        comp.comp1_fractions_layer.events.gamma, comp._on_colormap_changed
+    )
+    assert _is_connected(
+        comp.comp1_fractions_layer.events.colormap, comp._on_colormap_changed
+    )
+
+
+def test_on_histogram_offset_changed_updates_metadata_and_redraws(
+    make_viewer_model, qtbot
+):
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    comp.show_fraction_histogram = True
+
+    comp._on_histogram_offset_changed(0.3)
+
+    assert comp.histogram_offset == 0.3
+    settings = layer.metadata["settings"]["component_analysis"]
+    assert settings["two_component_line_settings"]["histogram_offset"] == 0.3
+
+
+def test_on_histogram_transparency_changed_updates_metadata_and_redraws(
+    make_viewer_model, qtbot
+):
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    comp.show_fraction_histogram = True
+
+    comp._on_histogram_transparency_changed(0.4)
+
+    assert abs(comp.histogram_alpha - 0.6) < 1e-9
+    settings = layer.metadata["settings"]["component_analysis"]
+    assert (
+        abs(settings["two_component_line_settings"]["histogram_alpha"] - 0.6)
+        < 1e-9
+    )
+
+
+class _RemoveRaisesArtist:
+    """Fake artist whose ``remove`` raises, exercising the suppressed
+    ValueError/AttributeError branch in ``_remove_histogram_overlay``."""
+
+    def remove(self):
+        raise ValueError("boom")
+
+
+def test_remove_histogram_overlay_single_artist(make_viewer_model, qtbot):
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    # Single artist (not a list/tuple) - exercises the wrap-into-list branch.
+    comp.component_histogram = _RemoveRaisesArtist()
+    comp._remove_histogram_overlay()
+    assert comp.component_histogram is None
+
+
+def test_get_all_artists_and_set_artists_visible_single_histogram_artist(
+    make_viewer_model, qtbot
+):
+    """``get_all_artists``/``set_artists_visible`` wrap a non-list/tuple
+    ``component_histogram`` into a single-element list before use."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    fake_artist = MagicMock()
+    comp.component_histogram = fake_artist
+
+    artists = comp.get_all_artists()
+    assert fake_artist in artists
+
+    comp.set_artists_visible(True)
+    fake_artist.set_visible.assert_called_once_with(True)
+
+
+def test_get_first_component_fraction_values_pools_multiple_layers(
+    make_viewer_model, qtbot
+):
+    """Fraction values are pooled (and non-finite values dropped) across
+    every fraction layer matching the first component's name."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    assert comp.comp1_fractions_layer is not None
+
+    comp1_name = comp.components[0].name_edit.text().strip() or "Component 1"
+    extra_layer = Image(
+        np.array([[0.25, 0.75], [np.nan, 0.5]]),
+        name=f"{comp1_name} fractions: other_image",
+    )
+    viewer.add_layer(extra_layer)
+
+    values = comp._get_first_component_fraction_values()
+
+    assert not np.any(np.isnan(values))
+    original_size = np.asarray(
+        comp.comp1_fractions_layer.data, dtype=float
+    ).size
+    assert values.size == original_size + 3
+
+
+def test_get_first_component_fraction_values_fallback_to_comp1_layer(
+    make_viewer_model, qtbot
+):
+    """When no fraction layer matches the live component name, values fall
+    back to ``comp1_fractions_layer`` directly."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    assert comp.comp1_fractions_layer is not None
+
+    # Renaming after analysis means no viewer layer matches the new name.
+    comp.components[0].name_edit.setText("Renamed Component")
+
+    values = comp._get_first_component_fraction_values()
+    expected = np.asarray(comp.comp1_fractions_layer.data, dtype=float).ravel()
+    expected = expected[np.isfinite(expected)]
+    assert values.size == expected.size
+    assert values.size > 0
+
+
+def test_get_first_component_fraction_values_returns_empty_with_no_data(
+    make_viewer_model, qtbot
+):
+    """With no fraction layers and no comp1_fractions_layer, an empty array
+    is returned."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    assert comp.comp1_fractions_layer is None
+
+    values = comp._get_first_component_fraction_values()
+    assert values.size == 0
+
+
+def test_draw_colormap_line_jet_fallback(make_viewer_model, qtbot):
+    """``_draw_colormap_line`` falls back to ``plt.cm.jet`` when
+    ``fractions_colormap`` is unset."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    comp.fractions_colormap = None
+
+    fig, ax = plt.subplots()
+    try:
+        comp._draw_colormap_line(ax, 0.0, 0.0, 1.0, 1.0)
+    finally:
+        plt.close(fig)
+
+
+def test_sync_component_layers_gamma_guard_returns_early(
+    make_viewer_model, qtbot
+):
+    """``_sync_component_layers_gamma`` returns immediately (without
+    touching any layers) while ``_updating_linked_layers`` is already
+    True."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    comp._updating_linked_layers = True
+
+    with patch.object(comp, "_get_all_layers_for_component") as mock_get:
+        comp._sync_component_layers_gamma(0, 1.5)
+
+    mock_get.assert_not_called()
+
+
+def test_find_and_reconnect_layer_expected_name(make_viewer_model, qtbot):
+    """Reconnecting via the expected layer name connects the gamma event."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    fraction_layer = Image(
+        np.zeros((5, 5)), name="Component 1 fractions: img1"
+    )
+    viewer.add_layer(fraction_layer)
+
+    comp._find_and_reconnect_layer(
+        "Component 1 fractions: img1", "Component 1", "img1", 0
+    )
+
+    assert comp.comp1_fractions_layer is fraction_layer
+    assert _is_connected(
+        fraction_layer.events.gamma, comp._on_colormap_changed
+    )
+
+
+def test_find_and_reconnect_layer_possible_names(make_viewer_model, qtbot):
+    """Reconnecting via one of the fallback naming conventions renames the
+    layer and connects the gamma event."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    fraction_layer = Image(
+        np.zeros((5, 5)), name="Component 1 fractions: img2"
+    )
+    viewer.add_layer(fraction_layer)
+
+    comp._find_and_reconnect_layer(
+        "Component 1 fractions: RENAMED", "Component 1", "img2", 0
+    )
+
+    assert comp.comp1_fractions_layer is fraction_layer
+    assert fraction_layer.name == "Component 1 fractions: RENAMED"
+    assert _is_connected(
+        fraction_layer.events.gamma, comp._on_colormap_changed
+    )
+
+
+def test_get_inverted_colormap_name_fallback(make_viewer_model, qtbot):
+    """Non-standard colormap names without explicit colors fall back to the
+    ``_r``-suffix inversion convention (the fallback name is a literal
+    ``jet``/``jet_r`` pair keyed only off whether the input already ends in
+    ``_r``)."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+
+    assert comp._get_inverted_colormap("zzz_not_a_real_colormap") == "jet_r"
+    assert comp._get_inverted_colormap("zzz_not_a_real_colormap_r") == "jet"
+
+
+def test_linear_projection_preserves_gamma_on_redisplay(
+    make_viewer_model, qtbot
+):
+    """Re-triggering the same analysis preserves a manually-set gamma on the
+    already-displayed comp1 fraction layer."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_linear_projection(comp)
+    assert comp.comp1_fractions_layer is not None
+
+    comp.comp1_fractions_layer.gamma = 2.5
+    comp._run_analysis()
+
+    assert comp.comp1_fractions_layer.gamma == 2.5
+
+
+def test_linear_projection_restores_saved_gamma_from_metadata(
+    make_viewer_model, qtbot
+):
+    """A gamma value saved in metadata under the first component's harmonic
+    data is picked up when the fraction layer is first created."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    layer.metadata["settings"]["component_analysis"] = {
+        "components": {
+            "0": {
+                "name": "Component 1",
+                "gs_harmonics": {
+                    "1": {
+                        "analysis_type": "Linear Projection",
+                        "colormap_name": "viridis",
+                        "gamma": 2.75,
+                    }
+                },
+            },
+            "1": {"name": "Component 2", "gs_harmonics": {}},
+        },
+    }
+
+    _setup_linear_projection(comp)
+
+    assert comp.comp1_fractions_layer is not None
+    assert comp.comp1_fractions_layer.gamma == 2.75
+
+
+def test_component_fit_restores_saved_gamma_for_non_first_component(
+    make_viewer_model, qtbot
+):
+    """Gamma saved under a non-first component's harmonic data is restored
+    when its fraction layer is (re-)created during Component Fit."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    layer.metadata["settings"]["component_analysis"] = {
+        "components": {
+            "0": {"name": "Component 1", "gs_harmonics": {}},
+            "1": {
+                "name": "Component 2",
+                "gs_harmonics": {
+                    "1": {
+                        "analysis_type": "Component Fit",
+                        "colormap_name": "viridis",
+                        "gamma": 3.25,
+                    }
+                },
+            },
+        },
+    }
+
+    comp.analysis_type_combo.setCurrentText("Component Fit")
+    comp.components[0].g_edit.setText("0.2")
+    comp.components[0].s_edit.setText("0.1")
+    comp._on_component_coords_changed(0)
+    comp.components[1].g_edit.setText("0.8")
+    comp.components[1].s_edit.setText("0.5")
+    comp._on_component_coords_changed(1)
+    comp._run_analysis()
+
+    assert len(comp.fraction_layers) == 2
+    assert comp.fraction_layers[1].gamma == 3.25
+
+
+def _valid_histogram_values():
+    return np.concatenate(
+        [np.full(20, 0.3), np.full(30, 0.6), np.full(5, 0.9)]
+    )
+
+
+def test_draw_fraction_histogram_overlay_empty_values_returns_none():
+    fig, ax = plt.subplots()
+    try:
+        result = draw_fraction_histogram_overlay(
+            ax, 0.0, 0.0, 1.0, 1.0, np.array([np.nan, np.nan]), None
+        )
+    finally:
+        plt.close(fig)
+    assert result is None
+
+
+def test_draw_fraction_histogram_overlay_all_values_out_of_range():
+    """Values entirely outside the fixed [0, 1] histogram range produce an
+    all-zero histogram (``counts.max() == 0``)."""
+    fig, ax = plt.subplots()
+    try:
+        result = draw_fraction_histogram_overlay(
+            ax, 0.0, 0.0, 1.0, 1.0, np.full(10, 5.0), None
+        )
+    finally:
+        plt.close(fig)
+    assert result is None
+
+
+def test_draw_fraction_histogram_overlay_smoothed_peak_not_positive():
+    """If the (best-effort) smoothing step collapses the histogram to all
+    zeros, the function bails out instead of drawing a degenerate curve."""
+    fig, ax = plt.subplots()
+    try:
+        with patch(
+            "scipy.ndimage.gaussian_filter1d",
+            return_value=np.zeros(150),
+        ):
+            result = draw_fraction_histogram_overlay(
+                ax, 0.0, 0.0, 1.0, 1.0, _valid_histogram_values(), None
+            )
+    finally:
+        plt.close(fig)
+    assert result is None
+
+
+def test_draw_fraction_histogram_overlay_zero_length_line():
+    fig, ax = plt.subplots()
+    try:
+        result = draw_fraction_histogram_overlay(
+            ax, 0.5, 0.5, 0.5, 0.5, _valid_histogram_values(), None
+        )
+    finally:
+        plt.close(fig)
+    assert result is None
+
+
+def test_draw_fraction_histogram_overlay_normal_flip_sign():
+    """A line direction whose default normal points 'down' is flipped so it
+    still points up (the ``ny < 0`` branch)."""
+    fig, ax = plt.subplots()
+    try:
+        # dx = -1, dy = 0 -> default normal (0, -1) has ny < 0 and gets flipped.
+        result = draw_fraction_histogram_overlay(
+            ax, 1.0, 0.0, 0.0, 0.0, _valid_histogram_values(), None
+        )
+    finally:
+        plt.close(fig)
+    assert result is not None
+
+
+def test_draw_fraction_histogram_overlay_zero_height_returns_none():
+    """A zero overlay height collapses every bar to zero (``v_max <= 0``)."""
+    fig, ax = plt.subplots()
+    try:
+        result = draw_fraction_histogram_overlay(
+            ax,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            _valid_histogram_values(),
+            None,
+            height=0.0,
+        )
+    finally:
+        plt.close(fig)
+    assert result is None
+
+
+def test_draw_fraction_histogram_overlay_degenerate_contrast_limits():
+    """``vmax <= vmin`` in the contrast limits is nudged apart instead of
+    raising in the normalization step."""
+    fig, ax = plt.subplots()
+    try:
+        result = draw_fraction_histogram_overlay(
+            ax,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            _valid_histogram_values(),
+            None,
+            contrast_limits=(0.5, 0.5),
+        )
+    finally:
+        plt.close(fig)
+    assert result is not None
+
+
+def test_draw_fraction_histogram_overlay_gamma_power_norm():
+    from matplotlib.colors import PowerNorm
+
+    fig, ax = plt.subplots()
+    try:
+        result = draw_fraction_histogram_overlay(
+            ax,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            _valid_histogram_values(),
+            None,
+            contrast_limits=(0.0, 1.0),
+            gamma=2.0,
+        )
+    finally:
+        plt.close(fig)
+    assert result is not None
+    assert isinstance(result[0].norm, PowerNorm)
+
+
+def test_draw_fraction_histogram_overlay_fractions_colormap_branches():
+    """Small (<=32 entries) colormaps use a smoothly-interpolated colormap;
+    an unset colormap falls back to ``jet``."""
+    fig, ax = plt.subplots()
+    try:
+        small_colormap = [
+            [0.0, 0.0, 0.0, 1.0],
+            [0.5, 0.5, 0.5, 1.0],
+            [1.0, 1.0, 1.0, 1.0],
+        ]
+        result_small = draw_fraction_histogram_overlay(
+            ax, 0.0, 0.0, 1.0, 1.0, _valid_histogram_values(), small_colormap
+        )
+        assert result_small is not None
+
+        result_none = draw_fraction_histogram_overlay(
+            ax, 0.0, 0.0, 1.0, 1.0, _valid_histogram_values(), None
+        )
+        assert result_none is not None
+        assert result_none[0].get_cmap() is plt.cm.jet
+    finally:
+        plt.close(fig)
+
+
+def test_draw_components_overlay_draws_fraction_histogram():
+    """``draw_components_overlay`` delegates to
+    ``draw_fraction_histogram_overlay`` when Linear Projection, the fraction
+    histogram setting, fraction data, and a fractions colormap are all
+    present."""
+    fig, ax = plt.subplots()
+    try:
+        settings = {
+            "show_fraction_histogram": True,
+            "fraction_data": _valid_histogram_values(),
+            "fractions_colormap": [
+                [0.0, 0.0, 0.0, 1.0],
+                [1.0, 1.0, 1.0, 1.0],
+            ],
+            "colormap_contrast_limits": (0.0, 1.0),
+        }
+        with patch(
+            "napari_phasors.components_tab.draw_fraction_histogram_overlay"
+        ) as mock_draw:
+            draw_components_overlay(
+                ax,
+                [0.6, 0.3],
+                [0.3, 0.2],
+                names=["Component 1", "Component 2"],
+                analysis_type="Linear Projection",
+                settings=settings,
+            )
+        mock_draw.assert_called_once()
+    finally:
+        plt.close(fig)

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -394,16 +394,21 @@ def test_components_widget_line_settings_dialog_effects(
     comp_widget._on_plot_setting_changed()
     assert comp_widget.show_colormap_line
 
-    # Change offset
-    comp_widget.line_offset_slider.setValue(120)  # 0.120
+    # Change offset (slider uses 3-decimal factor: 120 -> 0.120)
+    comp_widget.line_offset_slider.setValue(120)
     assert abs(comp_widget.line_offset - 0.12) < 1e-6
+
+    # Values can also be typed directly via the spinbox, which drives the slider.
+    comp_widget.line_offset_spin.setValue(-0.25)
+    assert abs(comp_widget.line_offset + 0.25) < 1e-6
+    assert comp_widget.line_offset_slider.value() == -250
 
     # Change width
     comp_widget.line_width_spin.setValue(5.0)
     assert comp_widget.line_width == 5.0
 
-    # Change alpha
-    comp_widget.line_alpha_slider.setValue(55)
+    # Transparency (inverse of alpha): 0.45 transparency -> 0.55 opacity
+    comp_widget.line_transparency_spin.setValue(0.45)
     assert abs(comp_widget.line_alpha - 0.55) < 1e-6
 
 
@@ -1126,18 +1131,14 @@ def test_components_histogram_multi_layer_linear_projection(
     comp_widget.histogram_component_combobox.setCurrentText(name1)
     comp_widget.update_component_histogram()
 
-    # One histogram dataset is stored per source image layer.
-    assert set(comp_widget.histogram_widget._datasets.keys()) == {
-        "layer_a",
-        "layer_b",
-    }
+    # All selected layers are pooled into a single merged histogram (rather
+    # than a per-layer mean +/- SD that looks like just one layer).
+    assert set(comp_widget.histogram_widget._datasets.keys()) == {"Layer"}
+    assert comp_widget.histogram_widget._show_sd is False
 
-    # The range slider clips every layer and keeps the per-layer histogram.
+    # The range slider clips every layer and keeps the merged histogram.
     comp_widget._on_fraction_range_changed(0.2, 0.8)
-    assert set(comp_widget.histogram_widget._datasets.keys()) == {
-        "layer_a",
-        "layer_b",
-    }
+    assert set(comp_widget.histogram_widget._datasets.keys()) == {"Layer"}
 
     # Early returns: an empty and an unresolved selection are both no-ops.
     comp_widget.histogram_component_combobox.blockSignals(True)
@@ -1150,6 +1151,52 @@ def test_components_histogram_multi_layer_linear_projection(
     comp_widget.histogram_component_combobox.setCurrentText("Ghost component")
     comp_widget.histogram_component_combobox.blockSignals(False)
     comp_widget._on_fraction_range_changed(0.1, 0.9)
+
+
+def test_components_gamma_links_layers_and_histogram(
+    make_viewer_model,
+    qtbot,
+):
+    """Changing gamma on one fraction layer syncs siblings and the histogram."""
+    viewer = make_viewer_model()
+    layer_a = create_image_layer_with_phasors()
+    layer_a.name = "layer_a"
+    layer_b = create_image_layer_with_phasors()
+    layer_b.name = "layer_b"
+    viewer.add_layer(layer_a)
+    viewer.add_layer(layer_b)
+
+    parent = PlotterWidget(viewer)
+    comp_widget = parent.components_tab
+    parent.tab_widget.setCurrentWidget(parent.components_tab)
+
+    comp_widget.analysis_type_combo.setCurrentText("Linear Projection")
+    comp_widget.components[0].g_edit.setText("0.2")
+    comp_widget.components[0].s_edit.setText("0.1")
+    comp_widget._on_component_coords_changed(0)
+    comp_widget.components[1].g_edit.setText("0.8")
+    comp_widget.components[1].s_edit.setText("0.5")
+    comp_widget._on_component_coords_changed(1)
+
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_a, layer_b]
+    ):
+        comp_widget._run_analysis()
+
+    # The first component owns one fraction layer per analyzed image.
+    first_component_layers = comp_widget._get_all_layers_for_component(0)
+    assert len(first_component_layers) == 2
+
+    name1, _ = comp_widget._linear_projection_component_names()
+    comp_widget.histogram_component_combobox.setCurrentText(name1)
+
+    # Changing gamma on one layer propagates to the sibling layer, the stored
+    # gradient gamma, and the histogram widget.
+    first_component_layers[0].gamma = 0.5
+
+    assert first_component_layers[1].gamma == 0.5
+    assert comp_widget.fractions_gamma == 0.5
+    assert comp_widget.histogram_widget.gamma == 0.5
 
 
 def test_components_stats_combobox_mirrors_histogram_combobox(
@@ -1643,6 +1690,24 @@ def test_color_action_widget_and_dialog(make_viewer_model, qtbot):
 # ---------------------------------------------------------------------------
 
 
+def test_components_histogram_dock_reserves_selector_row_height(
+    make_viewer_model, qtbot
+):
+    """The components histogram dock is taller than tabs without a selector row.
+
+    The docked histogram area is clamped to its minimum height, and the
+    Components tab uniquely adds a "Component:" selector row above the plot, so
+    its dock must reserve extra height to keep the whole canvas visible.
+    """
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+
+    components_min = parent.components_histogram_dock_widget.minimumHeight()
+    mapping_min = parent.phasor_map_histogram_dock_widget.minimumHeight()
+
+    assert components_min > mapping_min
+
+
 def _setup_components(make_viewer_model, freq=80.0):
     viewer = make_viewer_model()
     layer = create_image_layer_with_phasors()
@@ -1860,6 +1925,46 @@ def test_components_component_fit_three_and_colors(make_viewer_model, qtbot):
     # and a smaller count.
     assert comp._get_component_colors_for_count(3) is not None
     assert comp._get_component_colors_for_count(2) is not None
+
+
+def test_components_redisplay_preserves_display_settings(
+    make_viewer_model, qtbot
+):
+    """Re-displaying fraction images keeps manual colormap/contrast/gamma."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    comp._add_component()
+    comp.analysis_type_combo.setCurrentText("Component Fit")
+    for i, (g, s) in enumerate(
+        [("0.2", "0.1"), ("0.5", "0.3"), ("0.8", "0.5")]
+    ):
+        comp.components[i].g_edit.setText(g)
+        comp.components[i].s_edit.setText(s)
+        comp._on_component_coords_changed(i)
+
+    comp._run_analysis()
+    assert len(comp.fraction_layers) == 3
+
+    # Record the default colormap of an untouched layer, then manually tweak
+    # a different one's colormap, contrast limits and gamma.
+    other_layer = comp.fraction_layers[0]
+    other_colormap = other_layer.colormap.name
+
+    tweaked_layer = comp.fraction_layers[1]
+    tweaked_layer.colormap = "magma"
+    tweaked_layer.contrast_limits = (0.15, 0.85)
+    tweaked_layer.gamma = 0.4
+
+    # Press "Display Component Fraction Images" again.
+    comp._run_analysis()
+
+    new_tweaked = viewer.layers[tweaked_layer.name]
+    assert new_tweaked.colormap.name == "magma"
+    assert np.allclose(new_tweaked.contrast_limits, (0.15, 0.85))
+    assert new_tweaked.gamma == 0.4
+
+    # The untouched layer must keep its (default) colormap, not reset.
+    new_other = viewer.layers[other_layer.name]
+    assert new_other.colormap.name == other_colormap
 
 
 def test_components_auto_place_by_index(make_viewer_model, qtbot):
@@ -2128,3 +2233,108 @@ def test_components_widget_exceptions(make_viewer_model, qtbot):
     layer.metadata["G"] = np.ones((2, 10, 10))
     layer.metadata["harmonics"] = np.array([999])
     comp._run_analysis()  # Should return early
+
+
+def test_components_widget_fraction_histogram_overlay(
+    make_viewer_model,
+    qtbot,
+):
+    """Fraction histogram overlay is drawn/removed with the setting toggle."""
+    from matplotlib.image import AxesImage
+
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    comp_widget = parent.components_tab
+    parent.tab_widget.setCurrentWidget(comp_widget)
+
+    _setup_linear_projection(comp_widget)
+
+    # No overlay by default.
+    assert comp_widget.show_fraction_histogram is False
+    assert comp_widget.component_histogram is None
+
+    # Enable the overlay and redraw.
+    comp_widget.show_fraction_histogram = True
+    comp_widget.draw_line_between_components()
+
+    assert comp_widget.component_histogram is not None
+    # The overlay is a single seamless gradient image (no outline).
+    assert len(comp_widget.component_histogram) == 1
+    fill = comp_widget.component_histogram[0]
+    assert isinstance(fill, AxesImage)
+    assert fill in comp_widget.get_all_artists()
+    assert fill.get_alpha() == comp_widget.histogram_alpha
+
+    # Disable again -> overlay removed on next draw.
+    comp_widget.show_fraction_histogram = False
+    comp_widget.draw_line_between_components()
+    assert comp_widget.component_histogram is None
+
+
+def test_components_widget_fraction_histogram_height_setting(
+    make_viewer_model,
+    qtbot,
+):
+    """Overlay height scales the histogram profile."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    comp_widget = parent.components_tab
+    parent.tab_widget.setCurrentWidget(comp_widget)
+
+    _setup_linear_projection(comp_widget)
+
+    comp_widget.show_fraction_histogram = True
+
+    def _profile_height():
+        comp_widget.draw_line_between_components()
+        # The gradient image extent is in the local (u, v) frame; its top edge
+        # (v_max) scales linearly with the height setting.
+        im = comp_widget.component_histogram[0]
+        return im.get_extent()[3]
+
+    comp_widget.histogram_overlay_height = 0.1
+    small = _profile_height()
+    comp_widget.histogram_overlay_height = 0.6
+    large = _profile_height()
+
+    assert large > small
+    assert np.isclose(large / small, 6.0, rtol=1e-3)
+
+
+def test_components_widget_fraction_histogram_offset_flips_side(
+    make_viewer_model,
+    qtbot,
+):
+    """A negative histogram offset mirrors the overlay to the other side."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+
+    parent = PlotterWidget(viewer)
+    comp_widget = parent.components_tab
+    parent.tab_widget.setCurrentWidget(comp_widget)
+
+    _setup_linear_projection(comp_widget)
+    comp_widget.show_fraction_histogram = True
+
+    def _apex_display():
+        comp_widget.draw_line_between_components()
+        im = comp_widget.component_histogram[0]
+        # Map the local apex (u=0, top of the profile) through the image
+        # transform to display coordinates.
+        v_max = im.get_extent()[3]
+        return im.get_transform().transform((0.0, v_max))
+
+    comp_widget.histogram_offset = 0.1
+    pos_apex = _apex_display()
+    comp_widget.histogram_offset = -0.1
+    neg_apex = _apex_display()
+
+    # Flipping the sign puts the apex on the opposite side of the line.
+    assert not np.allclose(pos_apex, neg_apex)

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -222,7 +222,7 @@ def test_components_widget_fraction_calculation_creates_both_layers(
     )
 
     # Check initial colormap
-    assert comp_widget.comp1_fractions_layer.colormap.name == 'PiYG'
+    assert comp_widget.comp1_fractions_layer.colormap.name == 'jet'
 
     assert isinstance(comp_widget.component_line, LineCollection)
 

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -742,17 +742,26 @@ def test_components_widget_default_settings_structure(
     assert default_settings['analysis_type'] == 'Linear Projection'
     assert 'components' in default_settings
     assert isinstance(default_settings['components'], dict)
-    assert 'line_settings' in default_settings
-    assert 'show_colormap_line' in default_settings['line_settings']
-    assert 'show_component_dots' in default_settings['line_settings']
-    assert 'line_offset' in default_settings['line_settings']
-    assert 'line_width' in default_settings['line_settings']
-    assert 'line_alpha' in default_settings['line_settings']
-    assert 'label_settings' in default_settings
-    assert 'fontsize' in default_settings['label_settings']
-    assert 'bold' in default_settings['label_settings']
-    assert 'italic' in default_settings['label_settings']
-    assert 'color' in default_settings['label_settings']
+    # The default keys must match the ones edits are persisted under, so the
+    # restore path re-applies them (see ``_restore_line_and_label_settings``).
+    line_key = 'two_component_line_settings'
+    assert line_key in default_settings
+    assert 'show_colormap_line' in default_settings[line_key]
+    assert 'show_component_dots' in default_settings[line_key]
+    assert 'line_offset' in default_settings[line_key]
+    assert 'line_width' in default_settings[line_key]
+    assert 'line_alpha' in default_settings[line_key]
+    assert 'default_component_color' in default_settings[line_key]
+    assert 'show_fraction_histogram' in default_settings[line_key]
+    assert 'histogram_overlay_height' in default_settings[line_key]
+    assert 'histogram_offset' in default_settings[line_key]
+    assert 'histogram_alpha' in default_settings[line_key]
+    label_key = 'two_components_label_settings'
+    assert label_key in default_settings
+    assert 'fontsize' in default_settings[label_key]
+    assert 'bold' in default_settings[label_key]
+    assert 'italic' in default_settings[label_key]
+    assert 'color' in default_settings[label_key]
 
 
 def test_components_widget_style_state_initialization(
@@ -1763,6 +1772,66 @@ def test_components_restore_ui_only_from_metadata(make_viewer_model, qtbot):
     assert comp.label_bold is True
     assert comp.line_width == 2.0
     assert comp.show_colormap_line is False
+
+
+def test_components_restore_line_and_histogram_overlay_settings(
+    make_viewer_model, qtbot
+):
+    """Line + fraction-histogram overlay settings round-trip via metadata.
+
+    User edits are persisted under ``two_component_line_settings``; the restore
+    path must read that key (regression: it previously only read the unused
+    ``line_settings`` key, so overlay settings were never re-applied).
+    """
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    layer.metadata["settings"]["component_analysis"] = {
+        "analysis_type": "Linear Projection",
+        "last_analysis_harmonic": 1,
+        "components": {
+            "0": {
+                "name": "Comp A",
+                "gs_harmonics": {"1": {"g": 0.6, "s": 0.3}},
+            },
+            "1": {
+                "name": "Comp B",
+                "gs_harmonics": {"1": {"g": 0.3, "s": 0.2}},
+            },
+        },
+        "two_component_line_settings": {
+            "show_colormap_line": True,
+            "show_component_dots": False,
+            "line_offset": 0.07,
+            "line_width": 4.5,
+            "line_alpha": 0.6,
+            "default_component_color": "#abcdef",
+            "show_fraction_histogram": True,
+            "histogram_overlay_height": 0.42,
+            "histogram_offset": -0.15,
+            "histogram_alpha": 0.55,
+        },
+        "two_components_label_settings": {
+            "fontsize": 16,
+            "bold": True,
+            "italic": True,
+            "color": "red",
+        },
+    }
+
+    comp._restore_components_ui_only_from_metadata()
+
+    assert comp.show_component_dots is False
+    assert comp.line_offset == 0.07
+    assert comp.line_width == 4.5
+    assert comp.line_alpha == 0.6
+    assert comp.default_component_color == "#abcdef"
+    assert comp.show_fraction_histogram is True
+    assert comp.histogram_overlay_height == 0.42
+    assert comp.histogram_offset == -0.15
+    assert comp.histogram_alpha == 0.55
+    assert comp.label_fontsize == 16
+    assert comp.label_bold is True
+    assert comp.label_italic is True
+    assert comp.label_color == "red"
 
 
 def test_components_restore_and_recreate_linear_projection(

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -8,6 +8,7 @@ from phasorpy.phasor import phasor_nearest_neighbor
 from superqt import QToggleSwitch
 
 from napari_phasors._tests.test_plotter import create_image_layer_with_phasors
+from napari_phasors.fret_tab import draw_fret_trajectory_overlay
 from napari_phasors.plotter import PlotterWidget
 
 
@@ -2209,3 +2210,146 @@ def test_fret_widget_exceptions(make_viewer_model, qtbot):
     layer.metadata["S"] = np.ones((2, 10, 10))
     layer.metadata["harmonics"] = np.array([999])
     w.calculate_fret_efficiency()
+
+
+def test_plot_donor_trajectory_uses_jet_colormap_when_fret_colormap_unset(
+    make_viewer_model, qtbot
+):
+    """plot_donor_trajectory falls back to plt.cm.jet when a FRET layer is
+    active and colormap coloring is enabled but no custom fret_colormap has
+    been set (default state)."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    widget.donor_line_edit.setText("2.0")
+    widget.frequency_input.setText("80")
+    widget.background_real_edit.setText("0.1")
+    widget.background_imag_edit.setText("0.1")
+
+    # Simulate an active FRET layer with colormap coloring enabled and no
+    # custom colormap set.
+    mock_fret_layer = Mock()
+    mock_fret_layer.contrast_limits = (0.0, 1.0)
+    widget.fret_layer = mock_fret_layer
+    widget.use_colormap = True
+    widget.fret_colormap = None
+
+    parent.canvas_widget = Mock()
+    parent.canvas_widget.figure = Mock()
+    ax_mock = Mock()
+    parent.canvas_widget.figure.gca.return_value = ax_mock
+    parent.canvas_widget.canvas = Mock()
+
+    widget.plot_donor_trajectory()
+
+    assert widget.current_donor_circle is not None
+    assert widget.current_background_circle is not None
+    assert ax_mock.add_collection.called
+
+
+def test_apply_saved_fret_colormap_settings_recovers_after_exception(
+    make_viewer_model, qtbot
+):
+    """When restoring saved colormap settings on the FRET layer raises, the
+    except-handler still reconnects the colormap/contrast_limits/gamma
+    events instead of leaving the layer without callbacks."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    mock_layer = Mock()
+    mock_layer.events.colormap.disconnect.side_effect = RuntimeError("boom")
+    widget.fret_layer = mock_layer
+    widget._saved_colormap_name = "viridis"
+    widget._saved_colormap_colors = None
+    widget._saved_contrast_limits = [0.0, 1.0]
+    widget._saved_gamma = 1.0
+
+    # Should not raise even though the initial disconnect attempt fails.
+    widget._apply_saved_fret_colormap_settings()
+
+    assert mock_layer.events.colormap.connect.called
+    assert mock_layer.events.contrast_limits.connect.called
+    assert mock_layer.events.gamma.connect.called
+
+
+def test_reconnect_existing_fret_layer_direct(make_viewer_model, qtbot):
+    """_reconnect_existing_fret_layer connects events directly and caches
+    the layer's current colormap/contrast_limits/gamma when there are no
+    saved colormap settings to restore."""
+    import numpy as np
+    from napari.layers import Image
+
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    layer_name = "test_layer"
+    fret_layer_name = f"FRET efficiency: {layer_name}"
+    layer = Image(np.random.random((10, 10)), name=fret_layer_name)
+    viewer.add_layer(layer)
+
+    assert not hasattr(widget, '_saved_colormap_name')
+
+    widget._reconnect_existing_fret_layer(layer_name)
+
+    assert widget.fret_layer is layer
+    assert widget.colormap_gamma == layer.gamma
+    assert widget.colormap_contrast_limits == layer.contrast_limits
+    np.testing.assert_array_equal(widget.fret_colormap, layer.colormap.colors)
+
+
+def test_teardown_disconnects_real_fret_layer_events(make_viewer_model, qtbot):
+    """_teardown_on_layer_change disconnects colormap/contrast_limits/gamma
+    events from real FRET layers connected via the normal calculate flow."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    layer_a = create_image_layer_with_phasors()
+    layer_a.name = "layer_a"
+    layer_b = create_image_layer_with_phasors()
+    layer_b.name = "layer_b"
+    viewer.add_layer(layer_a)
+    viewer.add_layer(layer_b)
+
+    widget.donor_line_edit.setText("2.0")
+    widget.frequency_input.setText("80")
+    widget.background_real_edit.setText("0.1")
+    widget.background_imag_edit.setText("0.1")
+
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_a, layer_b]
+    ):
+        widget.calculate_fret_efficiency_button.click()
+
+    assert len(widget.fret_layers) == 2
+
+    widget._teardown_on_layer_change()
+
+    assert widget.fret_layer is None
+    assert widget.fret_layers == []
+
+
+def test_draw_fret_trajectory_overlay_uses_jet_colormap_by_default():
+    """The standalone draw_fret_trajectory_overlay falls back to plt.cm.jet
+    when no fret_colormap is supplied in settings."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    try:
+        trajectory_real = np.linspace(0.1, 0.9, 20)
+        trajectory_imag = np.linspace(0.1, 0.5, 20)
+        fret_efficiencies = np.linspace(0.0, 1.0, 20)
+
+        draw_fret_trajectory_overlay(
+            ax, trajectory_real, trajectory_imag, fret_efficiencies
+        )
+
+        # A colormap trajectory (LineCollection) plus donor/background
+        # circles should have been added to the axes.
+        assert len(ax.collections) == 1
+        assert len(ax.patches) == 2
+    finally:
+        plt.close(fig)

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -493,6 +493,40 @@ def test_colormap_events(make_viewer_model, qtbot):
     )  # Should have changed
 
 
+def test_fret_gamma_links_layers_and_histogram(make_viewer_model, qtbot):
+    """Changing gamma on one FRET layer syncs siblings and the histogram."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    layer_a = create_image_layer_with_phasors()
+    layer_a.name = "layer_a"
+    layer_b = create_image_layer_with_phasors()
+    layer_b.name = "layer_b"
+    viewer.add_layer(layer_a)
+    viewer.add_layer(layer_b)
+
+    widget.donor_line_edit.setText("2.0")
+    widget.frequency_input.setText("80")
+    widget.background_real_edit.setText("0.1")
+    widget.background_imag_edit.setText("0.1")
+
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_a, layer_b]
+    ):
+        widget.calculate_fret_efficiency_button.click()
+
+    assert len(widget.fret_layers) == 2
+
+    # Changing gamma on one FRET layer propagates to the sibling layer, the
+    # stored gamma, and the histogram widget.
+    widget.fret_layers[0].gamma = 0.7
+
+    assert widget.fret_layers[1].gamma == 0.7
+    assert widget.colormap_gamma == 0.7
+    assert widget.histogram_widget.gamma == 0.7
+
+
 def test_draw_colormap_trajectory(make_viewer_model, qtbot):
     """Test drawing trajectory with colormap."""
     viewer = make_viewer_model()

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -24,6 +24,12 @@ from superqt import QRangeSlider
 
 from napari_phasors._tests.test_plotter import create_image_layer_with_phasors
 from napari_phasors._utils import HistogramWidget
+from napari_phasors.phasor_mapping_tab import (
+    _DEFAULT_MESH_RESOLUTION,
+    PhasorMappingWidget,
+    _resolve_mesh_blur_sigma,
+    draw_phasor_mesh,
+)
 from napari_phasors.plotter import PlotterWidget
 
 
@@ -2209,3 +2215,97 @@ def test_phasor_mapping_exceptions(make_viewer_model, qtbot):
     layer.metadata["S"] = np.ones((2, 10, 10))
     layer.metadata["harmonics"] = np.array([999])
     pm.calculate_output_data()  # Should return early
+
+
+def test_resolve_mesh_blur_sigma_zero_display_px_fallback():
+    """_resolve_mesh_blur_sigma falls back to the default-resolution ratio
+    when the axes report a zero-sized (or unavailable) window extent."""
+    ax = MagicMock()
+    bbox = MagicMock()
+    bbox.width = 0.0
+    bbox.height = 0.0
+    ax.get_window_extent.return_value = bbox
+
+    resolution = 640
+    result = _resolve_mesh_blur_sigma(ax, resolution)
+
+    expected = max(1.5, 1.2 * resolution / _DEFAULT_MESH_RESOLUTION)
+    assert result == expected
+
+
+def test_draw_phasor_mesh_falls_back_when_interpolation_stage_unsupported(
+    make_viewer_model, qtbot
+):
+    """draw_phasor_mesh retries without ``interpolation_stage`` when the
+    installed Matplotlib's ``imshow`` doesn't accept that kwarg (older
+    Matplotlib versions)."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    try:
+        real_image = ax.imshow(np.zeros((2, 2)))
+        with patch.object(
+            ax,
+            "imshow",
+            side_effect=[TypeError("no interpolation_stage"), real_image],
+        ) as mock_imshow:
+            result = draw_phasor_mesh(ax, "Phase", resolution=4)
+
+        assert result is real_image
+        assert mock_imshow.call_count == 2
+    finally:
+        plt.close(fig)
+
+
+def test_get_output_colormap_name_branches():
+    """_get_output_colormap_name returns the colormap per output type and
+    falls back to 'plasma' for lifetime-style (or any other) outputs."""
+    assert PhasorMappingWidget._get_output_colormap_name("Phase") == "jet"
+    assert (
+        PhasorMappingWidget._get_output_colormap_name("Modulation")
+        == "viridis"
+    )
+    assert (
+        PhasorMappingWidget._get_output_colormap_name("Normal Lifetime")
+        == "plasma"
+    )
+
+
+def test_phasor_mapping_teardown_disconnects_real_layer_events(
+    make_viewer_model, qtbot
+):
+    """_teardown_on_layer_change disconnects colormap/contrast_limits/gamma
+    events from real metric layers still present in the viewer when there is
+    no primary layer selected."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    mapping_widget = parent.phasor_mapping_tab
+
+    output_layer = Image(
+        np.random.rand(10, 10), name="Apparent Phase Lifetime: test"
+    )
+    viewer.add_layer(output_layer)
+    output_layer.events.colormap.connect(mapping_widget._on_colormap_changed)
+    output_layer.events.contrast_limits.connect(
+        mapping_widget._on_colormap_changed
+    )
+    output_layer.events.gamma.connect(mapping_widget._on_colormap_changed)
+    mapping_widget.metric_layers = [output_layer]
+
+    # No primary layer selected -> get_primary_layer_name() returns "".
+    mapping_widget._teardown_on_layer_change()
+
+    assert mapping_widget.metric_layers == []
+
+
+def test_get_mesh_grid_resolution_exception_fallback(make_viewer_model, qtbot):
+    """_get_mesh_grid_resolution falls back to 1000 when
+    ``ax.get_window_extent`` raises."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    mapping_widget = parent.phasor_mapping_tab
+
+    ax = MagicMock()
+    ax.get_window_extent.side_effect = RuntimeError("boom")
+
+    assert mapping_widget._get_mesh_grid_resolution(ax) == 1000

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -159,9 +159,12 @@ def test_mesh_alpha_map_is_cached_for_repeated_refreshes(
         'napari_phasors.phasor_mapping_tab.gaussian_filter',
         return_value=blurred_base,
     ) as mock_filter:
-        first = lifetime_widget._get_mesh_alpha_map(mesh_mask, alpha_key, 0.5)
+        ax = parent.canvas_widget.axes
+        first = lifetime_widget._get_mesh_alpha_map(
+            mesh_mask, alpha_key, 0.5, 300, ax
+        )
         second = lifetime_widget._get_mesh_alpha_map(
-            mesh_mask, alpha_key, 0.25
+            mesh_mask, alpha_key, 0.25, 300, ax
         )
 
     assert mock_filter.call_count == 1
@@ -292,7 +295,7 @@ def test_phasor_mapping_widget_canvas_properties(make_viewer_model, qtbot):
     # Access the canvas through the histogram widget directly
     canvas = lifetime_widget.histogram_widget.fig.canvas
     assert isinstance(canvas, FigureCanvasQTAgg)
-    assert canvas.height() == 220  # Minimum canvas height set in the widget
+    assert canvas.height() == 180  # Minimum canvas height set in the widget
 
 
 def test_phasor_mapping_widget_type_changed_no_frequency(

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -80,8 +80,7 @@ def test_phasor_mapping_widget_initialization_values(make_viewer_model, qtbot):
     assert hasattr(lifetime_widget, 'lifetime_range_label')
     assert isinstance(lifetime_widget.lifetime_range_label, QLabel)
     assert (
-        lifetime_widget.lifetime_range_label.text()
-        == "Lifetime range (ns): 0.0 - 100.0"
+        lifetime_widget.lifetime_range_label.text() == "Lifetime range (ns):"
     )
 
     assert hasattr(lifetime_widget, 'lifetime_min_edit')
@@ -211,13 +210,12 @@ def test_phasor_mapping_widget_range_label_update(make_viewer_model, qtbot):
     parent = PlotterWidget(viewer)
     lifetime_widget = parent.phasor_mapping_tab
 
-    # Test label update
+    # Test edits update while dragging (label keeps just the prefix)
     test_value = (25000, 75000)  # Represents 25.0 - 75.0 ns with factor 1000
     lifetime_widget.histogram_widget._on_range_label_update(test_value)
 
     assert (
-        lifetime_widget.lifetime_range_label.text()
-        == "Lifetime range (ns): 25.00 - 75.00"
+        lifetime_widget.lifetime_range_label.text() == "Lifetime range (ns):"
     )
     assert lifetime_widget.lifetime_min_edit.text() == "25.00"
     assert lifetime_widget.lifetime_max_edit.text() == "75.00"
@@ -294,7 +292,7 @@ def test_phasor_mapping_widget_canvas_properties(make_viewer_model, qtbot):
     # Access the canvas through the histogram widget directly
     canvas = lifetime_widget.histogram_widget.fig.canvas
     assert isinstance(canvas, FigureCanvasQTAgg)
-    assert canvas.height() == 150  # Fixed height as set in setup_ui
+    assert canvas.height() == 220  # Minimum canvas height set in the widget
 
 
 def test_phasor_mapping_widget_type_changed_no_frequency(
@@ -915,6 +913,40 @@ def test_phasor_mapping_widget_colormap_changed_callback(
 
     # Reset flag
     lifetime_widget._updating_contrast_limits = False
+
+
+def test_phasor_mapping_gamma_links_layers_and_histogram(
+    make_viewer_model,
+    qtbot,
+):
+    """Changing gamma on one lifetime layer syncs siblings and the histogram."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    lifetime_widget = parent.phasor_mapping_tab
+
+    layer_1 = create_image_layer_with_phasors()
+    layer_2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer_1)
+    viewer.add_layer(layer_2)
+
+    lifetime_widget.frequency_input.setText("80.0")
+    parent._broadcast_frequency_value_across_tabs("80.0")
+    lifetime_widget.lifetime_type_combobox.setCurrentText("Normal Lifetime")
+
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_1, layer_2]
+    ):
+        lifetime_widget._on_calculate_lifetime_clicked()
+
+    assert len(lifetime_widget.metric_layers) == 2
+
+    # Changing gamma on one output layer propagates to the sibling layer, the
+    # stored gamma, and the histogram widget.
+    lifetime_widget.metric_layers[0].gamma = 0.6
+
+    assert lifetime_widget.metric_layers[1].gamma == 0.6
+    assert lifetime_widget.colormap_gamma == 0.6
+    assert lifetime_widget.histogram_widget.gamma == 0.6
 
 
 def test_phasor_mapping_widget_calculate_lifetimes_with_real_data(

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -355,7 +355,7 @@ def test_canvas_container_resize_starts_debounce_timer(make_viewer_model):
     # Test default property values
     assert plotter.harmonic == 1
     assert plotter.plot_type == 'HISTOGRAM2D'
-    assert plotter.histogram_colormap == 'turbo'
+    assert plotter.histogram_colormap == 'jet'
     assert plotter.toggle_semi_circle  # Should default to semi-circle mode
     assert plotter.white_background  # Should default to white background
 
@@ -602,7 +602,7 @@ def test_layer_settings_initialization_in_metadata(make_viewer_model):
     assert layer.metadata['settings']['semi_circle']
     assert layer.metadata['settings']['white_background']
     assert layer.metadata['settings']['plot_type'] == 'HISTOGRAM2D'
-    assert layer.metadata['settings']['colormap'] == 'turbo'
+    assert layer.metadata['settings']['colormap'] == 'jet'
     assert plotter.plotter_inputs_widget.marker_size_spinbox.value() == 50
     assert layer.metadata['settings']['number_of_bins'] == 150
     assert not layer.metadata['settings']['log_scale']
@@ -1036,7 +1036,7 @@ def test_phasor_plotter_colormap_combobox(make_viewer_model):
 
     # Test initial colormap
     initial_colormap = plotter.histogram_colormap
-    assert initial_colormap == 'turbo'  # or whatever the default is
+    assert initial_colormap == 'jet'  # or whatever the default is
 
     # Get available colormaps from combobox
     colormap_combobox = plotter.plotter_inputs_widget.colormap_combobox

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -1573,7 +1573,7 @@ def test_histogram_widget_taller_default_canvas_height(qtbot):
     """The histogram canvas has an increased minimum height."""
     widget = HistogramWidget()
     qtbot.addWidget(widget)
-    assert widget.fig.canvas.minimumHeight() >= 220
+    assert widget.fig.canvas.minimumHeight() >= 180
 
 
 def test_statistics_dock_export_csv(qtbot, tmp_path, monkeypatch):

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -1437,6 +1437,40 @@ def test_populate_colormap_combobox(qtbot):
     assert combo2.currentIndex() == 0
 
 
+def test_register_extra_colormaps_idempotent():
+    """Calling register_extra_colormaps twice skips already-registered names."""
+    from napari.utils.colormaps import AVAILABLE_COLORMAPS
+
+    from napari_phasors._utils import (
+        EXTRA_MATPLOTLIB_COLORMAPS,
+        register_extra_colormaps,
+    )
+
+    # First call (possibly a no-op if already registered at plugin import).
+    register_extra_colormaps()
+    for name in EXTRA_MATPLOTLIB_COLORMAPS:
+        assert name in AVAILABLE_COLORMAPS
+
+    # Second call must hit the "already registered" skip branch for every
+    # name without raising or duplicating entries.
+    register_extra_colormaps()
+    for name in EXTRA_MATPLOTLIB_COLORMAPS:
+        assert name in AVAILABLE_COLORMAPS
+
+
+def test_available_colormap_names_includes_extras():
+    from napari_phasors._utils import (
+        EXTRA_MATPLOTLIB_COLORMAPS,
+        available_colormap_names,
+    )
+
+    names = available_colormap_names()
+    for name in EXTRA_MATPLOTLIB_COLORMAPS:
+        assert name in names
+    # No duplicates from colormaps already present in napari's own list.
+    assert len(names) == len(set(names))
+
+
 def test_colormap_legend_proxy_and_handler(qtbot):
     import matplotlib.pyplot as plt
     from matplotlib.transforms import IdentityTransform

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -139,6 +139,36 @@ def test_histogram_widget_update_multi_data_autosd(qtbot):
     assert widget._show_sd is True
 
 
+def test_histogram_widget_gamma_uses_power_norm(qtbot):
+    """A non-unity gamma renders the colormap through a PowerNorm."""
+    from matplotlib.colors import PowerNorm
+
+    widget = HistogramWidget(bins=10)
+    qtbot.addWidget(widget)
+
+    widget.update_data(np.linspace(0.0, 1.0, 100))
+
+    colors = np.array([[0, 0, 0, 1], [1, 1, 1, 1]], dtype=float)
+
+    # Default gamma keeps a plain linear normalisation.
+    widget.update_colormap(colormap_colors=colors, contrast_limits=[0.0, 1.0])
+    _, norm = widget._get_cmap_and_norm()
+    assert not isinstance(norm, PowerNorm)
+
+    # A non-unity gamma switches to a matching PowerNorm.
+    widget.update_colormap(
+        colormap_colors=colors, contrast_limits=[0.0, 1.0], gamma=0.4
+    )
+    assert widget.gamma == 0.4
+    _, norm = widget._get_cmap_and_norm()
+    assert isinstance(norm, PowerNorm)
+    assert norm.gamma == 0.4
+
+    # Omitting gamma on a later update preserves the stored value.
+    widget.update_colormap(colormap_colors=colors, contrast_limits=[0.0, 2.0])
+    assert widget.gamma == 0.4
+
+
 def test_histogram_widget_grouped_sd_band(qtbot):
     """Grouped mode draws a shaded SD band per multi-file group when enabled."""
     from matplotlib.collections import PolyCollection
@@ -1503,6 +1533,47 @@ def test_histogram_widget_render_single_dataset_central_tendency(qtbot):
     widget._central_tendency = "Mean"
     widget._render()
     assert widget.counts is not None
+
+
+def test_histogram_widget_center_of_mass_uses_raw_unsmoothed_data(qtbot):
+    """The center-of-mass line comes from the raw histogram, not the smoothed
+    display curve, so smoothing on/off must not move it."""
+    rng = np.random.default_rng(0)
+    data = np.concatenate(
+        [rng.normal(2.0, 0.3, 5000), rng.normal(5.0, 0.5, 1500)]
+    )
+    widget = HistogramWidget(bins=150)
+    qtbot.addWidget(widget)
+    widget._central_tendency = "Center of mass"
+    widget.update_data(data)
+
+    expected = float(np.average(widget.bin_centers, weights=widget.counts))
+
+    def _drawn_com():
+        widget._render()
+        lines = [
+            ln for ln in widget.ax.get_lines() if ln.get_linestyle() == "--"
+        ]
+        assert len(lines) == 1
+        return float(lines[0].get_xdata()[0])
+
+    widget._smooth_curves = True
+    com_smoothed = _drawn_com()
+    widget._smooth_curves = False
+    com_raw = _drawn_com()
+
+    # Identical regardless of the display smoothing, and equal to the raw
+    # histogram's center of mass.
+    assert np.isclose(com_smoothed, expected)
+    assert np.isclose(com_raw, expected)
+    assert np.isclose(com_smoothed, com_raw)
+
+
+def test_histogram_widget_taller_default_canvas_height(qtbot):
+    """The histogram canvas has an increased minimum height."""
+    widget = HistogramWidget()
+    qtbot.addWidget(widget)
+    assert widget.fig.canvas.minimumHeight() >= 220
 
 
 def test_statistics_dock_export_csv(qtbot, tmp_path, monkeypatch):

--- a/src/napari_phasors/_tests/test_writer.py
+++ b/src/napari_phasors/_tests/test_writer.py
@@ -832,6 +832,40 @@ def test_export_image_multidim_uses_current_step(tmp_path):
     assert os.path.exists(out[0])
 
 
+def test_export_image_gamma_applies_power_norm(tmp_path):
+    """A layer with gamma != 1.0 is exported via a PowerNorm, not plain vmin/vmax.
+
+    Regression: previously the exported image used the raw contrast limits
+    and ignored gamma entirely, so it didn't match napari's on-screen
+    rendering whenever gamma correction was applied.
+    """
+    from napari.layers import Image
+    from PIL import Image as PILImage
+
+    from napari_phasors._writer import export_layer_as_image
+
+    data = np.linspace(0, 1, 16).reshape(4, 4)
+
+    linear_layer = Image(data.copy(), name="linear", colormap="gray")
+    linear_layer.gamma = 1.0
+    gamma_layer = Image(data.copy(), name="gamma", colormap="gray")
+    gamma_layer.gamma = 2.5
+
+    linear_path = export_layer_as_image(
+        str(tmp_path / "linear.png"), linear_layer, include_colorbar=False
+    )[0]
+    gamma_path = export_layer_as_image(
+        str(tmp_path / "gamma.png"), gamma_layer, include_colorbar=False
+    )[0]
+
+    with PILImage.open(linear_path) as linear_img:
+        linear_arr = np.array(linear_img)
+    with PILImage.open(gamma_path) as gamma_img:
+        gamma_arr = np.array(gamma_img)
+
+    assert not np.array_equal(linear_arr, gamma_arr)
+
+
 # ---------------------------------------------------------------------------
 # write_ome_tiff — dims / physical-size branches
 # ---------------------------------------------------------------------------

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -377,6 +377,61 @@ class PopoutWindowMixin:
             parent = parent.parent()
 
 
+EXTRA_MATPLOTLIB_COLORMAPS = (
+    'jet',
+    'nipy_spectral',
+    'ocean',
+    'gnuplot2',
+    'gnuplot',
+    'rainbow',
+    'brg',
+    'summer',
+    'winter',
+    'spring',
+    'autumn',
+    'cool',
+)
+
+
+def register_extra_colormaps() -> None:
+    """Make extra matplotlib colormaps selectable in napari's layer controls.
+
+    Napari's built-in colormap dropdown does not ship these matplotlib
+    colormaps by default, so this registers them globally the first time it
+    is called, making them available for any image or labels layer, not only
+    ones created by this plugin.
+    """
+    from napari.utils.colormaps import AVAILABLE_COLORMAPS
+    from napari.utils.colormaps import Colormap as NapariColormap
+
+    for name in EXTRA_MATPLOTLIB_COLORMAPS:
+        if name in AVAILABLE_COLORMAPS:
+            continue
+        colors = plt.get_cmap(name)(np.linspace(0, 1, 256))
+        AVAILABLE_COLORMAPS.add_colormap_if_missing(
+            NapariColormap(colors=colors, name=name, display_name=name)
+        )
+
+
+def available_colormap_names() -> list:
+    """Names of all colormaps offered in this plugin's colormap comboboxes.
+
+    Extends napari's built-in colormap list with the extra matplotlib
+    colormaps registered by :func:`register_extra_colormaps`, so widgets that
+    list colormaps (e.g. the histogram 2D colormap, phasor mapping, plotter
+    contours) also offer them.
+    """
+    from napari.utils import colormaps as napari_colormaps
+
+    names = list(napari_colormaps.ALL_COLORMAPS.keys())
+    names.extend(
+        name
+        for name in EXTRA_MATPLOTLIB_COLORMAPS
+        if name not in napari_colormaps.ALL_COLORMAPS
+    )
+    return names
+
+
 def create_napari_colormap_from_qcolor(color: QColor, name: str = "custom"):
     """Create a napari Colormap ramp from black to the given QColor."""
     from napari.utils import colormaps as napari_colormaps
@@ -442,10 +497,8 @@ def populate_colormap_combobox(
     combo, include_select_color=True, selected=None, available_colormaps=None
 ):
     """Populate a QComboBox with colormap names and icons."""
-    from napari.utils import colormaps as napari_colormaps
-
     if available_colormaps is None:
-        available_colormaps = list(napari_colormaps.ALL_COLORMAPS.keys())
+        available_colormaps = available_colormap_names()
 
     was_blocked = combo.blockSignals(True)
     try:
@@ -1195,7 +1248,7 @@ def build_group_styles_from_layer_metadata(viewer, layer_names):
             colors[next_gid] = c
             styles[next_gid] = {
                 'style': gstyle,
-                'colormap': gcmap or 'turbo',
+                'colormap': gcmap or 'jet',
                 'color': c,
             }
             next_gid += 1
@@ -1257,7 +1310,7 @@ def save_groups_to_layer_metadata(
             gstyle = style_data.get('style', 'solid')
             group_data['style'] = gstyle
             if gstyle == 'colormap':
-                group_data['colormap'] = style_data.get('colormap', 'turbo')
+                group_data['colormap'] = style_data.get('colormap', 'jet')
         layer.metadata['settings']['group'] = group_data
 
 

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2397,7 +2397,7 @@ class HistogramWidget(QWidget):
         ylabel: str = "Pixel count",
         bins: int = 150,
         default_colormap_name: str = "plasma",
-        canvas_height: int = 220,
+        canvas_height: int = 180,
         range_slider_enabled: bool = False,
         range_label_prefix: str = "Range",
         range_factor: int = 1000,
@@ -3768,7 +3768,7 @@ class HistogramDockWidget(QWidget):
         self.histogram_widget = histogram_widget
         self._stats_dock = None
 
-        self.setMinimumHeight(220)
+        self.setMinimumHeight(250)
         self.setMinimumWidth(300)
 
         layout = QVBoxLayout(self)
@@ -4201,6 +4201,12 @@ def read_ome_tiff_settings(file_path):
                 )
                 for key, value in napari_phasors_settings.items():
                     settings[key] = value
+                # Expose the file's harmonics alongside the real settings so a
+                # copied calibration can be matched to targets by harmonic.
+                # Only added when napari-phasors settings exist, so a file
+                # with no settings still reads back as empty.
+                if attrs.get("harmonic") is not None:
+                    settings.setdefault("harmonics", attrs["harmonic"])
         except (json.JSONDecodeError, KeyError):
             pass
     return settings
@@ -4257,7 +4263,25 @@ def compute_calibration_parameters(
     return phi_zero, mod_zero
 
 
-def apply_calibration_correction(layer, phi_zero, mod_zero):
+def _normalize_harmonics(values):
+    """Return ``values`` as a flat list of plain ints (best effort).
+
+    Harmonics read from metadata are often numpy integers; converting to
+    Python ints keeps dict lookups and user-facing messages clean (``2``
+    rather than ``np.int64(2)``).
+    """
+    result = []
+    for value in np.ravel(np.atleast_1d(values)):
+        try:
+            result.append(int(value))
+        except (TypeError, ValueError):
+            result.append(value)
+    return result
+
+
+def apply_calibration_correction(
+    layer, phi_zero, mod_zero, calibration_harmonics=None
+):
     """Apply a phasor calibration correction to a layer in place.
 
     Applies the polar correction ``(phi_zero, mod_zero)`` to both the
@@ -4272,33 +4296,81 @@ def apply_calibration_correction(layer, phi_zero, mod_zero):
         Phase correction parameter (per harmonic).
     mod_zero : float or numpy.ndarray
         Modulation correction parameter (per harmonic).
+    calibration_harmonics : sequence of int, optional
+        The harmonic each ``phi_zero`` / ``mod_zero`` value corresponds to.
+        When given, the correction is matched to the layer's harmonics *by
+        value*: only the calibration for the harmonics the layer actually has
+        is applied (e.g. a ``[1, 2]`` calibration applied to a single-harmonic
+        ``[1]`` file uses just the harmonic-1 correction). A :class:`ValueError`
+        is raised if the layer needs a harmonic the calibration does not cover.
+        When ``None`` (calibration harmonics unknown), the values are treated
+        positionally and must match the layer's harmonic count.
     """
     from phasorpy.phasor import phasor_transform
 
     metadata = layer.metadata
-    harmonics = np.atleast_1d(metadata.get("harmonics"))
+    harmonics = _normalize_harmonics(metadata.get("harmonics"))
     g_original = metadata["G_original"]
     s_original = metadata["S_original"]
     g_current = metadata["G"]
     s_current = metadata["S"]
 
-    if isinstance(phi_zero, list):
-        phi_zero = np.array(phi_zero)
-    if isinstance(mod_zero, list):
-        mod_zero = np.array(mod_zero)
+    if np.ndim(phi_zero) > 0:
+        phi_arr = np.ravel(np.asarray(phi_zero, dtype=float))
+        mod_arr = np.ravel(np.asarray(mod_zero, dtype=float))
 
-    if g_original.ndim > 1 and len(harmonics) > 1:
-        spatial_dims = g_original.ndim - 1
-        expand_shape = (slice(None),) + (None,) * spatial_dims
-        if np.ndim(phi_zero) > 0:
-            phi_expanded = phi_zero[expand_shape]
-            mod_expanded = mod_zero[expand_shape]
+        cal_harmonics = None
+        if calibration_harmonics is not None:
+            cal_harmonics = _normalize_harmonics(calibration_harmonics)
+            # Ignore inconsistent labels and fall back to positional matching.
+            if len(cal_harmonics) != len(phi_arr):
+                cal_harmonics = None
+
+        if cal_harmonics is not None:
+            # Match by harmonic value: keep only the calibration for the
+            # harmonics this file actually has, and error if any file harmonic
+            # is not covered by the calibration.
+            phi_map = dict(zip(cal_harmonics, phi_arr, strict=True))
+            mod_map = dict(zip(cal_harmonics, mod_arr, strict=True))
+            missing = [h for h in harmonics if h not in phi_map]
+            if missing:
+                raise ValueError(
+                    f"the calibration does not include harmonic(s) {missing} "
+                    f"needed by this file (calibration covers harmonics "
+                    f"{cal_harmonics}). Recompute or copy a calibration that "
+                    "includes these harmonics."
+                )
+            phi_sel = np.array([phi_map[h] for h in harmonics], dtype=float)
+            mod_sel = np.array([mod_map[h] for h in harmonics], dtype=float)
         else:
-            phi_expanded = phi_zero
-            mod_expanded = mod_zero
+            # Calibration harmonics unknown: require a positional 1:1 match so
+            # a genuine mismatch is reported instead of silently misaligning.
+            if len(phi_arr) != len(harmonics):
+                raise ValueError(
+                    f"calibration has {len(phi_arr)} harmonic(s) but this "
+                    f"file has {len(harmonics)} ({harmonics}). Use the same "
+                    "harmonics for the calibration reference and the files "
+                    "being processed (the 'Harmonics' field), or "
+                    "recompute/copy the calibration for these harmonics."
+                )
+            phi_sel = phi_arr
+            mod_sel = mod_arr
+
+        if g_original.ndim > 1:
+            spatial_dims = g_original.ndim - 1
+            expand_shape = (slice(None),) + (None,) * spatial_dims
+            phi_expanded = phi_sel[expand_shape]
+            mod_expanded = mod_sel[expand_shape]
+        else:
+            phi_expanded = phi_sel
+            mod_expanded = mod_sel
+        stored_phase = phi_sel.tolist()
+        stored_modulation = mod_sel.tolist()
     else:
         phi_expanded = phi_zero
         mod_expanded = mod_zero
+        stored_phase = float(phi_zero)
+        stored_modulation = float(mod_zero)
 
     real_original, imag_original = phasor_transform(
         g_original, s_original, phi_expanded, mod_expanded
@@ -4313,10 +4385,6 @@ def apply_calibration_correction(layer, phi_zero, mod_zero):
     metadata["S"] = imag
 
     settings = metadata.setdefault("settings", {})
-    settings["calibration_phase"] = (
-        phi_zero.tolist() if np.ndim(phi_zero) > 0 else float(phi_zero)
-    )
-    settings["calibration_modulation"] = (
-        mod_zero.tolist() if np.ndim(mod_zero) > 0 else float(mod_zero)
-    )
+    settings["calibration_phase"] = stored_phase
+    settings["calibration_modulation"] = stored_modulation
     settings["calibrated"] = True

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -12,7 +12,7 @@ import numpy as np
 import scipy
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.collections import LineCollection
-from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.colors import LinearSegmentedColormap, PowerNorm
 from matplotlib.figure import Figure
 from matplotlib.legend_handler import HandlerBase
 from matplotlib.patches import Polygon as MplPolygon
@@ -2362,7 +2362,7 @@ class HistogramWidget(QWidget):
         Name of the Matplotlib colormap to use as fallback when no explicit
         colormap colors are provided, by default ``"plasma"``.
     canvas_height : int, optional
-        Minimum pixel height of the canvas, by default 150. The canvas grows
+        Minimum pixel height of the canvas, by default 220. The canvas grows
         beyond this to fill the available vertical space.
     range_slider_enabled : bool, optional
         If ``True``, show a range slider with min / max edits above the
@@ -2397,7 +2397,7 @@ class HistogramWidget(QWidget):
         ylabel: str = "Pixel count",
         bins: int = 150,
         default_colormap_name: str = "plasma",
-        canvas_height: int = 150,
+        canvas_height: int = 220,
         range_slider_enabled: bool = False,
         range_label_prefix: str = "Range",
         range_factor: int = 1000,
@@ -2428,6 +2428,7 @@ class HistogramWidget(QWidget):
         # Colormap state (set externally)
         self.colormap_colors = None  # Nx4 array of RGBA colors
         self.contrast_limits = None  # [vmin, vmax]
+        self.gamma = 1.0  # power-law gamma applied to the colormap
 
         # Raw pooled data (for central tendency computation)
         self._raw_valid_data = None
@@ -2457,23 +2458,24 @@ class HistogramWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Optional range slider section
+        # Optional range slider section: label, min/max edits and the range
+        # slider all share a single row.
         if self._range_slider_enabled:
-            self.range_label = QLabel(
-                f"{self._range_label_prefix}: 0.0 - 100.0"
-            )
-            layout.addWidget(self.range_label)
+            range_row = QHBoxLayout()
 
-            edit_layout = QHBoxLayout()
+            self.range_label = QLabel(f"{self._range_label_prefix}:")
+            range_row.addWidget(self.range_label)
+
             self.range_min_edit = QLineEdit("0.0")
             self.range_max_edit = QLineEdit("100.0")
             self.range_min_edit.setValidator(QDoubleValidator())
             self.range_max_edit.setValidator(QDoubleValidator())
-            edit_layout.addWidget(QLabel("Min:"))
-            edit_layout.addWidget(self.range_min_edit)
-            edit_layout.addWidget(QLabel("Max:"))
-            edit_layout.addWidget(self.range_max_edit)
-            layout.addLayout(edit_layout)
+            self.range_min_edit.setMaximumWidth(60)
+            self.range_max_edit.setMaximumWidth(60)
+            range_row.addWidget(QLabel("Min:"))
+            range_row.addWidget(self.range_min_edit)
+            range_row.addWidget(QLabel("Max:"))
+            range_row.addWidget(self.range_max_edit)
 
             self.range_slider = QRangeSlider(Qt.Orientation.Horizontal)
             self.range_slider.setRange(0, 100)
@@ -2483,7 +2485,9 @@ class HistogramWidget(QWidget):
             self.range_slider.valueChanged.connect(self._on_range_label_update)
             self.range_slider.sliderPressed.connect(self._on_slider_pressed)
             self.range_slider.sliderReleased.connect(self._on_slider_released)
-            layout.addWidget(self.range_slider)
+            range_row.addWidget(self.range_slider, 1)
+
+            layout.addLayout(range_row)
 
             self.range_min_edit.editingFinished.connect(
                 self._on_range_min_edit
@@ -2595,9 +2599,6 @@ class HistogramWidget(QWidget):
         max_out = max_s / self.range_factor
         self.range_min_edit.setText(f"{min_out:.2f}")
         self.range_max_edit.setText(f"{max_out:.2f}")
-        self.range_label.setText(
-            f"{self._range_label_prefix}: {min_out:.2f} - {max_out:.2f}"
-        )
 
     def get_range(self) -> tuple:
         """Return ``(min_float, max_float)`` from the slider."""
@@ -2607,13 +2608,10 @@ class HistogramWidget(QWidget):
         return lo / self.range_factor, hi / self.range_factor
 
     def _on_range_label_update(self, value):
-        """Update label + edits while dragging (no heavy work)."""
+        """Update edits while dragging (no heavy work)."""
         lo, hi = value
         lo_f = lo / self.range_factor
         hi_f = hi / self.range_factor
-        self.range_label.setText(
-            f"{self._range_label_prefix}: {lo_f:.2f} - {hi_f:.2f}"
-        )
         self.range_min_edit.setText(f"{lo_f:.2f}")
         self.range_max_edit.setText(f"{hi_f:.2f}")
 
@@ -2998,6 +2996,7 @@ class HistogramWidget(QWidget):
         self,
         colormap_colors: np.ndarray = None,
         contrast_limits: list = None,
+        gamma: float = None,
     ) -> None:
         """Update the colormap / contrast limits and re-render.
 
@@ -3007,9 +3006,14 @@ class HistogramWidget(QWidget):
             Nx4 RGBA array that defines the colormap.
         contrast_limits : list, optional
             ``[vmin, vmax]`` for the normalisation.
+        gamma : float, optional
+            Power-law gamma applied to the colormap, matching napari's
+            layer ``gamma``. When ``None`` the current gamma is kept.
         """
         self.colormap_colors = colormap_colors
         self.contrast_limits = contrast_limits
+        if gamma is not None:
+            self.gamma = gamma
         if self.counts is not None:
             self._render()
 
@@ -3120,26 +3124,22 @@ class HistogramWidget(QWidget):
         """Return (cmap, norm) from current colormap state."""
         if self.colormap_colors is None or self.contrast_limits is None:
             cmap = plt.get_cmap(self.default_colormap_name)
-            norm = plt.Normalize(
-                vmin=(
-                    np.min(self.bin_centers)
-                    if len(self.bin_centers) > 0
-                    else 0
-                ),
-                vmax=(
-                    np.max(self.bin_centers)
-                    if len(self.bin_centers) > 0
-                    else 1
-                ),
-            )
+            vmin = np.min(self.bin_centers) if len(self.bin_centers) > 0 else 0
+            vmax = np.max(self.bin_centers) if len(self.bin_centers) > 0 else 1
         else:
             cmap = LinearSegmentedColormap.from_list(
                 "custom_cmap", self.colormap_colors
             )
-            norm = plt.Normalize(
-                vmin=self.contrast_limits[0],
-                vmax=self.contrast_limits[1],
-            )
+            vmin = self.contrast_limits[0]
+            vmax = self.contrast_limits[1]
+
+        gamma = getattr(self, "gamma", 1.0) or 1.0
+        if gamma != 1.0 and vmax > vmin:
+            # Reproduce napari's rendering: normalise to the contrast limits,
+            # then apply the layer gamma as a power law.
+            norm = PowerNorm(gamma, vmin=vmin, vmax=vmax)
+        else:
+            norm = plt.Normalize(vmin=vmin, vmax=vmax)
         return cmap, norm
 
     def _smooth_curve(self, y, sigma=2, upsample=5):
@@ -3245,12 +3245,25 @@ class HistogramWidget(QWidget):
                     )
         else:
             if self._raw_valid_data is not None:
-                val = self._compute_central_tendency(
-                    self._raw_valid_data,
-                    choice,
-                    self.bin_centers,
-                    self.bin_edges,
-                )
+                if (
+                    choice == "Center of mass"
+                    and self.counts is not None
+                    and self.bin_centers is not None
+                    and np.sum(self.counts) > 0
+                ):
+                    # Compute the centre of mass from the raw, unsmoothed
+                    # stored histogram (``self.counts``) so it is independent of
+                    # any curve smoothing applied only for display.
+                    val = float(
+                        np.average(self.bin_centers, weights=self.counts)
+                    )
+                else:
+                    val = self._compute_central_tendency(
+                        self._raw_valid_data,
+                        choice,
+                        self.bin_centers,
+                        self.bin_edges,
+                    )
                 if val is not None:
                     self.ax.axvline(
                         val, color="white", ls="--", lw=2, alpha=0.85
@@ -3755,7 +3768,7 @@ class HistogramDockWidget(QWidget):
         self.histogram_widget = histogram_widget
         self._stats_dock = None
 
-        self.setMinimumHeight(150)
+        self.setMinimumHeight(220)
         self.setMinimumWidth(300)
 
         layout = QVBoxLayout(self)

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2571,20 +2571,16 @@ class WriterWidget(PopoutWindowMixin, QWidget):
         )
         flimari_info = QLabel(
             "Send the selected phasor layer(s) directly to "
-            "<a href=\"https://github.com/GuangchenW/FLIMari\">FLIMari</a>, "
-            "without saving any file. FLIMari must be installed as a "
-            "napari plugin; if its dock widget isn't open yet, it will be "
-            "opened automatically. Since FLIMari works with total photon "
-            "counts rather than mean intensity, the counts are recovered "
-            "automatically. For layers loaded from formats without the raw "
-            "histogram (e.g. R64/REF), you'll be prompted to point to the "
-            "original raw file so the counts can be recovered."
+            "<a href=\"https://github.com/GuangchenW/FLIMari\">FLIMari</a>. "
+            "FLIMari must be installed as a napari plugin. For layers loaded "
+            "from formats without the raw histogram (e.g. R64/REF), you'll be "
+            "prompted to point to the original raw file so the counts can be recovered."
         )
         flimari_info.setWordWrap(True)
         flimari_info.setOpenExternalLinks(True)
         self.flimari_section.add_widget(flimari_info)
 
-        self.flimari_button = QPushButton("Export Phasor Layer to FLIMARI")
+        self.flimari_button = QPushButton("Export Phasor Layer to FLIMari")
         self.flimari_button.setEnabled(False)
         self.flimari_button.clicked.connect(self._send_to_flimari)
         self.flimari_section.add_widget(self.flimari_button)

--- a/src/napari_phasors/_writer.py
+++ b/src/napari_phasors/_writer.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Union
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.colors import LinearSegmentedColormap, PowerNorm
 from napari.layers import Labels
 from phasorpy.io import phasor_to_ometiff
 
@@ -465,6 +465,7 @@ def export_layer_as_image(
             is_labels = isinstance(current_layer, Labels)
             colormap = getattr(current_layer, 'colormap', None)
             contrast_limits = getattr(current_layer, 'contrast_limits', None)
+            gamma = getattr(current_layer, 'gamma', 1.0)
             layer_name = getattr(current_layer, 'name', f"layer_{i}")
         else:
             data = (
@@ -480,6 +481,7 @@ def export_layer_as_image(
             )
             colormap = attributes.get('colormap', None)
             contrast_limits = attributes.get('contrast_limits', None)
+            gamma = attributes.get('gamma', 1.0)
             layer_name = attributes.get('name', f"layer_{i}")
 
         _, ext = os.path.splitext(path)
@@ -584,8 +586,15 @@ def export_layer_as_image(
         }
         if data_2d.ndim == 2:
             imshow_kwargs["cmap"] = cmap
-            imshow_kwargs["vmin"] = clim[0]
-            imshow_kwargs["vmax"] = clim[1]
+            if gamma is not None and gamma != 1.0:
+                # Reproduce napari's rendering: normalize to the contrast
+                # limits, then apply gamma via a power-law norm.
+                imshow_kwargs["norm"] = PowerNorm(
+                    gamma, vmin=clim[0], vmax=clim[1]
+                )
+            else:
+                imshow_kwargs["vmin"] = clim[0]
+                imshow_kwargs["vmax"] = clim[1]
 
         im = ax.imshow(data_2d, **imshow_kwargs)
         ax.axis("off")

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -421,7 +421,7 @@ class ComponentsWidget(QWidget):
             xlabel="Fraction",
             ylabel="Pixel count",
             bins=150,
-            default_colormap_name="PiYG",
+            default_colormap_name="jet",
             range_slider_enabled=True,
             range_label_prefix="Fraction range",
             range_factor=1000,
@@ -3180,7 +3180,7 @@ class ComponentsWidget(QWidget):
             else:
                 colormap = ListedColormap(self.fractions_colormap)
         else:
-            colormap = plt.cm.PiYG
+            colormap = plt.cm.jet
 
         if (
             hasattr(self, 'colormap_contrast_limits')
@@ -3792,7 +3792,7 @@ class ComponentsWidget(QWidget):
                 colors=inverted_colors, name=f"inverted_{colormap_name}"
             )
 
-        return 'PiYG_r' if not colormap_name.endswith('_r') else 'PiYG'
+        return 'jet_r' if not colormap_name.endswith('_r') else 'jet'
 
     def _find_and_reconnect_layer(
         self, expected_name, component_name, layer_name, idx
@@ -4192,7 +4192,7 @@ class ComponentsWidget(QWidget):
         current_harmonic = getattr(self.parent_widget, 'harmonic', 1)
         harmonic_key = str(current_harmonic)
 
-        comp1_colormap = 'PiYG'
+        comp1_colormap = 'jet'
         valid_fraction = fraction_comp1[np.isfinite(fraction_comp1)]
         if valid_fraction.size > 0:
             frac_min = float(np.min(valid_fraction))

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -7,7 +7,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 import vispy.color
 from matplotlib.collections import LineCollection
-from matplotlib.colors import LinearSegmentedColormap, ListedColormap
+from matplotlib.colors import (
+    LinearSegmentedColormap,
+    ListedColormap,
+    PowerNorm,
+)
+from matplotlib.patches import Polygon as MplPolygon
+from matplotlib.transforms import Affine2D
 from napari.layers import Image
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 from napari.utils.notifications import show_error, show_info, show_warning
@@ -18,8 +24,8 @@ from phasorpy.lifetime import (
     phasor_to_normal_lifetime,
 )
 from phasorpy.phasor import phasor_center
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QKeySequence, QShortcut
+from qtpy.QtCore import QRectF, Qt
+from qtpy.QtGui import QColor, QKeySequence, QPainter, QShortcut
 from qtpy.QtWidgets import (
     QCheckBox,
     QColorDialog,
@@ -27,6 +33,7 @@ from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -35,6 +42,8 @@ from qtpy.QtWidgets import (
     QScrollArea,
     QSlider,
     QSpinBox,
+    QStyle,
+    QStyleOptionSlider,
     QVBoxLayout,
     QWidget,
     QWidgetAction,
@@ -127,6 +136,89 @@ class ColorActionWidget(QLabel):
                 parent = parent.parent()
 
 
+class CenterFillSlider(QSlider):
+    """Horizontal slider whose colored fill originates from the center (0).
+
+    A standard :class:`QSlider` fills its groove from the minimum edge to the
+    handle, which is misleading for a signed value centered at zero. This
+    subclass paints the fill from the zero position to the handle instead, so
+    dragging left of centre reads as negative and right as positive.
+    """
+
+    fill_color = QColor("#3b82f6")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Neutralise the default directional groove fill so only the
+        # centre-anchored fill drawn below is visible.
+        self.setStyleSheet("""
+            QSlider::groove:horizontal {
+                height: 4px;
+                background: #c7ccd4;
+                border-radius: 2px;
+            }
+            QSlider::sub-page:horizontal,
+            QSlider::add-page:horizontal {
+                background: #c7ccd4;
+                border-radius: 2px;
+            }
+            QSlider::handle:horizontal {
+                width: 12px;
+                margin: -5px 0;
+                border-radius: 6px;
+                background: #6b7280;
+            }
+            """)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        span = self.maximum() - self.minimum()
+        if span == 0:
+            return
+
+        opt = QStyleOptionSlider()
+        self.initStyleOption(opt)
+        groove = self.style().subControlRect(
+            QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self
+        )
+        handle = self.style().subControlRect(
+            QStyle.CC_Slider, opt, QStyle.SC_SliderHandle, self
+        )
+
+        # Map the zero value to a pixel the same way Qt positions the handle:
+        # the handle centre only travels within the groove inset by half its
+        # width. Using the naive groove-width mapping instead would drift the
+        # fill origin away from the handle at value 0.
+        handle_w = handle.width()
+        available = groove.width() - handle_w
+        zero_pos = self.style().sliderPositionFromValue(
+            self.minimum(), self.maximum(), 0, available, opt.upsideDown
+        )
+        zero_x = groove.x() + handle_w / 2.0 + zero_pos
+        handle_x = handle.center().x()
+
+        # Overlay the fill exactly on the grey groove line. The stylesheet
+        # draws the track 4px tall, centred on the groove rect; mirror that
+        # here using the float centre so the blue band shares the light-grey
+        # track's centre and thickness (QRect.center() floors for even
+        # heights, which shifted the band up by a pixel).
+        groove_thickness = 4.0
+        center_y = groove.y() + groove.height() / 2.0
+        left = min(zero_x, handle_x)
+        right = max(zero_x, handle_x)
+        rect = QRectF(
+            left,
+            center_y - groove_thickness / 2.0,
+            max(0.0, right - left),
+            groove_thickness,
+        )
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.fillRect(rect, self.fill_color)
+        painter.end()
+
+
 class PhasorCenterSelectionDialog(QDialog):
     def __init__(self, layers, parent=None, preselected=None):
         super().__init__(parent)
@@ -199,6 +291,7 @@ class ComponentsWidget(QWidget):
         self.comp2_fractions_layer = None
         self.fractions_colormap = None
         self.colormap_contrast_limits = None
+        self.fractions_gamma = 1.0
         self.component_colors = [
             'magenta',
             'cyan',
@@ -242,10 +335,19 @@ class ComponentsWidget(QWidget):
         self.line_alpha = 1
         self.default_component_color = 'dimgray'
 
+        # Fraction histogram overlay settings
+        self.show_fraction_histogram = False
+        self.histogram_overlay_height = 0.3
+        self.histogram_offset = 0.0
+        self.histogram_alpha = 0.75
+        self.component_histogram = None
+
         # Flag to prevent clearing lifetime when updating from lifetime
         self._updating_from_lifetime = False
         self._updating_settings = False  # Flag to prevent recursive updates
         self._needs_update = False  # Deferred update flag
+        # Guard against recursion while mirroring slider <-> spinbox pairs.
+        self._syncing_slider_spin = False
         # Guard to avoid recursion while mirroring the component selection
         # between the histogram and statistics comboboxes.
         self._syncing_component_comboboxes = False
@@ -820,6 +922,8 @@ class ComponentsWidget(QWidget):
                 self.component_polygon.remove()
             self.component_polygon = None
 
+        self._remove_histogram_overlay()
+
         self._update_component_visibility()
         self._update_analysis_options()
         self._update_button_states()
@@ -944,6 +1048,8 @@ class ComponentsWidget(QWidget):
                 self.component_polygon.remove()
             self.component_polygon = None
 
+        self._remove_histogram_overlay()
+
         self._update_components_setting_in_metadata('components', {})
 
         if self.parent_widget is not None:
@@ -966,6 +1072,10 @@ class ComponentsWidget(QWidget):
                 'line_offset': 0.0,
                 'line_width': 3.0,
                 'line_alpha': 1.0,
+                'show_fraction_histogram': False,
+                'histogram_overlay_height': 0.3,
+                'histogram_offset': 0.0,
+                'histogram_alpha': 0.75,
             },
             'label_settings': {
                 'fontsize': 10,
@@ -1131,6 +1241,18 @@ class ComponentsWidget(QWidget):
                 self.line_offset = line_settings.get('line_offset', 0.0)
                 self.line_width = line_settings.get('line_width', 3.0)
                 self.line_alpha = line_settings.get('line_alpha', 1.0)
+                self.show_fraction_histogram = line_settings.get(
+                    'show_fraction_histogram', False
+                )
+                self.histogram_overlay_height = line_settings.get(
+                    'histogram_overlay_height', 0.3
+                )
+                self.histogram_offset = line_settings.get(
+                    'histogram_offset', 0.0
+                )
+                self.histogram_alpha = line_settings.get(
+                    'histogram_alpha', 0.75
+                )
 
             if 'label_settings' in settings:
                 label_settings = settings['label_settings']
@@ -1290,6 +1412,18 @@ class ComponentsWidget(QWidget):
                 self.line_offset = line_settings.get('line_offset', 0.0)
                 self.line_width = line_settings.get('line_width', 3.0)
                 self.line_alpha = line_settings.get('line_alpha', 1.0)
+                self.show_fraction_histogram = line_settings.get(
+                    'show_fraction_histogram', False
+                )
+                self.histogram_overlay_height = line_settings.get(
+                    'histogram_overlay_height', 0.3
+                )
+                self.histogram_offset = line_settings.get(
+                    'histogram_offset', 0.0
+                )
+                self.histogram_alpha = line_settings.get(
+                    'histogram_alpha', 0.75
+                )
 
             if 'label_settings' in settings:
                 label_settings = settings['label_settings']
@@ -1375,6 +1509,7 @@ class ComponentsWidget(QWidget):
             colormap_name = harmonic_data.get('colormap_name')
             colormap_colors = harmonic_data.get('colormap_colors')
             contrast_limits = harmonic_data.get('contrast_limits')
+            gamma = harmonic_data.get('gamma')
 
             if not (colormap_name or colormap_colors):
                 continue
@@ -1399,6 +1534,9 @@ class ComponentsWidget(QWidget):
                 fraction_layer.events.colormap.disconnect(
                     self._on_colormap_changed
                 )
+                fraction_layer.events.gamma.disconnect(
+                    self._on_colormap_changed
+                )
 
             try:
                 if colormap_colors is not None:
@@ -1419,10 +1557,14 @@ class ComponentsWidget(QWidget):
                 if contrast_limits:
                     fraction_layer.contrast_limits = tuple(contrast_limits)
 
+                if gamma is not None:
+                    fraction_layer.gamma = gamma
+
             finally:
                 fraction_layer.events.colormap.connect(
                     self._on_colormap_changed
                 )
+                fraction_layer.events.gamma.connect(self._on_colormap_changed)
 
         if (
             len(settings.get('components', {})) == 2
@@ -1434,6 +1576,7 @@ class ComponentsWidget(QWidget):
             self.colormap_contrast_limits = (
                 self.comp1_fractions_layer.contrast_limits
             )
+            self.fractions_gamma = self.comp1_fractions_layer.gamma
 
         self._update_component_colors()
         self.draw_line_between_components()
@@ -1441,100 +1584,248 @@ class ComponentsWidget(QWidget):
         if self.parent_widget is not None:
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
+    def _make_slider_spin_row(
+        self,
+        label,
+        minv,
+        maxv,
+        value,
+        decimals,
+        on_value,
+        *,
+        center_fill=False,
+        tooltip=None,
+        step=None,
+    ):
+        """Build a labelled slider + spinbox pair kept in sync.
+
+        ``on_value`` is invoked with the float value whenever either the slider
+        or the spinbox changes. The value can therefore be dragged or typed
+        directly. Returns ``(row_layout, slider, spin)``.
+        """
+        factor = 10**decimals
+        row = QHBoxLayout()
+        lbl = QLabel(label)
+        row.addWidget(lbl)
+
+        slider = (
+            CenterFillSlider(Qt.Horizontal)
+            if center_fill
+            else QSlider(Qt.Horizontal)
+        )
+        slider.setRange(int(round(minv * factor)), int(round(maxv * factor)))
+        slider.setValue(int(round(value * factor)))
+
+        spin = QDoubleSpinBox()
+        spin.setDecimals(decimals)
+        spin.setRange(minv, maxv)
+        spin.setSingleStep(step if step is not None else 1.0 / factor)
+        spin.setValue(value)
+        spin.setMaximumWidth(85)
+
+        if tooltip:
+            for w in (lbl, slider, spin):
+                w.setToolTip(tooltip)
+
+        def on_slider(iv):
+            if self._syncing_slider_spin:
+                return
+            self._syncing_slider_spin = True
+            try:
+                spin.setValue(iv / factor)
+            finally:
+                self._syncing_slider_spin = False
+            on_value(iv / factor)
+
+        def on_spin(val):
+            if self._syncing_slider_spin:
+                return
+            self._syncing_slider_spin = True
+            try:
+                slider.setValue(int(round(val * factor)))
+            finally:
+                self._syncing_slider_spin = False
+            on_value(val)
+
+        slider.valueChanged.connect(on_slider)
+        spin.valueChanged.connect(on_spin)
+
+        row.addWidget(slider)
+        row.addWidget(spin)
+        return row, slider, spin
+
     def _open_plot_settings_dialog(self):
-        """Open dialog to edit plot settings."""
+        """Open dialog to edit line and fraction-histogram overlay settings."""
         if self.plot_dialog is not None and self.plot_dialog.isVisible():
             self.plot_dialog.raise_()
             self.plot_dialog.activateWindow()
             return
 
         self.plot_dialog = QDialog(self)
-        self.plot_dialog.setWindowTitle("Component Line Settings")
+        self.plot_dialog.setWindowTitle("Component Line & Histogram Settings")
+        self.plot_dialog.setMinimumWidth(460)
         vbox = QVBoxLayout(self.plot_dialog)
 
-        # Row 1: checkboxes
-        row1 = QHBoxLayout()
-        self.colormap_line_checkbox = QCheckBox("Overlay Colormap")
-        self.colormap_line_checkbox.setChecked(self.show_colormap_line)
-        self.colormap_line_checkbox.stateChanged.connect(
-            self._on_plot_setting_changed
-        )
-        row1.addWidget(self.colormap_line_checkbox)
-
+        # Top row: display checkboxes side by side.
+        checks_row = QHBoxLayout()
         self.show_dots_checkbox = QCheckBox("Show component positions")
         self.show_dots_checkbox.setChecked(self.show_component_dots)
         self.show_dots_checkbox.stateChanged.connect(
             self._on_plot_setting_changed
         )
-        row1.addWidget(self.show_dots_checkbox)
-        row1.addStretch()
-        vbox.addLayout(row1)
+        checks_row.addWidget(self.show_dots_checkbox)
+        checks_row.addStretch()
+        vbox.addLayout(checks_row)
 
-        # Row 2: line offset
-        row2 = QHBoxLayout()
-        row2.addWidget(QLabel("Line offset:"))
-        self.line_offset_slider = QSlider(Qt.Horizontal)
-        self.line_offset_slider.setRange(-500, 500)
-        self.line_offset_slider.setValue(int(self.line_offset * 1000))
-        self.line_offset_slider.valueChanged.connect(
-            self._on_line_offset_changed
+        # --- Line group -----------------------------------------------------
+        line_group = QGroupBox("Line")
+        line_layout = QVBoxLayout(line_group)
+
+        self.colormap_line_checkbox = QCheckBox("Overlay colormap")
+        self.colormap_line_checkbox.setChecked(self.show_colormap_line)
+        self.colormap_line_checkbox.stateChanged.connect(
+            self._on_plot_setting_changed
         )
-        row2.addWidget(self.line_offset_slider)
-        self.line_offset_value_label = QLabel(f"{self.line_offset:.3f}")
-        row2.addWidget(self.line_offset_value_label)
-        vbox.addLayout(row2)
+        line_layout.addWidget(self.colormap_line_checkbox)
 
-        # Row 3: width & alpha
-        row3 = QHBoxLayout()
-        row3.addWidget(QLabel("Line width:"))
-        self.line_width_spin = QDoubleSpinBox()
-        self.line_width_spin.setRange(0.5, 20.0)
-        self.line_width_spin.setSingleStep(0.5)
-        self.line_width_spin.setValue(self.line_width)
-        self.line_width_spin.valueChanged.connect(self._on_line_width_changed)
-        row3.addWidget(self.line_width_spin)
-
-        row3.addWidget(QLabel("Alpha:"))
-        self.line_alpha_slider = QSlider(Qt.Horizontal)
-        self.line_alpha_slider.setRange(0, 100)
-        self.line_alpha_slider.setValue(int(self.line_alpha * 100))
-        self.line_alpha_slider.valueChanged.connect(
-            self._on_line_alpha_changed
+        width_row, self.line_width_slider, self.line_width_spin = (
+            self._make_slider_spin_row(
+                "Width:",
+                0.5,
+                20.0,
+                self.line_width,
+                1,
+                self._on_line_width_changed,
+                step=0.5,
+            )
         )
-        row3.addWidget(self.line_alpha_slider)
-        self.line_alpha_value_label = QLabel(f"{self.line_alpha:.2f}")
-        row3.addWidget(self.line_alpha_value_label)
+        (
+            line_transp_row,
+            self.line_transparency_slider,
+            self.line_transparency_spin,
+        ) = self._make_slider_spin_row(
+            "Transparency:",
+            0.0,
+            1.0,
+            1.0 - self.line_alpha,
+            2,
+            self._on_line_transparency_changed,
+        )
+        top_line_row = QHBoxLayout()
+        top_line_row.addLayout(width_row)
+        top_line_row.addSpacing(12)
+        top_line_row.addLayout(line_transp_row)
+        line_layout.addLayout(top_line_row)
 
-        row3.addStretch()
-        vbox.addLayout(row3)
-
-        # Row 4: Color selection
-        row4 = QHBoxLayout()
-        row4.addWidget(QLabel("Default color:"))
+        offset_row, self.line_offset_slider, self.line_offset_spin = (
+            self._make_slider_spin_row(
+                "Offset:",
+                -1.0,
+                1.0,
+                self.line_offset,
+                3,
+                self._on_line_offset_changed,
+                center_fill=True,
+                tooltip="Shift the line perpendicular to its direction.",
+            )
+        )
+        color_row = QHBoxLayout()
+        color_row.addWidget(QLabel("Default color:"))
         self.color_button = QPushButton()
         self.color_button.setMaximumWidth(80)
         self.color_button.setStyleSheet(
-            f"background-color: {self.default_component_color}; border: 1px solid black;"
+            f"background-color: {self.default_component_color}; "
+            "border: 1px solid black;"
         )
         self.color_button.clicked.connect(self._on_color_button_clicked)
-        row4.addWidget(self.color_button)
+        color_row.addWidget(self.color_button)
+        color_row.addStretch()
 
-        row4.addStretch()
-        vbox.addLayout(row4)
+        bottom_line_row = QHBoxLayout()
+        bottom_line_row.addLayout(offset_row)
+        bottom_line_row.addSpacing(12)
+        bottom_line_row.addLayout(color_row)
+        line_layout.addLayout(bottom_line_row)
+        vbox.addWidget(line_group)
+
+        # --- Fraction histogram group --------------------------------------
+        hist_group = QGroupBox("Fraction histogram overlay")
+        hist_layout = QVBoxLayout(hist_group)
+
+        self.fraction_histogram_checkbox = QCheckBox(
+            "Overlay fraction histogram"
+        )
+        self.fraction_histogram_checkbox.setChecked(
+            self.show_fraction_histogram
+        )
+        self.fraction_histogram_checkbox.setToolTip(
+            "Overlay the histogram of the first component's fraction on top "
+            "of the line joining the components, colored with the line's "
+            "colormap. Available for a two-component Linear Projection."
+        )
+        self.fraction_histogram_checkbox.stateChanged.connect(
+            self._on_plot_setting_changed
+        )
+        hist_layout.addWidget(self.fraction_histogram_checkbox)
+
+        (
+            height_row,
+            self.histogram_height_slider,
+            self.histogram_height_spin,
+        ) = self._make_slider_spin_row(
+            "Height:",
+            0.05,
+            1.0,
+            self.histogram_overlay_height,
+            2,
+            self._on_histogram_height_changed,
+        )
+        (
+            hist_transp_row,
+            self.histogram_transparency_slider,
+            self.histogram_transparency_spin,
+        ) = self._make_slider_spin_row(
+            "Transparency:",
+            0.0,
+            1.0,
+            1.0 - self.histogram_alpha,
+            2,
+            self._on_histogram_transparency_changed,
+        )
+        top_hist_row = QHBoxLayout()
+        top_hist_row.addLayout(height_row)
+        top_hist_row.addSpacing(12)
+        top_hist_row.addLayout(hist_transp_row)
+        hist_layout.addLayout(top_hist_row)
+
+        (
+            hist_offset_row,
+            self.histogram_offset_slider,
+            self.histogram_offset_spin,
+        ) = self._make_slider_spin_row(
+            "Offset:",
+            -1.0,
+            1.0,
+            self.histogram_offset,
+            3,
+            self._on_histogram_offset_changed,
+            center_fill=True,
+            tooltip="Shift the histogram relative to the line. Positive keeps "
+            "it on one side; negative flips it to the other side. The "
+            "magnitude is the distance from the line.",
+        )
+        hist_layout.addLayout(hist_offset_row)
+        vbox.addWidget(hist_group)
 
         # Buttons
         buttons_layout = QHBoxLayout()
-
         reset_button = QPushButton("Reset")
         reset_button.clicked.connect(self._reset_plot_settings)
         buttons_layout.addWidget(reset_button)
-
         buttons_layout.addStretch()
-
         close_button = QPushButton("Close")
         close_button.clicked.connect(self.plot_dialog.close)
         buttons_layout.addWidget(close_button)
-
         vbox.addLayout(buttons_layout)
 
         self.plot_dialog.show()
@@ -1638,6 +1929,8 @@ class ComponentsWidget(QWidget):
             with contextlib.suppress(ValueError, AttributeError):
                 self.component_line.remove()
             self.component_line = None
+
+        self._remove_histogram_overlay()
 
         if self.parent_widget is not None:
             self.parent_widget.canvas_widget.canvas.draw_idle()
@@ -1782,23 +2075,43 @@ class ComponentsWidget(QWidget):
         default_line_alpha = 1
         default_component_color = 'dimgray'
 
+        default_show_fraction_histogram = False
+        default_histogram_overlay_height = 0.3
+        default_histogram_offset = 0.0
+        default_histogram_alpha = 0.75
+
         self.show_colormap_line = default_show_colormap_line
         self.show_component_dots = default_show_component_dots
         self.line_offset = default_line_offset
         self.line_width = default_line_width
         self.line_alpha = default_line_alpha
         self.default_component_color = default_component_color
+        self.show_fraction_histogram = default_show_fraction_histogram
+        self.histogram_overlay_height = default_histogram_overlay_height
+        self.histogram_offset = default_histogram_offset
+        self.histogram_alpha = default_histogram_alpha
 
         self.colormap_line_checkbox.setChecked(default_show_colormap_line)
         self.show_dots_checkbox.setChecked(default_show_component_dots)
 
-        self.line_offset_slider.setValue(int(default_line_offset * 1000))
-        self.line_offset_value_label.setText(f"{default_line_offset:.3f}")
+        if hasattr(self, 'fraction_histogram_checkbox'):
+            self.fraction_histogram_checkbox.setChecked(
+                default_show_fraction_histogram
+            )
 
-        self.line_width_spin.setValue(default_line_width)
-
-        self.line_alpha_slider.setValue(int(default_line_alpha * 100))
-        self.line_alpha_value_label.setText(f"{default_line_alpha:.2f}")
+        # Updating the spinboxes cascades to the linked sliders and their
+        # value handlers, so this both refreshes the UI and re-applies state.
+        for attr, val in (
+            ('line_offset_spin', default_line_offset),
+            ('line_width_spin', default_line_width),
+            ('line_transparency_spin', 1.0 - default_line_alpha),
+            ('histogram_height_spin', default_histogram_overlay_height),
+            ('histogram_offset_spin', default_histogram_offset),
+            ('histogram_transparency_spin', 1.0 - default_histogram_alpha),
+        ):
+            spin = getattr(self, attr, None)
+            if spin is not None:
+                spin.setValue(val)
 
         if hasattr(self, 'color_button'):
             self.color_button.setStyleSheet(
@@ -1833,6 +2146,9 @@ class ComponentsWidget(QWidget):
                 )
                 self.comp1_fractions_layer.events.contrast_limits.disconnect(
                     self._on_contrast_limits_changed
+                )
+                self.comp1_fractions_layer.events.gamma.disconnect(
+                    self._on_colormap_changed
                 )
 
                 if self._saved_colormap_colors is not None:
@@ -1872,6 +2188,9 @@ class ComponentsWidget(QWidget):
                 self.comp1_fractions_layer.events.contrast_limits.connect(
                     self._on_contrast_limits_changed
                 )
+                self.comp1_fractions_layer.events.gamma.connect(
+                    self._on_colormap_changed
+                )
 
                 self.draw_line_between_components()
 
@@ -1883,6 +2202,9 @@ class ComponentsWidget(QWidget):
                     )
                     self.comp1_fractions_layer.events.contrast_limits.connect(
                         self._on_contrast_limits_changed
+                    )
+                    self.comp1_fractions_layer.events.gamma.connect(
+                        self._on_colormap_changed
                     )
                 except Exception:  # noqa: BLE001
                     pass
@@ -1900,6 +2222,11 @@ class ComponentsWidget(QWidget):
             artists.append(self.component_line)
         if self.component_polygon is not None:
             artists.append(self.component_polygon)
+        if self.component_histogram is not None:
+            hist_artists = self.component_histogram
+            if not isinstance(hist_artists, (list, tuple)):
+                hist_artists = [hist_artists]
+            artists.extend(hist_artists)
         return artists
 
     def set_artists_visible(self, visible):
@@ -1914,6 +2241,12 @@ class ComponentsWidget(QWidget):
             self.component_line.set_visible(visible)
         if self.component_polygon is not None:
             self.component_polygon.set_visible(visible)
+        if self.component_histogram is not None:
+            hist_artists = self.component_histogram
+            if not isinstance(hist_artists, (list, tuple)):
+                hist_artists = [hist_artists]
+            for artist in hist_artists:
+                artist.set_visible(visible)
 
     def clear_artists(self):
         """Clear (remove) all artists created by this widget."""
@@ -1937,6 +2270,15 @@ class ComponentsWidget(QWidget):
             self._update_components_setting_in_metadata(
                 'two_component_line_settings.show_component_dots',
                 self.show_component_dots,
+            )
+
+        if hasattr(self, 'fraction_histogram_checkbox'):
+            self.show_fraction_histogram = (
+                self.fraction_histogram_checkbox.isChecked()
+            )
+            self._update_components_setting_in_metadata(
+                'two_component_line_settings.show_fraction_histogram',
+                self.show_fraction_histogram,
             )
 
         active_components = [
@@ -1967,20 +2309,53 @@ class ComponentsWidget(QWidget):
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
     def _on_line_offset_changed(self, value):
-        """Handle changes to line offset from slider."""
-        self.line_offset = value / 1000.0
+        """Handle changes to line offset (float, data units)."""
+        self.line_offset = float(value)
         self._update_components_setting_in_metadata(
             'two_component_line_settings.line_offset', self.line_offset
         )
-
-        if hasattr(self, 'line_offset_value_label'):
-            self.line_offset_value_label.setText(f"{self.line_offset:.3f}")
         self.draw_line_between_components()
         if self.parent_widget is not None:
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
+    def _on_histogram_height_changed(self, value):
+        """Handle changes to the fraction histogram overlay height (float)."""
+        self.histogram_overlay_height = float(value)
+        self._update_components_setting_in_metadata(
+            'two_component_line_settings.histogram_overlay_height',
+            self.histogram_overlay_height,
+        )
+        if self.show_fraction_histogram:
+            self.draw_line_between_components()
+            if self.parent_widget is not None:
+                self.parent_widget.canvas_widget.canvas.draw_idle()
+
+    def _on_histogram_offset_changed(self, value):
+        """Handle changes to the fraction histogram overlay offset (float)."""
+        self.histogram_offset = float(value)
+        self._update_components_setting_in_metadata(
+            'two_component_line_settings.histogram_offset',
+            self.histogram_offset,
+        )
+        if self.show_fraction_histogram:
+            self.draw_line_between_components()
+            if self.parent_widget is not None:
+                self.parent_widget.canvas_widget.canvas.draw_idle()
+
+    def _on_histogram_transparency_changed(self, value):
+        """Handle changes to the histogram transparency (0=opaque, 1=clear)."""
+        self.histogram_alpha = 1.0 - float(value)
+        self._update_components_setting_in_metadata(
+            'two_component_line_settings.histogram_alpha',
+            self.histogram_alpha,
+        )
+        if self.show_fraction_histogram:
+            self.draw_line_between_components()
+            if self.parent_widget is not None:
+                self.parent_widget.canvas_widget.canvas.draw_idle()
+
     def _on_line_width_changed(self, value):
-        """Handle changes to line width from spinbox."""
+        """Handle changes to line width (float)."""
         self.line_width = float(value)
         self._update_components_setting_in_metadata(
             'two_component_line_settings.line_width', self.line_width
@@ -1997,15 +2372,12 @@ class ComponentsWidget(QWidget):
             if self.parent_widget is not None:
                 self.parent_widget.canvas_widget.canvas.draw_idle()
 
-    def _on_line_alpha_changed(self, value):
-        """Handle changes to line alpha from slider."""
-        self.line_alpha = value / 100.0
+    def _on_line_transparency_changed(self, value):
+        """Handle changes to line transparency (0=opaque, 1=clear)."""
+        self.line_alpha = 1.0 - float(value)
         self._update_components_setting_in_metadata(
             'two_component_line_settings.line_alpha', self.line_alpha
         )
-
-        if hasattr(self, 'line_alpha_value_label'):
-            self.line_alpha_value_label.setText(f"{self.line_alpha:.2f}")
 
         if self.component_line is not None and hasattr(
             self.component_line, 'set_alpha'
@@ -3075,6 +3447,8 @@ class ComponentsWidget(QWidget):
                 self.component_polygon.remove()
             self.component_polygon = None
 
+        self._remove_histogram_overlay()
+
         try:
             if len(active_components) >= 3:
                 self._update_polygon()
@@ -3141,6 +3515,14 @@ class ComponentsWidget(QWidget):
                         self.component_line.set_solid_capstyle('butt')
 
                 self._update_component_colors()
+
+            if (
+                self.show_fraction_histogram
+                and self.analysis_type == "Linear Projection"
+                and self.comp1_fractions_layer is not None
+                and self.fractions_colormap is not None
+            ):
+                self._draw_fraction_histogram_overlay(ax, ox1, oy1, ox2, oy2)
 
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
@@ -3222,13 +3604,90 @@ class ComponentsWidget(QWidget):
             segments, cmap=colormap, linewidths=self.line_width
         )
         lc.set_array(np.array(colors))
-        lc.set_clim(vmin, vmax)
+        gamma = getattr(self, 'fractions_gamma', 1.0) or 1.0
+        if gamma != 1.0 and vmax > vmin:
+            # Match the fraction layer's gamma so the phasor-plot gradient
+            # reads the same as the image and the histogram.
+            lc.set_norm(PowerNorm(gamma, vmin=vmin, vmax=vmax))
+        else:
+            lc.set_clim(vmin, vmax)
         lc.set_alpha(self.line_alpha)
 
         if hasattr(lc, "set_capstyle"):
             with contextlib.suppress(Exception):
                 lc.set_capstyle('butt')
         self.component_line = ax.add_collection(lc)
+
+    def _remove_histogram_overlay(self):
+        """Remove the fraction histogram overlay artists, if present."""
+        if self.component_histogram is None:
+            return
+        artists = self.component_histogram
+        if not isinstance(artists, (list, tuple)):
+            artists = [artists]
+        for artist in artists:
+            with contextlib.suppress(ValueError, AttributeError):
+                artist.remove()
+        self.component_histogram = None
+
+    def _get_first_component_fraction_values(self):
+        """Return the pooled first-component fraction values for the histogram.
+
+        Pools the current (possibly range-clipped) fraction data across every
+        image layer analyzed for the first component so the overlay tracks the
+        histogram widget's range slider, matching the merged fraction histogram.
+        """
+        comp1_name = None
+        if self.components and self.components[0] is not None:
+            comp1_name = self.components[0].name_edit.text().strip()
+        if not comp1_name:
+            comp1_name = "Component 1"
+
+        layers = self._get_fraction_layers_for_component(comp1_name)
+        arrays = []
+        for fl in layers.values():
+            arrays.append(np.asarray(fl.data, dtype=float).ravel())
+
+        if not arrays and self.comp1_fractions_layer is not None:
+            arrays.append(
+                np.asarray(
+                    self.comp1_fractions_layer.data, dtype=float
+                ).ravel()
+            )
+
+        if not arrays:
+            return np.empty(0)
+
+        pooled = np.concatenate(arrays)
+        return pooled[np.isfinite(pooled)]
+
+    def _draw_fraction_histogram_overlay(self, ax, x1, y1, x2, y2):
+        """Overlay the first component's fraction histogram on the line.
+
+        Delegates to the shared, stateless
+        :func:`draw_fraction_histogram_overlay` so the interactive plot and the
+        batch-analysis export render identically.
+        """
+        if self.comp1_fractions_layer is None:
+            return
+
+        values = self._get_first_component_fraction_values()
+        artists = draw_fraction_histogram_overlay(
+            ax,
+            x1,
+            y1,
+            x2,
+            y2,
+            values,
+            self.fractions_colormap,
+            height=self.histogram_overlay_height,
+            offset=self.histogram_offset,
+            alpha=self.histogram_alpha,
+            contrast_limits=self.colormap_contrast_limits,
+            gamma=getattr(self, 'fractions_gamma', 1.0),
+        )
+        if artists:
+            self.component_histogram = artists
 
     def _update_polygon(self):
         """Update polygon for multi-component visualization."""
@@ -3274,16 +3733,19 @@ class ComponentsWidget(QWidget):
         if getattr(self, '_updating_linked_layers', False):
             return
 
-        if (
-            self.comp1_fractions_layer is not None
-            and layer == self.comp1_fractions_layer
-        ):
-            self.fractions_colormap = layer.colormap.colors
-            self.colormap_contrast_limits = layer.contrast_limits
-
         comp_idx = self._find_component_index_for_layer(layer)
         if comp_idx is None:
             return
+
+        # The phasor-plot line/overlay gradient tracks the FIRST component's
+        # colormap. With multiple analyzed images there is one fraction layer
+        # per image, so update the gradient for ANY first-component layer -- not
+        # only the specific one stored in ``comp1_fractions_layer`` (which would
+        # otherwise leave the line stale when a different image's layer changes).
+        if comp_idx == 0:
+            self.fractions_colormap = layer.colormap.colors
+            self.colormap_contrast_limits = layer.contrast_limits
+            self.fractions_gamma = layer.gamma
 
         colormap_name = getattr(layer.colormap, 'name', 'custom')
         is_standard_colormap = self._is_standard_colormap(colormap_name)
@@ -3307,8 +3769,10 @@ class ComponentsWidget(QWidget):
             tuple(layer.contrast_limits),
         )
 
-        # Sync colormap to all other layers belonging to the same component
+        # Sync colormap / gamma to all other layers belonging to the same
+        # component so the derived layers of every analyzed image stay in step.
         self._sync_component_layers_colormap(comp_idx, layer.colormap)
+        self._sync_component_layers_gamma(comp_idx, layer.gamma)
 
         self._update_component_colors()
         self.draw_line_between_components()
@@ -3333,6 +3797,7 @@ class ComponentsWidget(QWidget):
             self.histogram_widget.update_colormap(
                 colormap_colors=layer.colormap.colors,
                 contrast_limits=list(layer.contrast_limits),
+                gamma=layer.gamma,
             )
         else:
             self._refresh_second_component_colormap(
@@ -3347,15 +3812,14 @@ class ComponentsWidget(QWidget):
         if getattr(self, '_updating_linked_layers', False):
             return
 
-        if (
-            self.comp1_fractions_layer is not None
-            and layer == self.comp1_fractions_layer
-        ):
-            self.colormap_contrast_limits = layer.contrast_limits
-
         comp_idx = self._find_component_index_for_layer(layer)
         if comp_idx is None:
             return
+
+        # Keep the line gradient's contrast in sync for any first-component
+        # fraction layer, not just the one stored in ``comp1_fractions_layer``.
+        if comp_idx == 0:
+            self.colormap_contrast_limits = layer.contrast_limits
 
         contrast_limits = layer.contrast_limits
         if hasattr(contrast_limits, 'tolist') or isinstance(
@@ -3426,6 +3890,7 @@ class ComponentsWidget(QWidget):
             self.histogram_widget.update_colormap(
                 colormap_colors=layer.colormap.colors,
                 contrast_limits=contrast_limits,
+                gamma=layer.gamma,
             )
         else:
             self._refresh_second_component_colormap(
@@ -3456,6 +3921,7 @@ class ComponentsWidget(QWidget):
         self.histogram_widget.update_colormap(
             colormap_colors=np.asarray(layer.colormap.colors)[::-1],
             contrast_limits=[1.0 - limits[1], 1.0 - limits[0]],
+            gamma=layer.gamma,
         )
 
     def _find_component_index_for_layer(self, layer):
@@ -3528,6 +3994,21 @@ class ComponentsWidget(QWidget):
             for layer in layers_to_update:
                 if layer.contrast_limits != contrast_limits:
                     layer.contrast_limits = contrast_limits
+        finally:
+            self._updating_linked_layers = False
+
+    def _sync_component_layers_gamma(self, comp_idx, gamma):
+        """Sync gamma across all layers belonging to the same component."""
+        if getattr(self, '_updating_linked_layers', False):
+            return
+
+        try:
+            self._updating_linked_layers = True
+            layers_to_update = self._get_all_layers_for_component(comp_idx)
+
+            for layer in layers_to_update:
+                if layer.gamma != gamma:
+                    layer.gamma = gamma
         finally:
             self._updating_linked_layers = False
 
@@ -3807,6 +4288,9 @@ class ComponentsWidget(QWidget):
                 self.comp1_fractions_layer.events.contrast_limits.connect(
                     self._on_contrast_limits_changed
                 )
+                self.comp1_fractions_layer.events.gamma.connect(
+                    self._on_colormap_changed
+                )
         else:
             possible_names = [
                 f"Component {idx + 1} fractions: {layer_name}",
@@ -3825,6 +4309,9 @@ class ComponentsWidget(QWidget):
                         )
                         self.comp1_fractions_layer.events.contrast_limits.connect(
                             self._on_contrast_limits_changed
+                        )
+                        self.comp1_fractions_layer.events.gamma.connect(
+                            self._on_colormap_changed
                         )
                     break
 
@@ -3903,6 +4390,9 @@ class ComponentsWidget(QWidget):
                 self.comp1_fractions_layer.events.contrast_limits.disconnect(
                     self._on_contrast_limits_changed
                 )
+                self.comp1_fractions_layer.events.gamma.disconnect(
+                    self._on_colormap_changed
+                )
             except Exception:  # noqa: BLE001
                 pass
 
@@ -3910,6 +4400,7 @@ class ComponentsWidget(QWidget):
         self.comp2_fractions_layer = None
         self.fractions_colormap = None
         self.colormap_contrast_limits = None
+        self.fractions_gamma = 1.0
 
     def _restore_on_layer_change(self):
         """Deferred restore: update UI state from metadata."""
@@ -4192,7 +4683,8 @@ class ComponentsWidget(QWidget):
         current_harmonic = getattr(self.parent_widget, 'harmonic', 1)
         harmonic_key = str(current_harmonic)
 
-        comp1_colormap = 'jet'
+        comp1_colormap = None
+        comp1_gamma = None
         valid_fraction = fraction_comp1[np.isfinite(fraction_comp1)]
         if valid_fraction.size > 0:
             frac_min = float(np.min(valid_fraction))
@@ -4203,7 +4695,18 @@ class ComponentsWidget(QWidget):
         else:
             contrast_limits = (0, 1)
 
-        if '0' in settings.get('components', {}):
+        # If the fraction layer is already displayed (the user clicked the
+        # button again), preserve its current colormap, contrast limits and
+        # gamma. This takes precedence over the stored defaults so manual
+        # display tweaks - including colormaps propagated from other analyzed
+        # images - survive a re-display.
+        if comp1_fractions_layer_name in self.viewer.layers:
+            existing_layer = self.viewer.layers[comp1_fractions_layer_name]
+            comp1_colormap = existing_layer.colormap
+            contrast_limits = existing_layer.contrast_limits
+            comp1_gamma = existing_layer.gamma
+
+        if comp1_colormap is None and '0' in settings.get('components', {}):
             comp_data = settings['components']['0']
             if harmonic_key in comp_data.get('gs_harmonics', {}):
                 harmonic_data = comp_data['gs_harmonics'][harmonic_key]
@@ -4240,6 +4743,11 @@ class ComponentsWidget(QWidget):
                             contrast_limits = tuple(
                                 harmonic_data['contrast_limits']
                             )
+                        if harmonic_data.get('gamma') is not None:
+                            comp1_gamma = harmonic_data['gamma']
+
+        if comp1_colormap is None:
+            comp1_colormap = 'jet'
 
         if comp1_fractions_layer_name in self.viewer.layers:
             self.viewer.layers.remove(
@@ -4257,6 +4765,8 @@ class ComponentsWidget(QWidget):
         self.comp1_fractions_layer = self.viewer.add_layer(
             comp1_selected_fractions_layer
         )
+        if comp1_gamma is not None:
+            self.comp1_fractions_layer.gamma = comp1_gamma
         self.comp1_fractions_layer.metadata['fraction_data_original'] = (
             fraction_comp1.copy()
         )
@@ -4306,12 +4816,18 @@ class ComponentsWidget(QWidget):
                 comp_data['gs_harmonics'][harmonic_key]['contrast_limits'] = (
                     list(self.comp1_fractions_layer.contrast_limits)
                 )
+                comp_data['gs_harmonics'][harmonic_key][
+                    'gamma'
+                ] = self.comp1_fractions_layer.gamma
 
         self.comp1_fractions_layer.events.colormap.connect(
             self._on_colormap_changed
         )
         self.comp1_fractions_layer.events.contrast_limits.connect(
             self._on_contrast_limits_changed
+        )
+        self.comp1_fractions_layer.events.gamma.connect(
+            self._on_colormap_changed
         )
 
         self._update_component_colors()
@@ -4505,6 +5021,7 @@ class ComponentsWidget(QWidget):
                 fraction_layer_name = f"{name} fraction: {layer.name}"
 
                 colormap = None
+                gamma = None
                 valid_fraction = fraction[np.isfinite(fraction)]
                 if valid_fraction.size > 0:
                     frac_min = float(np.min(valid_fraction))
@@ -4516,7 +5033,18 @@ class ComponentsWidget(QWidget):
                     contrast_limits = (0, 1)
                 idx_str = str(i)
 
-                if (
+                # If the fraction layer is already displayed (the user clicked
+                # the button again), preserve its current colormap, contrast
+                # limits and gamma. This takes precedence over the stored
+                # defaults so manual display tweaks - including colormaps
+                # propagated from other analyzed images - survive a re-display.
+                if fraction_layer_name in self.viewer.layers:
+                    existing_layer = self.viewer.layers[fraction_layer_name]
+                    colormap = existing_layer.colormap
+                    contrast_limits = existing_layer.contrast_limits
+                    gamma = existing_layer.gamma
+
+                if colormap is None and (
                     not self._updating_settings
                     and idx_str in settings.get('components', {})
                     and harmonic_key
@@ -4545,14 +5073,8 @@ class ComponentsWidget(QWidget):
                             contrast_limits = tuple(
                                 harmonic_data['contrast_limits']
                             )
-
-                if (
-                    colormap is None
-                    and fraction_layer_name in self.viewer.layers
-                ):
-                    existing_layer = self.viewer.layers[fraction_layer_name]
-                    colormap = existing_layer.colormap
-                    contrast_limits = existing_layer.contrast_limits
+                        if harmonic_data.get('gamma') is not None:
+                            gamma = harmonic_data['gamma']
 
                 if colormap is None:
                     if i < len(self.component_colormap_names):
@@ -4573,12 +5095,15 @@ class ComponentsWidget(QWidget):
                 new_layer.metadata['fraction_data_original'] = fraction.copy()
 
                 new_layer.contrast_limits = contrast_limits
+                if gamma is not None:
+                    new_layer.gamma = gamma
 
                 self.fraction_layers.append(new_layer)
                 new_layer.events.colormap.connect(self._on_colormap_changed)
                 new_layer.events.contrast_limits.connect(
                     self._on_contrast_limits_changed
                 )
+                new_layer.events.gamma.connect(self._on_colormap_changed)
 
                 if (
                     not self._updating_settings
@@ -4626,6 +5151,9 @@ class ComponentsWidget(QWidget):
                     comp_data['gs_harmonics'][harmonic_key][
                         'contrast_limits'
                     ] = list(new_layer.contrast_limits)
+                    comp_data['gs_harmonics'][harmonic_key][
+                        'gamma'
+                    ] = new_layer.gamma
 
             self._update_component_colors()
 
@@ -4923,10 +5451,20 @@ class ComponentsWidget(QWidget):
         self.histogram_widget.update_colormap(
             colormap_colors=colormap_colors,
             contrast_limits=[min_val, max_val],
+            gamma=first_layer.gamma,
         )
 
+        # Pool the (clipped) data from every selected layer into a single
+        # merged histogram so all layers contribute, rather than showing a
+        # per-layer mean +/- SD that visually resembles a single layer.
         if len(clipped_data) > 1:
-            self.histogram_widget.update_multi_data(clipped_data)
+            pooled = np.concatenate(
+                [
+                    np.asarray(d, dtype=float).ravel()
+                    for d in clipped_data.values()
+                ]
+            )
+            self.histogram_widget.update_data(pooled)
         else:
             first_data = next(iter(clipped_data.values()))
             self.histogram_widget.update_data(first_data)
@@ -4963,6 +5501,7 @@ class ComponentsWidget(QWidget):
         self.histogram_widget.update_colormap(
             colormap_colors=colormap_colors,
             contrast_limits=contrast_limits,
+            gamma=first_layer.gamma,
         )
 
         # Ensure the range slider uses the full original data extent.
@@ -5007,6 +5546,7 @@ class ComponentsWidget(QWidget):
             self.histogram_widget.update_colormap(
                 colormap_colors=colormap_colors,
                 contrast_limits=[range_min, range_max],
+                gamma=first_layer.gamma,
             )
 
             self.histogram_widget.set_range(
@@ -5016,12 +5556,19 @@ class ComponentsWidget(QWidget):
                 slider_max=data_max,
             )
 
+        # Pool the data from every selected layer into a single merged
+        # histogram so all layers contribute, rather than showing a per-layer
+        # mean +/- SD that visually resembles a single layer.
         if len(fraction_layers_map) > 1:
-            per_layer_data = {
-                img_name: (1.0 - fl.data if invert else fl.data)
-                for img_name, fl in fraction_layers_map.items()
-            }
-            self.histogram_widget.update_multi_data(per_layer_data)
+            pooled_layers = [
+                (
+                    1.0 - np.asarray(fl.data, dtype=float)
+                    if invert
+                    else np.asarray(fl.data, dtype=float)
+                ).ravel()
+                for fl in fraction_layers_map.values()
+            ]
+            self.histogram_widget.update_data(np.concatenate(pooled_layers))
         else:
             data = first_layer.data
             if invert:
@@ -5042,6 +5589,185 @@ class ComponentsWidget(QWidget):
         event.accept()
 
 
+def draw_fraction_histogram_overlay(
+    ax,
+    x1,
+    y1,
+    x2,
+    y2,
+    values,
+    fractions_colormap,
+    *,
+    height=0.3,
+    offset=0.0,
+    alpha=0.75,
+    bins=150,
+    contrast_limits=None,
+    gamma=1.0,
+):
+    """Draw the first-component fraction histogram along the component line.
+
+    Stateless helper shared by the interactive Components tab and the batch
+    export so both render identically. The histogram of ``values`` (the
+    first-component fraction) uses the line joining the two components as its
+    baseline and rises perpendicular to it; the area under the curve is filled
+    with a seamless colormap gradient (a single ``imshow`` clipped to the curve
+    polygon and transformed into the line's frame).
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axes hosting the phasor plot.
+    x1, y1, x2, y2 : float
+        Endpoints of the (possibly offset) component line: component 1 at
+        ``(x1, y1)``, component 2 at ``(x2, y2)``.
+    values : array-like
+        First-component fraction values (any shape); flattened and filtered.
+    fractions_colormap : array-like or None
+        Nx4 RGBA color ramp for the gradient (falls back to ``jet``).
+    height : float
+        Peak histogram height as a fraction of the line length.
+    offset : float
+        Signed perpendicular offset of the histogram relative to the line.
+        Positive keeps it on the "up" side; negative flips it to the other side.
+    alpha : float
+        Opacity of the gradient fill.
+    bins : int
+        Number of histogram bins.
+    contrast_limits : sequence of float, optional
+        ``(vmin, vmax)`` in first-component fraction space used to normalize the
+        gradient. When given, the gradient tracks the fraction layer's contrast
+        limits / range slider; otherwise it falls back to the data extent.
+
+    Returns
+    -------
+    list of matplotlib artists, or ``None`` if nothing was drawn.
+    """
+    values = np.asarray(values, dtype=float).ravel()
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return None
+
+    counts, bin_edges = np.histogram(values, bins=bins, range=(0.0, 1.0))
+    if counts.max() == 0:
+        return None
+    bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+
+    # Smooth the curve for a clean profile, matching the histogram widget.
+    counts = counts.astype(float)
+    with contextlib.suppress(Exception):
+        import scipy.ndimage
+
+        counts = scipy.ndimage.gaussian_filter1d(counts, sigma=2)
+    peak = counts.max()
+    if peak <= 0:
+        return None
+
+    # Geometry of the (possibly offset) component line.
+    dx = x2 - x1
+    dy = y2 - y1
+    length = np.hypot(dx, dy)
+    if length == 0:
+        return None
+    ux, uy = dx / length, dy / length
+    # Base normal, pointing "up" on screen for a consistent orientation.
+    nx, ny = -uy, ux
+    if ny < 0:
+        nx, ny = -nx, -ny
+
+    # Signed histogram offset relative to the line: positive keeps the
+    # histogram on the "up" side, negative flips it to the other side. The
+    # magnitude displaces the baseline from the line by that distance.
+    rise_sign = -1.0 if offset < 0 else 1.0
+    rdx, rdy = rise_sign * nx, rise_sign * ny
+    origin_x = x1 + offset * nx
+    origin_y = y1 + offset * ny
+
+    max_height = height * length
+    heights = counts / peak * max_height
+    v_max = float(np.max(heights))
+    if v_max <= 0:
+        return None
+
+    # Colormap consistent with the component line.
+    if fractions_colormap is not None and len(fractions_colormap) > 0:
+        if len(fractions_colormap) <= 32:
+            cmap = LinearSegmentedColormap.from_list(
+                "fractions_interp", fractions_colormap, N=256
+            )
+        else:
+            cmap = ListedColormap(fractions_colormap)
+    else:
+        cmap = plt.cm.jet
+
+    # Normalize the gradient to the fraction layer's contrast limits (or range
+    # slider) when provided, so the overlay tracks those controls. Fall back to
+    # the full data extent otherwise.
+    if contrast_limits is not None:
+        vmin = float(contrast_limits[0])
+        vmax = float(contrast_limits[1])
+    else:
+        vmin = float(np.min(values))
+        vmax = float(np.max(values))
+    if vmax <= vmin:
+        vmax = vmin + 1e-6
+    gamma = gamma or 1.0
+    if gamma != 1.0:
+        norm = PowerNorm(gamma, vmin=vmin, vmax=vmax)
+    else:
+        norm = plt.Normalize(vmin=vmin, vmax=vmax)
+
+    alpha = min(1.0, max(0.0, alpha))
+
+    # Local (u, v) frame: u runs along the line (u=0 at component 1,
+    # u=length at component 2), v rises perpendicular. A point (u, v) maps to
+    # data coordinates via ``origin + u*along + v*rise``.
+    local_to_data = Affine2D(
+        matrix=np.array(
+            [
+                [ux, rdx, origin_x],
+                [uy, rdy, origin_y],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+    )
+    transform = local_to_data + ax.transData
+
+    # Gradient image varying along u (fraction 1 at component 1 -> 0 at
+    # component 2). Preserve the plot's view limits, which ``imshow`` would
+    # otherwise try to rescale.
+    prev_xlim = ax.get_xlim()
+    prev_ylim = ax.get_ylim()
+    gradient = np.linspace(1.0, 0.0, 256).reshape(1, -1)
+    im = ax.imshow(
+        gradient,
+        aspect="auto",
+        extent=[0.0, length, 0.0, v_max],
+        origin="lower",
+        cmap=cmap,
+        norm=norm,
+        alpha=alpha,
+        interpolation="bilinear",
+        zorder=11,
+    )
+    im.set_transform(transform)
+    ax.set_xlim(prev_xlim)
+    ax.set_ylim(prev_ylim)
+
+    # Clip the gradient to the area under the (smoothed) histogram curve.
+    u_curve = (1.0 - bin_centers) * length
+    clip_verts = np.column_stack(
+        [
+            np.concatenate([u_curve, u_curve[::-1]]),
+            np.concatenate([heights, np.zeros_like(heights)]),
+        ]
+    )
+    clip_poly = MplPolygon(clip_verts, closed=True, transform=transform)
+    im.set_clip_path(clip_poly)
+
+    return [im]
+
+
 def draw_components_overlay(
     ax,
     reals,
@@ -5056,7 +5782,11 @@ def draw_components_overlay(
 
     import numpy as np
     from matplotlib.collections import LineCollection
-    from matplotlib.colors import LinearSegmentedColormap, ListedColormap
+    from matplotlib.colors import (
+        LinearSegmentedColormap,
+        ListedColormap,
+        PowerNorm,
+    )
     from matplotlib.patches import PathPatch
     from matplotlib.path import Path
 
@@ -5069,6 +5799,7 @@ def draw_components_overlay(
     show_colormap_line = settings.get("show_colormap_line", False)
     fractions_colormap = settings.get("fractions_colormap")
     colormap_contrast_limits = settings.get("colormap_contrast_limits", (0, 1))
+    colormap_gamma = settings.get("colormap_gamma", 1.0) or 1.0
     label_fontsize = settings.get("label_fontsize", 10)
     label_fontweight = settings.get("label_fontweight", "normal")
     label_fontstyle = settings.get("label_fontstyle", "normal")
@@ -5202,7 +5933,12 @@ def draw_components_overlay(
                     segments, cmap=colormap, linewidths=line_width, zorder=10
                 )
                 lc.set_array(np.array(segment_colors))
-                lc.set_clim(vmin, vmax)
+                if colormap_gamma != 1.0 and vmax > vmin:
+                    lc.set_norm(
+                        PowerNorm(colormap_gamma, vmin=vmin, vmax=vmax)
+                    )
+                else:
+                    lc.set_clim(vmin, vmax)
                 lc.set_alpha(line_alpha)
                 with contextlib.suppress(Exception):
                     lc.set_capstyle('butt')
@@ -5218,6 +5954,30 @@ def draw_components_overlay(
             )[0]
             with contextlib.suppress(Exception):
                 line.set_solid_capstyle('butt')
+
+        # Optional first-component fraction histogram overlaid on the line,
+        # matching the interactive Components tab.
+        fraction_data = settings.get("fraction_data")
+        if (
+            analysis_type == "Linear Projection"
+            and settings.get("show_fraction_histogram")
+            and fraction_data is not None
+            and fractions_colormap is not None
+        ):
+            draw_fraction_histogram_overlay(
+                ax,
+                ox1,
+                oy1,
+                ox2,
+                oy2,
+                fraction_data,
+                fractions_colormap,
+                height=settings.get("histogram_overlay_height", 0.3),
+                offset=settings.get("histogram_offset", 0.0),
+                alpha=settings.get("histogram_alpha", 0.75),
+                contrast_limits=colormap_contrast_limits,
+                gamma=colormap_gamma,
+            )
 
     elif num_components >= 3:
         vertices = [(reals[i], imags[i]) for i in range(num_components)]

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -1066,24 +1066,75 @@ class ComponentsWidget(QWidget):
         return {
             'analysis_type': 'Linear Projection',
             'components': {},
-            'line_settings': {
+            # NOTE: keys here must match the ones written by
+            # ``_on_plot_setting_changed`` / ``_pick_label_color`` and read by
+            # the restore methods, otherwise edits are persisted under one key
+            # but restored from another (and never re-applied).
+            'two_component_line_settings': {
                 'show_colormap_line': True,
                 'show_component_dots': True,
                 'line_offset': 0.0,
                 'line_width': 3.0,
                 'line_alpha': 1.0,
+                'default_component_color': 'dimgray',
                 'show_fraction_histogram': False,
                 'histogram_overlay_height': 0.3,
                 'histogram_offset': 0.0,
                 'histogram_alpha': 0.75,
             },
-            'label_settings': {
+            'two_components_label_settings': {
                 'fontsize': 10,
                 'bold': False,
                 'italic': False,
                 'color': 'black',
             },
         }
+
+    def _restore_line_and_label_settings(self, settings):
+        """Restore the two-component line / histogram-overlay and label styles.
+
+        User edits are persisted under ``two_component_line_settings`` and
+        ``two_components_label_settings`` (see ``_on_plot_setting_changed`` and
+        ``_pick_label_color``). Older metadata used ``line_settings`` /
+        ``label_settings``, so fall back to those for backward compatibility.
+        """
+        line_settings = (
+            settings.get('two_component_line_settings')
+            or settings.get('line_settings')
+            or {}
+        )
+        if line_settings:
+            self.show_colormap_line = line_settings.get(
+                'show_colormap_line', True
+            )
+            self.show_component_dots = line_settings.get(
+                'show_component_dots', True
+            )
+            self.line_offset = line_settings.get('line_offset', 0.0)
+            self.line_width = line_settings.get('line_width', 3.0)
+            self.line_alpha = line_settings.get('line_alpha', 1.0)
+            self.default_component_color = line_settings.get(
+                'default_component_color', 'dimgray'
+            )
+            self.show_fraction_histogram = line_settings.get(
+                'show_fraction_histogram', False
+            )
+            self.histogram_overlay_height = line_settings.get(
+                'histogram_overlay_height', 0.3
+            )
+            self.histogram_offset = line_settings.get('histogram_offset', 0.0)
+            self.histogram_alpha = line_settings.get('histogram_alpha', 0.75)
+
+        label_settings = (
+            settings.get('two_components_label_settings')
+            or settings.get('label_settings')
+            or {}
+        )
+        if label_settings:
+            self.label_fontsize = label_settings.get('fontsize', 10)
+            self.label_bold = label_settings.get('bold', False)
+            self.label_italic = label_settings.get('italic', False)
+            self.label_color = label_settings.get('color', 'black')
 
     def _update_components_setting_in_metadata(self, key_path, value):
         """Update a specific component setting in the current layer's metadata."""
@@ -1230,36 +1281,7 @@ class ComponentsWidget(QWidget):
                         if g is not None and s is not None:
                             self._create_component_at_coordinates(idx, g, s)
 
-            if 'line_settings' in settings:
-                line_settings = settings['line_settings']
-                self.show_colormap_line = line_settings.get(
-                    'show_colormap_line', True
-                )
-                self.show_component_dots = line_settings.get(
-                    'show_component_dots', True
-                )
-                self.line_offset = line_settings.get('line_offset', 0.0)
-                self.line_width = line_settings.get('line_width', 3.0)
-                self.line_alpha = line_settings.get('line_alpha', 1.0)
-                self.show_fraction_histogram = line_settings.get(
-                    'show_fraction_histogram', False
-                )
-                self.histogram_overlay_height = line_settings.get(
-                    'histogram_overlay_height', 0.3
-                )
-                self.histogram_offset = line_settings.get(
-                    'histogram_offset', 0.0
-                )
-                self.histogram_alpha = line_settings.get(
-                    'histogram_alpha', 0.75
-                )
-
-            if 'label_settings' in settings:
-                label_settings = settings['label_settings']
-                self.label_fontsize = label_settings.get('fontsize', 10)
-                self.label_bold = label_settings.get('bold', False)
-                self.label_italic = label_settings.get('italic', False)
-                self.label_color = label_settings.get('color', 'black')
+            self._restore_line_and_label_settings(settings)
 
             # Draw visual elements (lines between components) but do NOT
             # run analysis or create fraction layers.
@@ -1401,36 +1423,7 @@ class ComponentsWidget(QWidget):
                         if g is not None and s is not None:
                             self._create_component_at_coordinates(idx, g, s)
 
-            if 'line_settings' in settings:
-                line_settings = settings['line_settings']
-                self.show_colormap_line = line_settings.get(
-                    'show_colormap_line', True
-                )
-                self.show_component_dots = line_settings.get(
-                    'show_component_dots', True
-                )
-                self.line_offset = line_settings.get('line_offset', 0.0)
-                self.line_width = line_settings.get('line_width', 3.0)
-                self.line_alpha = line_settings.get('line_alpha', 1.0)
-                self.show_fraction_histogram = line_settings.get(
-                    'show_fraction_histogram', False
-                )
-                self.histogram_overlay_height = line_settings.get(
-                    'histogram_overlay_height', 0.3
-                )
-                self.histogram_offset = line_settings.get(
-                    'histogram_offset', 0.0
-                )
-                self.histogram_alpha = line_settings.get(
-                    'histogram_alpha', 0.75
-                )
-
-            if 'label_settings' in settings:
-                label_settings = settings['label_settings']
-                self.label_fontsize = label_settings.get('fontsize', 10)
-                self.label_bold = label_settings.get('bold', False)
-                self.label_italic = label_settings.get('italic', False)
-                self.label_color = label_settings.get('color', 'black')
+            self._restore_line_and_label_settings(settings)
 
             components_created = [
                 c
@@ -1840,6 +1833,10 @@ class ComponentsWidget(QWidget):
                 f"background-color: {self.default_component_color}; border: 1px solid black;"
             )
 
+            self._update_components_setting_in_metadata(
+                'two_component_line_settings.default_component_color',
+                self.default_component_color,
+            )
             self._on_plot_setting_changed()
 
     def _update_analysis_options(self):
@@ -2411,6 +2408,15 @@ class ComponentsWidget(QWidget):
         self.label_fontsize = self.fontsize_spin.value()
         self.label_bold = self.bold_checkbox.isChecked()
         self.label_italic = self.italic_checkbox.isChecked()
+        self._update_components_setting_in_metadata(
+            'two_components_label_settings.fontsize', self.label_fontsize
+        )
+        self._update_components_setting_in_metadata(
+            'two_components_label_settings.bold', self.label_bold
+        )
+        self._update_components_setting_in_metadata(
+            'two_components_label_settings.italic', self.label_italic
+        )
         self._apply_styles_to_labels()
 
     def _apply_styles_to_labels(self):

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -3,7 +3,7 @@ import contextlib
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import LineCollection
-from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.colors import LinearSegmentedColormap, PowerNorm
 from napari.layers import Image
 from napari.utils.notifications import show_error, show_warning
 from phasorpy.lifetime import (
@@ -58,6 +58,7 @@ class FretWidget(QWidget):
         self.fret_layers = []  # List of all FRET efficiency layers
         self.colormap_contrast_limits = None
         self.fret_colormap = None
+        self.colormap_gamma = 1.0
         self._updating_linked_layers = (
             False  # Flag to prevent recursive updates
         )
@@ -1172,7 +1173,13 @@ class FretWidget(QWidget):
             segments, cmap=colormap, linewidths=3, zorder=zorder
         )
         lc.set_array(np.array(colors))
-        lc.set_clim(vmin, vmax)
+        gamma = getattr(self, 'colormap_gamma', 1.0) or 1.0
+        if gamma != 1.0 and vmax > vmin:
+            # Match the FRET layer's gamma so the phasor-plot trajectory reads
+            # the same as the image and the histogram.
+            lc.set_norm(PowerNorm(gamma, vmin=vmin, vmax=vmax))
+        else:
+            lc.set_clim(vmin, vmax)
 
         self.current_donor_line = ax.add_collection(lc)
 
@@ -1183,15 +1190,18 @@ class FretWidget(QWidget):
 
         source_layer = event.source
         new_colormap = source_layer.colormap
+        new_gamma = source_layer.gamma
 
         # Update stored values
         self.fret_colormap = new_colormap.colors
         self.colormap_contrast_limits = source_layer.contrast_limits
+        self.colormap_gamma = new_gamma
 
         # Update histogram colormap
         self.histogram_widget.update_colormap(
             colormap_colors=self.fret_colormap,
             contrast_limits=list(self.colormap_contrast_limits),
+            gamma=self.colormap_gamma,
         )
 
         # Extract colormap info for metadata
@@ -1213,6 +1223,9 @@ class FretWidget(QWidget):
         self._update_fret_setting_in_metadata(
             'colormap_settings.colormap_changed', True
         )
+        self._update_fret_setting_in_metadata(
+            'colormap_settings.gamma', new_gamma
+        )
 
         # Update all other FRET layers to match
         self._updating_linked_layers = True
@@ -1220,6 +1233,7 @@ class FretWidget(QWidget):
             for layer in self.fret_layers:
                 if layer != source_layer and layer in self.viewer.layers:
                     layer.colormap = new_colormap
+                    layer.gamma = new_gamma
         finally:
             self._updating_linked_layers = False
 
@@ -1240,6 +1254,7 @@ class FretWidget(QWidget):
         self.histogram_widget.update_colormap(
             colormap_colors=self.fret_colormap,
             contrast_limits=list(self.colormap_contrast_limits),
+            gamma=self.colormap_gamma,
         )
 
         # Prepare for metadata
@@ -1445,6 +1460,7 @@ class FretWidget(QWidget):
                 self._saved_contrast_limits = colormap_settings.get(
                     'contrast_limits', (0, 1)
                 )
+                self._saved_gamma = colormap_settings.get('gamma', 1.0)
                 self._colormap_was_changed = colormap_settings.get(
                     'colormap_changed', False
                 )
@@ -1487,6 +1503,9 @@ class FretWidget(QWidget):
                 self.fret_layer.events.contrast_limits.disconnect(
                     self._on_contrast_limits_changed
                 )
+                self.fret_layer.events.gamma.disconnect(
+                    self._on_colormap_changed
+                )
 
                 if self._saved_colormap_colors is not None:
                     from napari.utils.colormaps import Colormap
@@ -1510,8 +1529,12 @@ class FretWidget(QWidget):
 
                 self.fret_layer.contrast_limits = saved_limits
 
+                if getattr(self, '_saved_gamma', None) is not None:
+                    self.fret_layer.gamma = self._saved_gamma
+
                 self.fret_colormap = self.fret_layer.colormap.colors
                 self.colormap_contrast_limits = self.fret_layer.contrast_limits
+                self.colormap_gamma = self.fret_layer.gamma
 
                 self.fret_layer.events.colormap.connect(
                     self._on_colormap_changed
@@ -1519,6 +1542,7 @@ class FretWidget(QWidget):
                 self.fret_layer.events.contrast_limits.connect(
                     self._on_contrast_limits_changed
                 )
+                self.fret_layer.events.gamma.connect(self._on_colormap_changed)
 
                 self.plot_donor_trajectory()
 
@@ -1530,6 +1554,9 @@ class FretWidget(QWidget):
                     )
                     self.fret_layer.events.contrast_limits.connect(
                         self._on_contrast_limits_changed
+                    )
+                    self.fret_layer.events.gamma.connect(
+                        self._on_colormap_changed
                     )
                 except Exception:  # noqa: BLE001
                     pass
@@ -1545,12 +1572,14 @@ class FretWidget(QWidget):
             self.fret_layer.events.contrast_limits.connect(
                 self._on_contrast_limits_changed
             )
+            self.fret_layer.events.gamma.connect(self._on_colormap_changed)
 
             if hasattr(self, '_saved_colormap_name'):
                 self._apply_saved_fret_colormap_settings()
             else:
                 self.fret_colormap = self.fret_layer.colormap.colors
                 self.colormap_contrast_limits = self.fret_layer.contrast_limits
+                self.colormap_gamma = self.fret_layer.gamma
 
     def rename_layer(self, old_name: str, new_name: str):
         """Rename derived layers when base layer is renamed."""
@@ -1604,6 +1633,7 @@ class FretWidget(QWidget):
                 if self.colormap_contrast_limits is not None
                 else None
             ),
+            gamma=self.colormap_gamma,
         )
         if len(per_layer) > 1:
             self.histogram_widget.update_multi_data(per_layer)
@@ -1641,6 +1671,7 @@ class FretWidget(QWidget):
             self.histogram_widget.update_colormap(
                 colormap_colors=self.fret_colormap,
                 contrast_limits=[min_val, max_val],
+                gamma=self.colormap_gamma,
             )
             if len(per_layer) > 1:
                 self.histogram_widget.update_multi_data(per_layer)
@@ -1698,6 +1729,7 @@ class FretWidget(QWidget):
                     layer.events.contrast_limits.disconnect(
                         self._on_contrast_limits_changed
                     )
+                    layer.events.gamma.disconnect(self._on_colormap_changed)
                 except Exception:  # noqa: BLE001
                     pass
 
@@ -1781,6 +1813,7 @@ class FretWidget(QWidget):
                     layer.events.contrast_limits.disconnect(
                         self._on_contrast_limits_changed
                     )
+                    layer.events.gamma.disconnect(self._on_colormap_changed)
                 except Exception:  # noqa: BLE001
                     pass
         self.fret_layers = []
@@ -1933,12 +1966,14 @@ class FretWidget(QWidget):
             fret_layer.events.contrast_limits.connect(
                 self._on_contrast_limits_changed
             )
+            fret_layer.events.gamma.connect(self._on_colormap_changed)
 
             # Store reference to first FRET layer for backward compatibility
             if self.fret_layer is None:
                 self.fret_layer = fret_layer
                 self.fret_colormap = fret_layer.colormap.colors
                 self.colormap_contrast_limits = fret_layer.contrast_limits
+                self.colormap_gamma = fret_layer.gamma
 
             try:
                 frequency_float = float(self.frequency_input.text().strip())

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -1066,7 +1066,7 @@ class FretWidget(QWidget):
                         "fret_interp", self.fret_colormap, N=256
                     )
                 else:
-                    colormap = plt.cm.turbo
+                    colormap = plt.cm.jet
 
                 donor_color = colormap(0.0)[:3]
                 background_color = colormap(1.0)[:3]
@@ -1135,7 +1135,7 @@ class FretWidget(QWidget):
                 "fret_interp", self.fret_colormap, N=256
             )
         else:
-            colormap = plt.cm.turbo
+            colormap = plt.cm.jet
 
         if (
             hasattr(self, 'colormap_contrast_limits')
@@ -2024,9 +2024,9 @@ def draw_fret_trajectory_overlay(
             elif isinstance(fret_colormap, list):
                 colormap = ListedColormap(fret_colormap)
             else:
-                colormap = plt.cm.turbo
+                colormap = plt.cm.jet
         else:
-            colormap = plt.cm.turbo
+            colormap = plt.cm.jet
 
         donor_color = colormap(0.0)[:3]
         background_color = colormap(1.0)[:3]

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -84,6 +84,31 @@ def compute_phasor_mesh_mask(
     return mask
 
 
+def _resolve_mesh_blur_sigma(ax, resolution, target_px=1.2, floor=1.5):
+    """Return the alpha-mask blur sigma (grid-cell units) for a mesh edge.
+
+    The mesh's edge anti-aliasing works by Gaussian-blurring the boolean
+    exclusion mask, then letting Matplotlib's Lanczos resampling downscale
+    that to display pixels. Sigma has to be picked in *display-pixel* terms
+    (``target_px``) and converted to grid cells via ``resolution /
+    display_px``, not left as a flat constant: at a fixed sigma, a
+    high-resolution grid (this widget scales it up to 1280 for on-screen
+    sharpness) has cells much smaller than a display pixel, so the blur band
+    becomes sub-pixel and Lanczos-resamples into a ringing/dashed edge
+    instead of a smooth fade -- most visible on shallow-angle mesh
+    boundaries (e.g. a phase limit near the real axis). ``floor`` keeps a
+    minimum blur even when the grid is coarser than the display (e.g. the
+    default low-resolution grid), where the ratio alone would undershoot.
+    """
+    display_px = 0.0
+    with contextlib.suppress(Exception):
+        bbox = ax.get_window_extent()
+        display_px = max(float(bbox.width), float(bbox.height))
+    if display_px <= 0:
+        return max(floor, target_px * resolution / _DEFAULT_MESH_RESOLUTION)
+    return max(floor, target_px * resolution / display_px)
+
+
 def draw_phasor_mesh(
     ax,
     kind,
@@ -201,8 +226,9 @@ def draw_phasor_mesh(
     mesh_cmap.set_bad((0, 0, 0, 0))
 
     if alpha_map is None:
+        sigma = _resolve_mesh_blur_sigma(ax, resolution)
         alpha_base = gaussian_filter(
-            (~mask).astype(float), sigma=1.2, mode="nearest"
+            (~mask).astype(float), sigma=sigma, mode="nearest"
         )
         alpha_map = np.clip(alpha_base, 0.0, 1.0) * alpha
 
@@ -2154,7 +2180,9 @@ class PhasorMappingWidget(QWidget):
 
         return grid
 
-    def _get_mesh_alpha_map(self, mesh_mask, alpha_key, mesh_alpha: float):
+    def _get_mesh_alpha_map(
+        self, mesh_mask, alpha_key, mesh_alpha: float, resolution: int, ax
+    ):
         cached = self._mesh_alpha_cache.get(alpha_key)
         if cached is not None:
             with contextlib.suppress(ValueError):
@@ -2162,8 +2190,11 @@ class PhasorMappingWidget(QWidget):
             self._mesh_alpha_cache_order.append(alpha_key)
             return cached * mesh_alpha
 
+        # See ``_resolve_mesh_blur_sigma`` for why sigma must be resolved
+        # from the actual display size rather than left as a flat constant.
+        sigma = _resolve_mesh_blur_sigma(ax, resolution)
         alpha_base = gaussian_filter(
-            (~mesh_mask).astype(float), sigma=1.2, mode="nearest"
+            (~mesh_mask).astype(float), sigma=sigma, mode="nearest"
         )
         alpha_base = np.clip(alpha_base, 0.0, 1.0)
         self._mesh_alpha_cache[alpha_key] = alpha_base
@@ -2286,6 +2317,8 @@ class PhasorMappingWidget(QWidget):
                 mesh_mask,
                 alpha_key,
                 mesh_alpha,
+                resolution,
+                ax,
             )
 
             self._remove_mesh_overlay()

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -76,7 +76,11 @@ def compute_phasor_mesh_mask(
         mask |= ~((m_grid >= mod_min) & (m_grid <= mod_max))
     if clip_semicircle and semicircle:
         with np.errstate(invalid="ignore"):
-            mask |= m_grid > np.cos(p_grid)
+            # Bound by the arc (m <= cos(phase)) and by the diameter (s >= 0).
+            # In semicircle mode the phase comes straight from ``atan2`` so
+            # points below the diameter have a negative phase; clipping them
+            # stops the mesh from bleeding past the bottom of the semicircle.
+            mask |= (m_grid > np.cos(p_grid)) | (p_grid < 0)
     return mask
 
 
@@ -85,7 +89,7 @@ def draw_phasor_mesh(
     kind,
     *,
     semicircle=True,
-    colormap="hsv",
+    colormap="jet",
     alpha=0.45,
     alpha_map=None,
     phase_range=None,
@@ -179,7 +183,13 @@ def draw_phasor_mesh(
         )
 
     field = p_grid if kind == "Phase" else m_grid
-    field_masked = np.ma.array(field, mask=mask)
+    # The exterior of the mesh is hidden purely through ``alpha_map`` (0 outside
+    # the visible region). We deliberately keep the *colour* field fully valid
+    # everywhere rather than masking it: a masked colour field renders excluded
+    # cells as the "bad" colour, and blending those transparent-black cells into
+    # the feathered edge under RGBA interpolation produces a grey halo / shadow
+    # around the outline. Filling non-finite values keeps the edge colours clean.
+    field = np.nan_to_num(np.asarray(field, dtype=float), nan=0.0)
 
     if isinstance(colormap, str):
         cmap = resolve_colormap_by_name(colormap)
@@ -220,12 +230,12 @@ def draw_phasor_mesh(
     }
     try:
         image = ax.imshow(
-            field_masked,
+            field,
             interpolation_stage="rgba",
             **mesh_imshow_kwargs,
         )
     except TypeError:
-        image = ax.imshow(field_masked, **mesh_imshow_kwargs)
+        image = ax.imshow(field, **mesh_imshow_kwargs)
     # Restore a 1:1 data aspect; ``aspect="auto"`` on imshow otherwise stretches
     # the axes and distorts the phasor plot.
     ax.set_aspect(1, adjustable="box")
@@ -264,13 +274,14 @@ class PhasorMappingWidget(QWidget):
         self.current_output_type = "Apparent Phase Lifetime"
         self._overlay_imshow = None
         self._mesh_overlay_imshow = None
-        self._phase_colormap_name = "hsv"
+        self._phase_colormap_name = "jet"
         self._modulation_colormap_name = "viridis"
         self._coloring_paused_by_tab = False
         self.min_lifetime = None
         self.max_lifetime = None
         self.lifetime_colormap = None
         self.colormap_contrast_limits = None
+        self.colormap_gamma = 1.0
         self.lifetime_type = None
         self.lifetime_range_factor = (
             1000  # Factor to convert to integer for slider
@@ -1013,7 +1024,7 @@ class PhasorMappingWidget(QWidget):
     @staticmethod
     def _get_output_colormap_name(output_type: str) -> str:
         if output_type == "Phase":
-            return "hsv"
+            return "jet"
         if output_type == "Modulation":
             return "viridis"
         return "plasma"
@@ -1245,7 +1256,7 @@ class PhasorMappingWidget(QWidget):
                 self.lifetime_min_edit.setText('0.0')
                 self.lifetime_max_edit.setText('100.0')
                 self.lifetime_range_label.setText(
-                    f'{self.histogram_widget._range_label_prefix}: 0.0 - 100.0'
+                    f'{self.histogram_widget._range_label_prefix}:'
                 )
                 self._set_frequency_input_enabled(True)
                 self.mesh_overlay_checkbox.blockSignals(True)
@@ -1631,7 +1642,7 @@ class PhasorMappingWidget(QWidget):
         self.lifetime_range_slider.setValue((min_slider_val, max_slider_val))
 
         self.lifetime_range_label.setText(
-            f"{self.histogram_widget._range_label_prefix}: {self.min_lifetime:.2f} - {self.max_lifetime:.2f}"
+            f"{self.histogram_widget._range_label_prefix}:"
         )
 
         self.lifetime_min_edit.setText(f"{self.min_lifetime:.2f}")
@@ -1650,6 +1661,7 @@ class PhasorMappingWidget(QWidget):
         self.histogram_widget.update_colormap(
             colormap_colors=self.lifetime_colormap,
             contrast_limits=self.colormap_contrast_limits,
+            gamma=self.colormap_gamma,
         )
 
         output_type = self._get_selected_output_type()
@@ -1710,6 +1722,7 @@ class PhasorMappingWidget(QWidget):
                     layer.events.contrast_limits.disconnect(
                         self._on_colormap_changed
                     )
+                    layer.events.gamma.disconnect(self._on_colormap_changed)
         self.metric_layers = []
         self.lifetime_layers = []
         self.lifetime_layer = None
@@ -1753,11 +1766,13 @@ class PhasorMappingWidget(QWidget):
             output_layer.events.contrast_limits.connect(
                 self._on_colormap_changed
             )
+            output_layer.events.gamma.connect(self._on_colormap_changed)
 
             if self.lifetime_layer is None:
                 self.lifetime_layer = output_layer
                 self.lifetime_colormap = output_layer.colormap.colors
                 self.colormap_contrast_limits = output_layer.contrast_limits
+                self.colormap_gamma = output_layer.gamma
 
     def create_lifetime_layer(self):
         """Backward-compatible alias for output layer creation."""
@@ -1773,10 +1788,12 @@ class PhasorMappingWidget(QWidget):
         source_layer = event.source
         new_colormap = source_layer.colormap
         new_contrast_limits = source_layer.contrast_limits
+        new_gamma = source_layer.gamma
 
         # Update stored values
         self.lifetime_colormap = new_colormap.colors
         self.colormap_contrast_limits = new_contrast_limits
+        self.colormap_gamma = new_gamma
 
         output_type = self._get_selected_output_type()
         if output_type in {"Phase", "Modulation"}:
@@ -1800,12 +1817,14 @@ class PhasorMappingWidget(QWidget):
                 if layer != source_layer and layer in self.viewer.layers:
                     layer.colormap = new_colormap
                     layer.contrast_limits = new_contrast_limits
+                    layer.gamma = new_gamma
         finally:
             self._updating_linked_layers = False
 
         self.histogram_widget.update_colormap(
             colormap_colors=self.lifetime_colormap,
             contrast_limits=self.colormap_contrast_limits,
+            gamma=self.colormap_gamma,
         )
 
         if output_type in {"Phase", "Modulation"} and (
@@ -1850,6 +1869,9 @@ class PhasorMappingWidget(QWidget):
                             self._on_colormap_changed
                         )
                         layer.events.contrast_limits.disconnect(
+                            self._on_colormap_changed
+                        )
+                        layer.events.gamma.disconnect(
                             self._on_colormap_changed
                         )
 
@@ -2002,7 +2024,7 @@ class PhasorMappingWidget(QWidget):
                         self.lifetime_min_edit.setText(f"{min_val:.2f}")
                         self.lifetime_max_edit.setText(f"{max_val:.2f}")
                         self.lifetime_range_label.setText(
-                            f"{self.histogram_widget._range_label_prefix}: {min_val:.2f} - {max_val:.2f}"
+                            f"{self.histogram_widget._range_label_prefix}:"
                         )
                     finally:
                         self._updating_settings = False
@@ -2068,11 +2090,17 @@ class PhasorMappingWidget(QWidget):
             self._mesh_overlay_imshow = None
 
     def _get_mesh_grid_resolution(self, ax) -> int:
+        # Sample the mesh grid well above the on-screen pixel size so the mesh
+        # outline (the curved semicircle / range boundaries) stays finely
+        # detailed - especially when zoomed out, where a coarse grid spreads
+        # few samples over a wide data extent and the edge looks rough. Grids
+        # are cached per view, so a higher resolution only costs on a new
+        # zoom/pan level (~25 ms at the cap, within the redraw debounce).
         with contextlib.suppress(Exception):
             bbox = ax.get_window_extent()
-            target = int(max(float(bbox.width), float(bbox.height)) * 1.2)
-            return int(np.clip(target, 320, 640))
-        return 480
+            target = int(max(float(bbox.width), float(bbox.height)) * 2.0)
+            return int(np.clip(target, 640, 1280))
+        return 1000
 
     def _make_mesh_grid_cache_key(self, ax, resolution: int):
         x_min, x_max = ax.get_xlim()
@@ -2517,6 +2545,8 @@ class PhasorMappingWidget(QWidget):
                 layer.events.contrast_limits.disconnect(
                     self._on_colormap_changed
                 )
+            with contextlib.suppress(TypeError, ValueError, AttributeError):
+                layer.events.gamma.disconnect(self._on_colormap_changed)
 
         event.accept()
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -9,11 +9,11 @@ import matplotlib.ticker as ticker
 import numpy as np
 from biaplotter.plotter import CanvasWidget
 from matplotlib.colorbar import Colorbar
-from matplotlib.colors import LinearSegmentedColormap, LogNorm
+from matplotlib.colors import LogNorm
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle, Patch
 from napari.layers import Image, Labels, Shapes
-from napari.utils import colormaps, notifications
+from napari.utils import notifications
 from phasorpy.lifetime import phasor_from_lifetime
 from phasorpy.phasor import phasor_center as _phasor_center
 from phasorpy.phasor import phasor_to_polar
@@ -55,6 +55,7 @@ from ._utils import (
     StatisticsTableWidget,
     analysis_section_stylesheet,
     apply_filter_and_threshold,
+    available_colormap_names,
     build_group_styles_from_layer_metadata,
     build_groups_from_layer_metadata,
     make_section,
@@ -569,7 +570,7 @@ class ContourLayerSettingsDialog(QDialog):
         self,
         *,
         display_mode="Merged",
-        merged_colormap="turbo",
+        merged_colormap="jet",
         merged_style="colormap",
         merged_color=None,
         show_legend=True,
@@ -599,7 +600,7 @@ class ContourLayerSettingsDialog(QDialog):
         self._group_row_data = []
         self._available_colormaps = list(available_colormaps or [])
         if not self._available_colormaps:
-            self._available_colormaps = list(colormaps.ALL_COLORMAPS.keys())
+            self._available_colormaps = available_colormap_names()
 
         group_assignments = dict(group_assignments or {})
         layer_colors = dict(layer_colors or {})
@@ -881,7 +882,7 @@ class ContourLayerSettingsDialog(QDialog):
         color=None,
         checked_layers=None,
         style="colormap",
-        colormap_name="turbo",
+        colormap_name="jet",
     ):
         default_tab10 = plt.cm.tab10.colors
         idx = len(self._group_row_data)
@@ -2003,10 +2004,10 @@ class PlotterWidget(QWidget):
         # Set contour single-layer defaults before wiring UI signals.
         # Combo-box population can emit callbacks during initialization.
         self._histogram_style = "colormap"
-        self._histogram_colormap_name = "turbo"
+        self._histogram_colormap_name = "jet"
         self._histogram_color = (0.1216, 0.4667, 0.7059)
         self._single_contour_style = "colormap"
-        self._single_contour_colormap = "turbo"
+        self._single_contour_colormap = "jet"
         self._single_contour_color = (0.1216, 0.4667, 0.7059)
         self._preserve_plot_type_on_restore = False
 
@@ -2216,7 +2217,7 @@ class PlotterWidget(QWidget):
         self._populate_main_colormap_combobox(
             selected=self._single_contour_colormap,
         )
-        self.histogram_colormap = "turbo"
+        self.histogram_colormap = "jet"
 
         # Initialize attributes
         self.polar_plot_artist_list = []
@@ -2227,7 +2228,7 @@ class PlotterWidget(QWidget):
         self._contour_group_assignments = {}
         self._contour_group_colors = {}
         self._contour_group_names = {}
-        self._contour_multi_layer_colormap = "turbo"
+        self._contour_multi_layer_colormap = "jet"
         self._contour_merged_style = "colormap"
         self._contour_merged_color = (0.1216, 0.4667, 0.7059)
         self._contour_layer_styles = {}
@@ -2865,12 +2866,12 @@ class PlotterWidget(QWidget):
                 'contour_single_style', 'colormap'
             )
             self._single_contour_colormap = settings.get(
-                'contour_single_colormap', settings.get('colormap', 'turbo')
+                'contour_single_colormap', settings.get('colormap', 'jet')
             )
             self._single_contour_color = tuple(
                 settings.get('contour_single_color', (0.1216, 0.4667, 0.7059))
             )
-            self._histogram_colormap_name = settings.get('colormap', 'turbo')
+            self._histogram_colormap_name = settings.get('colormap', 'jet')
             self._histogram_style = settings.get('histogram_style', 'colormap')
             self._histogram_color = tuple(
                 settings.get('histogram_color', (0.1216, 0.4667, 0.7059))
@@ -3936,7 +3937,7 @@ class PlotterWidget(QWidget):
             group_names=current_group_names,
             layer_styles=current_layer_styles,
             group_styles=current_group_styles,
-            available_colormaps=list(colormaps.ALL_COLORMAPS.keys()),
+            available_colormaps=available_colormap_names(),
             parent=self,
         )
 
@@ -5565,7 +5566,7 @@ class PlotterWidget(QWidget):
     @histogram_colormap.setter
     def histogram_colormap(self, colormap: str):
         """Sets the histogram colormap from the colormap combobox."""
-        if colormap not in colormaps.ALL_COLORMAPS:
+        if resolve_colormap_by_name(colormap) is None:
             notifications.WarningNotification(
                 f"{colormap} is not a valid colormap. Setting to default colormap."
             )
@@ -7532,14 +7533,8 @@ class PlotterWidget(QWidget):
                         )
                     )
                 else:
-                    selected_histogram_colormap = colormaps.ALL_COLORMAPS[
+                    selected_histogram_colormap = resolve_colormap_by_name(
                         self.histogram_colormap
-                    ]
-                    selected_histogram_colormap = (
-                        LinearSegmentedColormap.from_list(
-                            self.histogram_colormap,
-                            selected_histogram_colormap.colors,
-                        )
                     )
                 histogram_artist.histogram_colormap = (
                     selected_histogram_colormap
@@ -7632,9 +7627,9 @@ class PlotterWidget(QWidget):
             )
             if cmap_name == "Select color...":
                 # Sentinel entry for solid style; keep a valid fallback colormap.
-                cmap_name = "turbo"
+                cmap_name = "jet"
         elif cmap_name == "Select color...":
-            cmap_name = self._single_contour_colormap or "turbo"
+            cmap_name = self._single_contour_colormap or "jet"
 
         return resolve_colormap_by_name(cmap_name)
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -4959,6 +4959,19 @@ class PlotterWidget(QWidget):
         )
         dock_layout.insertWidget(0, component_selector)
 
+        # The docked histogram area is clamped to its minimum height
+        # (see ``_resize_initial_docks``). This dock uniquely carries the
+        # "Component:" selector row above the plot, so grow its minimum by that
+        # row's height; otherwise the extra row eats into the histogram canvas
+        # and the bottom of the plot is clipped in the Components tab.
+        selector_extra = (
+            component_selector.sizeHint().height() + dock_layout.spacing()
+        )
+        self.components_histogram_dock_widget.setMinimumHeight(
+            self.components_histogram_dock_widget.minimumHeight()
+            + selector_extra
+        )
+
         self._components_hist_page_idx = self._histogram_stack.addWidget(
             self.components_histogram_dock_widget
         )


### PR DESCRIPTION
## Summary

The main fix in this branch is that `export_layer_as_image` did not account for a layer's **gamma** correction, so exported images did not match what was rendered in napari whenever gamma ≠ 1.0. While fixing that, the colormap handling across the plugin was also unified and extended, and calibration harmonic matching was hardened.

Also adds the feature of plotting the component histogram along line between two components in the phasor plot. 

Fixes #336 
Fixes #333 
Closes #334 

## Changes

### Bug fix: gamma ignored on image export
- `_writer.py`: `export_layer_as_image` now reads the layer's `gamma` attribute and, when it differs from `1.0`, reproduces napari's rendering by using a `matplotlib.colors.PowerNorm(gamma, vmin, vmax)` instead of plain `vmin`/`vmax` normalization. Previously the exported image ignored gamma entirely and only used the raw contrast limits.

### Gamma correction added to Analysis widgets
- Added gamma correction controls/state to the **FRET** and **Phasor Mapping** (components) tabs, so the colormap gradient used in phasor-plot overlays (histograms, trajectories) matches the gamma applied to the corresponding image layer.
- Gamma is now persisted/restored via layer metadata (`harmonic_data['gamma']` / `settings['colormap_gamma']`) alongside colormap and contrast limits, and kept in sync across linked layers (e.g. all layers belonging to the same component) via `_sync_component_layers_gamma`.

### Colormap updates
- Changed the default colormap from `'hsv'`/`'turbo'` to `'jet'` in Phasor Mapping, component styling, and documentation (`docs/guides/phasor_mapping.md`) for better visibility.
- Added `register_extra_colormaps()` (called on plugin import in `__init__.py`) to register extra matplotlib colormaps (`jet`, `nipy_spectral`, `ocean`, `gnuplot2`, `gnuplot`, `rainbow`, `brg`, `summer`, `winter`, `spring`, `autumn`, `cool`) globally with napari, so they're selectable in napari's built-in layer controls too, not just this plugin's widgets.
- Added `available_colormap_names()` to extend the list of colormaps offered in this plugin's colormap comboboxes with those extra colormaps.
- Increased mesh grid resolution in phasor mapping for finer detail, and made the blur sigma for mesh edges dynamic based on grid resolution.

### Calibration handling
- `apply_calibration_correction` now accepts an optional `calibration_harmonics` parameter and matches calibration values to a layer's harmonics **by value** rather than positionally: if a calibration covers harmonics `[1, 2]` but the file only has harmonic `[1]`, only the harmonic-1 correction is applied. A `ValueError` is raised if the layer needs a harmonic the calibration doesn't cover, and a clearer error is raised for genuine positional mismatches when calibration harmonics are unknown.
- Component tab settings (line/label styling) are now correctly persisted and restored, including gamma.

### Batch analysis error reporting
- Added a `_pipeline_step` context manager in `_batch_analysis.py` that annotates exceptions with the pipeline step that failed (`Calibration`, `Filter / Threshold`, `Image mask`, `Components`, `Phasor Mapping`, `FRET`, `Selection`), making batch processing failures easier to diagnose.

### UI tweaks
- `HistogramWidget`: default canvas height increased, and the optional range slider row was reorganized (label, min/max edits, and slider now share a single horizontal row instead of stacking) to avoid clipping when extra UI elements are present.

## Testing
- Added/updated tests for calibration harmonic matching, component settings restoration (`test_phasor_mapping_tab.py`, `test_components_tab.py`), FRET gamma handling (`test_fret_tab.py`), colormap registration and combobox population (`test_utils_widgets.py`), and batch analysis pipeline step reporting (`test_batch_analysis.py`).