### PR TITLE
Add update check for newer napari-phasors releases

### DIFF
--- a/src/napari_phasors/_tests/test_update_check.py
+++ b/src/napari_phasors/_tests/test_update_check.py
@@ -1,0 +1,425 @@
+import json
+import time
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+from qtpy.QtWidgets import QMessageBox
+
+from napari_phasors import _update_check as uc
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object returned by ``urlopen``."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+class _FakeSignal:
+    """Minimal stand-in for a Qt signal: single-slot connect + sync emit."""
+
+    def __init__(self):
+        self._callback = None
+
+    def connect(self, callback):
+        self._callback = callback
+
+    def emit(self, value):
+        if self._callback is not None:
+            self._callback(value)
+
+
+class _FakeWorker:
+    """Runs the wrapped function synchronously instead of on a thread."""
+
+    def __init__(self, func):
+        self._func = func
+        self.returned = _FakeSignal()
+
+    def start(self):
+        self.returned.emit(self._func())
+
+
+def _fake_thread_worker(func):
+    def factory(*args, **kwargs):
+        return _FakeWorker(lambda: func(*args, **kwargs))
+
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def _isolate_update_check(tmp_path, monkeypatch):
+    """Isolate persisted config and session-guard state for every test."""
+    monkeypatch.setattr(uc, "user_config_dir", lambda name: str(tmp_path))
+    monkeypatch.setattr(uc, "_checked_this_session", False)
+    monkeypatch.setattr(uc, "_live_dialog", None)
+    yield
+
+
+# --- _config_path -----------------------------------------------------
+
+
+def test_config_path_uses_platformdirs(tmp_path):
+    assert uc._config_path() == Path(str(tmp_path)) / "update_check.json"
+
+
+# --- _load_config / _save_config ---------------------------------------
+
+
+def test_load_config_missing_file_returns_empty_dict():
+    assert uc._load_config() == {}
+
+
+def test_save_and_load_config_round_trip():
+    uc._save_config({"skipped_version": "1.2.3", "last_check": 1.0})
+    assert uc._load_config() == {
+        "skipped_version": "1.2.3",
+        "last_check": 1.0,
+    }
+
+
+def test_load_config_invalid_json_returns_empty_dict():
+    path = uc._config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not valid json {{{")
+    assert uc._load_config() == {}
+
+
+def test_load_config_non_dict_json_returns_empty_dict():
+    path = uc._config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[1, 2, 3]")
+    assert uc._load_config() == {}
+
+
+def test_save_config_swallows_oserror(monkeypatch):
+    def boom(self, *args, **kwargs):
+        raise OSError("cannot create directory")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    uc._save_config({"a": 1})  # must not raise
+
+
+# --- _fetch_latest_version ----------------------------------------------
+
+
+def test_fetch_latest_version_success(monkeypatch):
+    payload = {"info": {"version": "1.2.3"}}
+    monkeypatch.setattr(
+        uc.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(payload),
+    )
+    assert uc._fetch_latest_version() == "1.2.3"
+
+
+def test_fetch_latest_version_returns_none_on_network_error(monkeypatch):
+    def raise_error(request, timeout):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(uc.urllib.request, "urlopen", raise_error)
+    assert uc._fetch_latest_version() is None
+
+
+def test_fetch_latest_version_returns_none_for_non_string_version(
+    monkeypatch,
+):
+    payload = {"info": {"version": 123}}
+    monkeypatch.setattr(
+        uc.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(payload),
+    )
+    assert uc._fetch_latest_version() is None
+
+
+# --- _is_source_install ---------------------------------------------------
+
+
+def test_is_source_install_true_for_local_version_segment():
+    assert uc._is_source_install(Version("0.4.2+gabcdef1")) is True
+
+
+def test_is_source_install_true_for_devrelease():
+    assert uc._is_source_install(Version("0.4.2.dev5")) is True
+
+
+def test_is_source_install_false_for_plain_release():
+    assert uc._is_source_install(Version("0.4.2")) is False
+
+
+# --- _upgrade_instructions -------------------------------------------------
+
+
+def test_upgrade_instructions_pip_first_outside_conda(monkeypatch):
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    lines = uc._upgrade_instructions().splitlines()
+    assert lines[0].startswith("• pip")
+    assert lines[1].startswith("• conda")
+    assert lines[2].startswith("• napari")
+
+
+def test_upgrade_instructions_conda_first_inside_conda_env(monkeypatch):
+    monkeypatch.setenv("CONDA_PREFIX", "/opt/conda/envs/napari-phasors")
+    lines = uc._upgrade_instructions().splitlines()
+    assert lines[0].startswith("• conda")
+    assert lines[1].startswith("• pip")
+    assert lines[2].startswith("• napari")
+
+
+# --- _show_update_dialog ----------------------------------------------
+
+
+def test_show_update_dialog_builds_expected_content(qtbot):
+    uc._show_update_dialog("1.2.3", "1.0.0")
+    box = uc._live_dialog
+    assert box is not None
+    # NOTE: box.windowTitle() is intentionally not asserted here: on macOS,
+    # Qt ignores/clears QMessageBox window titles per platform HIG, so the
+    # getter returns "" there regardless of what setWindowTitle() was given.
+    assert "Installed: 1.0.0" in box.text()
+    assert "Latest: 1.2.3" in box.text()
+    assert box.checkBox() is not None
+    assert box.checkBox().text() == "Don't show this message again"
+    box.close()
+
+
+def test_show_update_dialog_checkbox_checked_persists_skipped_version(
+    qtbot,
+):
+    uc._show_update_dialog("2.0.0", "1.0.0")
+    box = uc._live_dialog
+    box.checkBox().setChecked(True)
+    box.done(QMessageBox.Ok)
+    assert uc._load_config().get("skipped_version") == "2.0.0"
+
+
+def test_show_update_dialog_checkbox_unchecked_does_not_persist(qtbot):
+    uc._show_update_dialog("2.0.0", "1.0.0")
+    box = uc._live_dialog
+    box.done(QMessageBox.Ok)
+    assert "skipped_version" not in uc._load_config()
+
+
+# --- _handle_latest_version -------------------------------------------
+
+
+def test_handle_latest_version_records_last_check_when_latest_is_none():
+    uc._handle_latest_version(None, Version("1.0.0"), None)
+    assert "last_check" in uc._load_config()
+
+
+def test_handle_latest_version_no_dialog_when_latest_is_none(monkeypatch):
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc._handle_latest_version(None, Version("1.0.0"), None)
+    assert shown == []
+
+
+def test_handle_latest_version_skips_dismissed_version(monkeypatch):
+    uc._save_config({"skipped_version": "2.0.0"})
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc._handle_latest_version("2.0.0", Version("1.0.0"), None)
+    assert shown == []
+
+
+def test_handle_latest_version_no_dialog_when_not_newer(monkeypatch):
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc._handle_latest_version("1.0.0", Version("1.0.0"), None)
+    assert shown == []
+
+
+def test_handle_latest_version_shows_dialog_when_newer(monkeypatch):
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    parent = object()
+    uc._handle_latest_version("2.0.0", Version("1.0.0"), parent)
+    assert shown == [("2.0.0", "1.0.0", parent)]
+
+
+def test_handle_latest_version_still_notifies_for_later_release(
+    monkeypatch,
+):
+    """A version skipped once must not suppress a *later* release."""
+    uc._save_config({"skipped_version": "2.0.0"})
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc._handle_latest_version("3.0.0", Version("1.0.0"), None)
+    assert shown == [("3.0.0", "1.0.0", None)]
+
+
+def test_handle_latest_version_handles_invalid_version_string(monkeypatch):
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc._handle_latest_version("not-a-version", Version("1.0.0"), None)
+    assert shown == []
+
+
+# --- maybe_check_for_update ------------------------------------------
+
+
+def test_maybe_check_for_update_runs_once_per_session(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        uc, "_is_source_install", lambda v: calls.append(v) or True
+    )
+    uc.maybe_check_for_update()
+    uc.maybe_check_for_update()
+    assert len(calls) == 1
+
+
+def test_maybe_check_for_update_returns_for_invalid_installed_version(
+    monkeypatch,
+):
+    monkeypatch.setattr(uc, "__installed_version__", "not-a-version")
+    called = []
+    monkeypatch.setattr(
+        uc, "_is_source_install", lambda v: called.append(v) or False
+    )
+    uc.maybe_check_for_update()
+    assert called == []
+
+
+def test_maybe_check_for_update_skips_source_install(monkeypatch):
+    monkeypatch.setattr(uc, "__installed_version__", "0.4.2.dev1+gabcdef1")
+    fetch_called = []
+    monkeypatch.setattr(
+        uc, "_fetch_latest_version", lambda: fetch_called.append(True)
+    )
+    uc.maybe_check_for_update()
+    assert fetch_called == []
+
+
+def test_maybe_check_for_update_throttled_by_recent_check(monkeypatch):
+    monkeypatch.setattr(uc, "__installed_version__", "1.0.0")
+    uc._save_config({"last_check": time.time()})
+    fetch_called = []
+    monkeypatch.setattr(
+        uc, "_fetch_latest_version", lambda: fetch_called.append(True)
+    )
+    uc.maybe_check_for_update()
+    assert fetch_called == []
+
+
+def test_maybe_check_for_update_runs_after_stale_check(monkeypatch):
+    monkeypatch.setattr(uc, "__installed_version__", "1.0.0")
+    uc._save_config(
+        {"last_check": time.time() - uc.CHECK_INTERVAL_SECONDS - 1}
+    )
+    monkeypatch.setattr(
+        "napari.qt.threading.thread_worker", _fake_thread_worker
+    )
+    monkeypatch.setattr(uc, "_fetch_latest_version", lambda: "2.0.0")
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc.maybe_check_for_update(parent=None)
+    assert shown == [("2.0.0", "1.0.0", None)]
+
+
+def test_maybe_check_for_update_returns_when_thread_worker_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(uc, "__installed_version__", "1.0.0")
+    import napari.qt.threading as napari_threading
+
+    monkeypatch.delattr(napari_threading, "thread_worker")
+    fetch_called = []
+    monkeypatch.setattr(
+        uc, "_fetch_latest_version", lambda: fetch_called.append(True)
+    )
+    uc.maybe_check_for_update()
+    assert fetch_called == []
+
+
+def test_maybe_check_for_update_end_to_end_shows_dialog(monkeypatch):
+    """Full happy path through the real (fake-threaded) worker plumbing."""
+    monkeypatch.setattr(uc, "__installed_version__", "1.0.0")
+    monkeypatch.setattr(
+        "napari.qt.threading.thread_worker", _fake_thread_worker
+    )
+    monkeypatch.setattr(uc, "_fetch_latest_version", lambda: "2.0.0")
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+
+    parent = object()
+    uc.maybe_check_for_update(parent=parent)
+
+    assert shown == [("2.0.0", "1.0.0", parent)]
+    assert "last_check" in uc._load_config()
+
+
+def test_maybe_check_for_update_end_to_end_no_dialog_when_up_to_date(
+    monkeypatch,
+):
+    monkeypatch.setattr(uc, "__installed_version__", "1.0.0")
+    monkeypatch.setattr(
+        "napari.qt.threading.thread_worker", _fake_thread_worker
+    )
+    monkeypatch.setattr(uc, "_fetch_latest_version", lambda: "1.0.0")
+    shown = []
+    monkeypatch.setattr(
+        uc, "_show_update_dialog", lambda *a, **k: shown.append(a)
+    )
+    uc.maybe_check_for_update()
+    assert shown == []
+
+
+# --- widget wiring ------------------------------------------------------
+
+
+def test_phasor_transform_triggers_update_check(
+    monkeypatch, make_viewer_model
+):
+    from napari_phasors import _widget as widget_mod
+
+    calls = []
+    monkeypatch.setattr(
+        widget_mod,
+        "maybe_check_for_update",
+        lambda parent=None: calls.append(parent),
+    )
+    viewer = make_viewer_model()
+    widget = widget_mod.PhasorTransform(viewer)
+    assert calls == [widget]
+
+
+def test_plotter_widget_triggers_update_check(monkeypatch, make_viewer_model):
+    from napari_phasors import plotter as plotter_mod
+
+    calls = []
+    monkeypatch.setattr(
+        plotter_mod,
+        "maybe_check_for_update",
+        lambda parent=None: calls.append(parent),
+    )
+    viewer = make_viewer_model()
+    widget = plotter_mod.PlotterWidget(viewer)
+    assert calls == [widget]

--- a/src/napari_phasors/_update_check.py
+++ b/src/napari_phasors/_update_check.py
@@ -1,0 +1,204 @@
+"""Unobtrusive background check for newer ``napari-phasors`` releases.
+
+On startup (once per session, and at most once a week) this queries PyPI in a
+background thread and, if a newer stable release is available, shows a small
+dialog with upgrade instructions. The dialog offers a "Don't notify me about
+updates again" checkbox that permanently disables the check.
+
+Everything here fails silently: no network, an odd PyPI response, or an
+unwritable config directory must never disrupt the plugin.
+"""
+
+import json
+import os
+import time
+import urllib.request
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+from platformdirs import user_config_dir
+
+# pragma: no cover - version file always present in a built/installed package
+try:
+    from ._version import version as __installed_version__
+except ImportError:
+    __installed_version__ = "unknown"
+
+#: PyPI JSON endpoint for the project.
+PYPI_URL = "https://pypi.org/pypi/napari-phasors/json"
+
+#: Minimum time between actual network checks (one week).
+CHECK_INTERVAL_SECONDS = 7 * 24 * 60 * 60
+
+#: Network timeout for the PyPI request, in seconds.
+_REQUEST_TIMEOUT = 3.0
+
+#: Guard so the check runs at most once per interpreter session, regardless of
+#: how many plugin widgets the user opens.
+_checked_this_session = False
+
+
+def _config_path() -> Path:
+    """Return the path to the persistent update-check config file."""
+    return Path(user_config_dir("napari-phasors")) / "update_check.json"
+
+
+def _load_config() -> dict:
+    """Load the persisted config, returning an empty dict on any failure."""
+    try:
+        with open(_config_path(), encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_config(config: dict) -> None:
+    """Persist the config, silently ignoring any write failure."""
+    try:
+        path = _config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(config, f)
+    except OSError:
+        pass
+
+
+def _fetch_latest_version() -> str | None:
+    """Return the latest stable version string from PyPI, or ``None``."""
+    try:
+        request = urllib.request.Request(
+            PYPI_URL, headers={"User-Agent": "napari-phasors-update-check"}
+        )
+        with urllib.request.urlopen(
+            request, timeout=_REQUEST_TIMEOUT
+        ) as response:
+            data = json.load(response)
+        version = data.get("info", {}).get("version")
+        return version if isinstance(version, str) else None
+    except Exception:  # noqa: BLE001 - never let a check break startup
+        return None
+
+
+def _is_source_install(installed: Version) -> bool:
+    """Whether this looks like an editable/source build (not a PyPI release).
+
+    ``setuptools_scm`` stamps such builds with a local version segment (e.g.
+    ``0.4.2.dev75+gb0c98f1``). We never nag developers running from source.
+    """
+    return installed.local is not None or installed.is_devrelease
+
+
+def _upgrade_instructions() -> str:
+    """Return upgrade instructions, ordered by the likely install method."""
+    pip_line = "• pip:   pip install --upgrade napari-phasors"
+    conda_line = "• conda: conda update -c conda-forge napari-phasors"
+    napari_line = "• napari: Plugins ▸ Install/Uninstall Plugins… ▸ Update"
+    # Inside a conda environment, surface the conda command first.
+    if os.environ.get("CONDA_PREFIX"):
+        lines = [conda_line, pip_line, napari_line]
+    else:
+        lines = [pip_line, conda_line, napari_line]
+    return "\n".join(lines)
+
+
+def _show_update_dialog(latest: str, installed: str, parent=None) -> None:
+    """Show the (non-modal) update dialog with a "don't ask again" option."""
+    from qtpy.QtWidgets import QCheckBox, QMessageBox
+
+    box = QMessageBox(parent)
+    box.setIcon(QMessageBox.Information)
+    box.setWindowTitle("napari-phasors update available")
+    box.setText(
+        f"A new version of napari-phasors is available.\n\n"
+        f"Installed: {installed}\nLatest: {latest}"
+    )
+    box.setInformativeText(
+        "To update, use the method matching your installation:\n\n"
+        f"{_upgrade_instructions()}\n\n"
+        "(Restart napari after updating.)"
+    )
+    box.setStandardButtons(QMessageBox.Ok)
+
+    dont_ask = QCheckBox("Don't notify me about updates again")
+    box.setCheckBox(dont_ask)
+
+    def _on_finished(_result):
+        if dont_ask.isChecked():
+            config = _load_config()
+            config["disabled"] = True
+            _save_config(config)
+
+    box.finished.connect(_on_finished)
+    # Non-modal so it never blocks the UI; keep a reference alive so it is not
+    # garbage-collected before the user interacts with it.
+    box.setModal(False)
+    box.show()
+    global _live_dialog
+    _live_dialog = box
+
+
+#: Keeps the non-modal dialog alive until dismissed.
+_live_dialog = None
+
+
+def _handle_latest_version(latest: str | None, installed: Version, parent):
+    """Record the check and show the dialog if a newer release exists."""
+    config = _load_config()
+    config["last_check"] = time.time()
+    _save_config(config)
+
+    if latest is None:
+        return
+    try:
+        if Version(latest) > installed:
+            _show_update_dialog(latest, str(installed), parent)
+    except InvalidVersion:
+        pass
+
+
+def maybe_check_for_update(parent=None) -> None:
+    """Kick off an unobtrusive background check for a newer release.
+
+    Safe to call from multiple widget constructors: it runs at most once per
+    session and no more than once per :data:`CHECK_INTERVAL_SECONDS`. Skips
+    entirely for source/dev installs and when the user has opted out.
+    """
+    global _checked_this_session
+    if _checked_this_session:
+        return
+    _checked_this_session = True
+
+    try:
+        installed = Version(__installed_version__)
+    except InvalidVersion:
+        return
+
+    if _is_source_install(installed):
+        return
+
+    config = _load_config()
+    if config.get("disabled"):
+        return
+
+    last_check = config.get("last_check", 0)
+    if (
+        isinstance(last_check, (int, float))
+        and time.time() - last_check < CHECK_INTERVAL_SECONDS
+    ):
+        return
+
+    try:
+        from napari.qt.threading import thread_worker
+    except ImportError:
+        return
+
+    @thread_worker
+    def _worker():
+        return _fetch_latest_version()
+
+    worker = _worker()
+    worker.returned.connect(
+        lambda latest: _handle_latest_version(latest, installed, parent)
+    )
+    worker.start()

--- a/src/napari_phasors/_update_check.py
+++ b/src/napari_phasors/_update_check.py
@@ -2,8 +2,9 @@
 
 On startup (once per session, and at most once a week) this queries PyPI in a
 background thread and, if a newer stable release is available, shows a small
-dialog with upgrade instructions. The dialog offers a "Don't notify me about
-updates again" checkbox that permanently disables the check.
+dialog with upgrade instructions. The dialog offers a "Don't show this
+message again" checkbox that suppresses the notice for that specific
+version only — a later release still triggers a fresh notice.
 
 Everything here fails silently: no network, an odd PyPI response, or an
 unwritable config directory must never disrupt the plugin.
@@ -103,7 +104,11 @@ def _upgrade_instructions() -> str:
 
 
 def _show_update_dialog(latest: str, installed: str, parent=None) -> None:
-    """Show the (non-modal) update dialog with a "don't ask again" option."""
+    """Show the (non-modal) update dialog with a "don't ask again" option.
+
+    The checkbox only suppresses the notice for ``latest``: once a newer
+    version is released, the notice reappears.
+    """
     from qtpy.QtWidgets import QCheckBox, QMessageBox
 
     box = QMessageBox(parent)
@@ -120,13 +125,13 @@ def _show_update_dialog(latest: str, installed: str, parent=None) -> None:
     )
     box.setStandardButtons(QMessageBox.Ok)
 
-    dont_ask = QCheckBox("Don't notify me about updates again")
+    dont_ask = QCheckBox("Don't show this message again")
     box.setCheckBox(dont_ask)
 
     def _on_finished(_result):
         if dont_ask.isChecked():
             config = _load_config()
-            config["disabled"] = True
+            config["skipped_version"] = latest
             _save_config(config)
 
     box.finished.connect(_on_finished)
@@ -143,12 +148,16 @@ _live_dialog = None
 
 
 def _handle_latest_version(latest: str | None, installed: Version, parent):
-    """Record the check and show the dialog if a newer release exists."""
+    """Record the check and show the dialog if a newer release exists.
+
+    Skips the dialog if the user previously dismissed the notice for this
+    exact ``latest`` version via "Don't show this message again".
+    """
     config = _load_config()
     config["last_check"] = time.time()
     _save_config(config)
 
-    if latest is None:
+    if latest is None or latest == config.get("skipped_version"):
         return
     try:
         if Version(latest) > installed:
@@ -162,7 +171,11 @@ def maybe_check_for_update(parent=None) -> None:
 
     Safe to call from multiple widget constructors: it runs at most once per
     session and no more than once per :data:`CHECK_INTERVAL_SECONDS`. Skips
-    entirely for source/dev installs and when the user has opted out.
+    entirely for source/dev installs. If the user previously dismissed the
+    notice for the latest-known version via "Don't show this message again",
+    the dialog itself is suppressed for that version only (see
+    :func:`_handle_latest_version`) — the check still runs so a newer release
+    is detected.
     """
     global _checked_this_session
     if _checked_this_session:
@@ -178,9 +191,6 @@ def maybe_check_for_update(parent=None) -> None:
         return
 
     config = _load_config()
-    if config.get("disabled"):
-        return
-
     last_check = config.get("last_check", 0)
     if (
         isinstance(last_check, (int, float))

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -45,6 +45,7 @@ from ._reader import (
     napari_get_reader,
     raw_file_stack_reader,
 )
+from ._update_check import maybe_check_for_update
 from ._utils import (
     CheckableComboBox,
     CollapsibleSection,
@@ -141,6 +142,9 @@ class PhasorTransform(PopoutWindowMixin, QWidget):
             ".lif": LifWidget,
             ".json": JsonWidget,
         }
+
+        # Unobtrusive, throttled check for a newer release (see module docs).
+        maybe_check_for_update(parent=self)
 
     def _open_file_dialog(self):
         """Open a dialog to select one or many files for import.

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -44,6 +44,7 @@ from qtpy.QtWidgets import (
 )
 from superqt import QToggleSwitch
 
+from ._update_check import maybe_check_for_update
 from ._utils import (
     CheckableComboBox,
     CollapsibleSection,
@@ -1552,6 +1553,9 @@ class PlotterWidget(QWidget):
         super().__init__()
         self._is_closing = False
         self.viewer = napari_viewer
+
+        # Unobtrusive, throttled check for a newer release (see module docs).
+        maybe_check_for_update(parent=self)
 
         self.setWindowTitle("Phasor Plot")
         self.setObjectName("Phasor Plot")


### PR DESCRIPTION
## Summary

Adds a lightweight, opt-in-by-default check that lets users know when a newer
`napari-phasors` release is available, without being intrusive.

- On first widget open (`Phasor Custom Import` or `Phasor Plot`), a background
  thread (`napari.qt.threading.thread_worker`) queries PyPI's JSON API for the
  latest published version and compares it against the installed one.
- If a newer version exists, a small non-modal dialog appears with upgrade
  instructions tailored to the likely install method (conda vs. pip vs. the
  napari plugin manager), ordered by whichever is detected (`CONDA_PREFIX`).
- The dialog has a **"Don't show this message again"** checkbox. Checking it
  suppresses the notice for *that specific version only* — a later release
  still triggers a fresh notice.
- The check itself is throttled to at most once per session and once per
  week (cached in a small local config file via `platformdirs`), and is
  skipped entirely for source/editable installs (detected via the
  `setuptools_scm`-stamped dev/local version segment), so it never fires for
  contributors running from a git checkout.
- Fails silently on any network error, malformed PyPI response, or
  unwritable config path — it can never disrupt plugin startup.

## Why

Users on older releases have no way to know a newer version exists short of
checking PyPI/GitHub manually. A toast/popup on every launch would be
annoying, so this is throttled, remembers dismissals per-version, and stays
out of the way for developers.

## Implementation

- `src/napari_phasors/_update_check.py` (new): all the logic — config
  persistence, PyPI fetch, version comparison, dialog, throttling.
- `src/napari_phasors/_widget.py`, `src/napari_phasors/plotter.py`: call
  `maybe_check_for_update(parent=self)` once from each of the two main
  widget entry points.

## Testing

- New `src/napari_phasors/_tests/test_update_check.py` (34 tests) covering:
  config load/save (including corrupt/non-dict JSON and write failures),
  the PyPI fetch (success, network failure, malformed payload), source-install
  detection, the conda/pip instruction ordering, dialog construction and both
  checkbox states, the per-version skip logic (including that a *later*
  release still notifies after an earlier one was dismissed), and the full
  `maybe_check_for_update` gating (session guard, throttle window, missing
  `thread_worker`, end-to-end dialog-shown/not-shown via a fake synchronous
  worker).
- Ran the full existing `test_widget.py` and `test_plotter.py` suites to
  confirm the new constructor calls don't introduce real network activity or
  regressions (dev/editable installs short-circuit before any network call).
- Manually verified dialog construction and the checkbox → config persistence
  round-trip offscreen.