### PR TITLE
Several bug fixes: Fix UI elements and enhance layer handling in tests and components

### DIFF
--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QDialog
+from qtpy.QtWidgets import QDialog, QWidget
 
 # Patch napari's _QtMainWindow.eventFilter to guard against PySide6 passing
 # QWidgetItem (a non-QObject) as the `watched` argument, which causes a
@@ -110,14 +110,58 @@ def _ensure_qapp(qapp):
 
 
 @pytest.fixture(autouse=True)
-def _hide_qdialog(monkeypatch):
-    orig_show = QDialog.show
+def _hide_widgets_on_screen(monkeypatch):
+    """Keep every widget/dialog shown during a test off the physical screen.
 
-    def hidden_show(self):
-        self.setAttribute(Qt.WA_DontShowOnScreen, True)
-        orig_show(self)
+    Several plugin widgets call ``self.show()`` themselves (e.g.
+    ``HistogramWidget.update_data``, the ``PopoutWindowMixin`` "Phasor
+    Custom Import" window) in addition to the dialogs tests open directly.
+    Left unpatched, those calls pop up real windows/plots while the suite
+    runs. Setting ``Qt.WA_DontShowOnScreen`` before ``show()`` keeps Qt's
+    normal layout/rendering machinery working (so ``isVisible()``, size
+    hints, ``showEvent`` etc. all still behave the same) without mapping a
+    window onto the display. ``QWidget.show`` and ``QDialog.show`` are
+    separate bound methods in PyQt/PySide, so both need patching.
+    """
 
-    monkeypatch.setattr(QDialog, "show", hidden_show)
+    def _make_hidden_show(orig_show):
+        def hidden_show(self, *args, **kwargs):
+            self.setAttribute(Qt.WA_DontShowOnScreen, True)
+            return orig_show(self, *args, **kwargs)
+
+        return hidden_show
+
+    monkeypatch.setattr(QWidget, "show", _make_hidden_show(QWidget.show))
+    monkeypatch.setattr(QDialog, "show", _make_hidden_show(QDialog.show))
+
+
+@pytest.fixture(autouse=True)
+def _stub_color_dialog(monkeypatch):
+    """Prevent ``QColorDialog.getColor`` from opening a real color picker.
+
+    Several color-swatch buttons (marker color, contour color, cursor
+    color, ...) call ``QColorDialog.getColor(...)`` on click. On most
+    platforms this uses the *native* OS color panel rather than going
+    through Qt's own ``QDialog``/``QWidget`` machinery, so it bypasses the
+    ``_hide_widgets_on_screen`` patch above entirely and pops up a real
+    little window during the test run. Default to returning the initial
+    color unchanged (as if the user closed the picker without changing
+    anything); a test that needs to simulate picking a specific color can
+    still override this locally with its own ``monkeypatch.setattr``.
+    """
+    from qtpy.QtGui import QColor
+    from qtpy.QtWidgets import QColorDialog
+
+    def _fake_get_color(*args, **kwargs):
+        for arg in args:
+            if isinstance(arg, QColor):
+                return arg
+        initial = kwargs.get("initial")
+        if isinstance(initial, QColor):
+            return initial
+        return QColor()
+
+    monkeypatch.setattr(QColorDialog, "getColor", _fake_get_color)
 
 
 @pytest.fixture(autouse=True)

--- a/src/napari_phasors/_tests/conftest.py
+++ b/src/napari_phasors/_tests/conftest.py
@@ -234,11 +234,35 @@ def _cleanup_widgets_after_test(request):
             w.close()
             w.deleteLater()
 
-    # 4. Process all pending Qt events to execute deleteLater calls
-    from qtpy.QtCore import QCoreApplication
+    # 4. Process all pending Qt events to execute deleteLater calls.
+    # ``processEvents()`` alone does NOT deliver ``DeferredDelete`` events,
+    # so without the explicit ``sendPostedEvents`` flush the C++ side of the
+    # widgets deleteLater()'d above is destroyed at some arbitrary later
+    # event-loop spin — e.g. while the next test is constructing its napari
+    # viewer — leaving Python wrappers pointing at freed Qt objects.
+    from qtpy.QtCore import QCoreApplication, QEvent
 
     with contextlib.suppress(Exception):
         QCoreApplication.processEvents()
+        QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+        QCoreApplication.processEvents()
+
+    # 5. Collect cyclic garbage now, at a controlled point.
+    # The root conftest disables automatic GC under PySide6, so reference
+    # cycles (matplotlib Figure <-> canvas, closed widgets captured by
+    # lambdas/signal closures) otherwise accumulate for the worker's whole
+    # lifetime. The first ``make_napari_viewer`` test then detonates them:
+    # napari's fixture calls ``gc.collect()`` during *setup*, destroying
+    # hundreds of stale Qt wrappers mid-viewer-construction, which
+    # segfaults PySide6 xdist workers ("worker 'gwN' crashed" at the first
+    # make_napari_viewer test after widget-heavy files). Collecting here —
+    # right after the plugin widgets were closed and their deferred
+    # deletions flushed, with no viewer half-built — keeps every collection
+    # small and safe.
+    import gc
+
+    with contextlib.suppress(Exception):
+        gc.collect()
 
 
 @pytest.fixture

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -857,6 +857,9 @@ def test_components_widget_harmonic_signal_connection(
 
 def test_components_widget_scroll_area_exists(make_viewer_model, qtbot):
     """Test that a scroll area is created for the components widget."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtWidgets import QScrollArea
+
     viewer = make_viewer_model()
     parent = PlotterWidget(viewer)
     comp_widget = parent.components_tab
@@ -864,6 +867,12 @@ def test_components_widget_scroll_area_exists(make_viewer_model, qtbot):
     # The layout should contain a scroll area
     assert comp_widget.layout() is not None
     assert comp_widget.layout().count() > 0
+
+    # The horizontal scrollbar must only appear once the content genuinely
+    # can't shrink further, not be permanently suppressed.
+    scroll_area = comp_widget.findChild(QScrollArea)
+    assert scroll_area is not None
+    assert scroll_area.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
 
 
 def test_components_fraction_range_updates_layer_and_is_reversible(

--- a/src/napari_phasors/_tests/test_import_export_settings.py
+++ b/src/napari_phasors/_tests/test_import_export_settings.py
@@ -124,23 +124,22 @@ def test_import_from_layer_dialog_accepted(make_viewer_model, qtbot):
                 mock_dialog.assert_called_once()
                 mock_dialog_instance.exec.assert_called_once()
 
-                # Verify the layer selection combobox was populated
-                mock_combo_instance.addItems.assert_called_with(['layer2'])
+                # Verify the layer selection combobox was populated with
+                # every phasor layer, including ones currently checked for
+                # visualization in the phasor plot.
+                mock_combo_instance.addItems.assert_called_with(
+                    ['layer1', 'layer2']
+                )
 
                 # Verify that since the first dialog was accepted,
                 # the second dialog was shown.
                 mock_show_import_dialog.assert_called_once()
 
 
-def test_import_from_layer_no_other_layers(make_viewer_model, qtbot):
-    """Test import when there are no other layers available."""
+def test_import_from_layer_no_phasor_layers(make_viewer_model, qtbot):
+    """Test import when there are no layers with phasor data available."""
     viewer = make_viewer_model()
-    layer1 = create_image_layer_with_phasors()
-    layer1.name = "layer1"
-    viewer.add_layer(layer1)
-
     plotter = PlotterWidget(viewer)
-    plotter.image_layer_with_phasor_features_combobox.setCurrentText("layer1")
 
     with (
         patch('napari_phasors.plotter.QDialog') as mock_dialog,
@@ -159,7 +158,7 @@ def test_import_from_layer_no_other_layers(make_viewer_model, qtbot):
         ) as mock_show_import_dialog:
             with patch('napari_phasors.plotter.QComboBox') as mock_combo:
                 mock_combo_instance = Mock()
-                # When no other layers are available, the combobox is empty
+                # When no phasor layers are available, the combobox is empty
                 # and currentText returns an empty string.
                 mock_combo_instance.currentText = Mock(return_value="")
                 mock_combo.return_value = mock_combo_instance
@@ -175,6 +174,47 @@ def test_import_from_layer_no_other_layers(make_viewer_model, qtbot):
 
                 # Verify the second dialog was NOT shown
                 mock_show_import_dialog.assert_not_called()
+
+
+def test_import_from_layer_includes_currently_selected_layer(
+    make_viewer_model, qtbot
+):
+    """The source-layer dropdown must include layers currently checked in
+    the plotter's image-layer combobox, not just unchecked ones."""
+    viewer = make_viewer_model()
+    layer1 = create_image_layer_with_phasors()
+    layer1.name = "layer1"
+    viewer.add_layer(layer1)
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layer_with_phasor_features_combobox.setCurrentText("layer1")
+    # Ensure layer1 is checked (selected for visualization) in the
+    # checkable combobox, matching the reported bug scenario.
+    plotter.image_layers_checkable_combobox.setCheckedItems(["layer1"])
+
+    with (
+        patch('napari_phasors.plotter.QDialog') as mock_dialog,
+        patch('napari_phasors.plotter.QVBoxLayout'),
+        patch('napari_phasors.plotter.QLabel'),
+        patch('napari_phasors.plotter.QDialogButtonBox'),
+    ):
+
+        mock_dialog.Accepted = 1
+        mock_dialog_instance = Mock()
+        mock_dialog_instance.exec = Mock(return_value=mock_dialog.Accepted)
+        mock_dialog.return_value = mock_dialog_instance
+
+        with patch.object(plotter, '_show_import_dialog'):
+            with patch('napari_phasors.plotter.QComboBox') as mock_combo:
+                mock_combo_instance = Mock()
+                mock_combo_instance.currentText = Mock(return_value="layer1")
+                mock_combo.return_value = mock_combo_instance
+
+                plotter._import_settings_from_layer()
+
+                # layer1 is checked for visualization but must still be
+                # offered as a source layer to copy settings from.
+                mock_combo_instance.addItems.assert_called_with(['layer1'])
 
 
 def test_import_all_settings_from_layer(make_viewer_model, qtbot):

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -258,7 +258,7 @@ def test_phasor_mapping_widget_plot_histogram_no_data(
     assert lifetime_widget.histogram_widget.counts is None
     assert not lifetime_widget.histogram_widget.isHidden()
     assert not lifetime_widget.histogram_widget._settings_button.isEnabled()
-    assert not lifetime_widget.histogram_widget.save_png_button.isEnabled()
+    assert not lifetime_widget.histogram_widget.save_button.isEnabled()
 
 
 def test_phasor_mapping_widget_ui_layout(make_viewer_model, qtbot):
@@ -873,7 +873,7 @@ def test_phasor_mapping_widget_image_layer_changed_no_layer(
     assert lifetime_widget.lifetime_data_original is None
     assert lifetime_widget.histogram_widget.counts is None
     assert not lifetime_widget.histogram_widget._settings_button.isEnabled()
-    assert not lifetime_widget.histogram_widget.save_png_button.isEnabled()
+    assert not lifetime_widget.histogram_widget.save_button.isEnabled()
 
 
 def test_phasor_mapping_widget_colormap_changed_callback(

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -112,6 +112,9 @@ def test_phasor_mapping_widget_initialization_values(make_viewer_model, qtbot):
     assert len(scroll_areas) == 1
     scroll_area = scroll_areas[0]
     assert scroll_area.widgetResizable()
+    # The horizontal scrollbar must only appear once the content genuinely
+    # can't shrink further, not be permanently suppressed.
+    assert scroll_area.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
 
     # Histogram widget is now hosted in the shared dock stack.
     assert (

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -372,6 +372,14 @@ def test_canvas_container_resize_starts_debounce_timer(make_viewer_model):
         "None",
     ]
 
+    # The plot-type combobox must not force the Plot Settings tab wide just
+    # to display its longest item text ("Density Plot (2D Histogram)") --
+    # it should truncate/elide instead of setting a large minimum width.
+    assert (
+        plotter.plotter_inputs_widget.plot_type_combobox.minimumSizeHint().width()
+        < 200
+    )
+
     # Test colormap combobox has items (should have all available colormaps)
     assert plotter.plotter_inputs_widget.colormap_combobox.count() > 0
 
@@ -395,6 +403,41 @@ def test_canvas_container_resize_starts_debounce_timer(make_viewer_model):
     ylim = plotter.canvas_widget.axes.get_ylim()
     assert xlim[0] == -0.1 and xlim[1] == 1.1
     assert ylim[0] == -0.1 and ylim[1] == 0.7
+
+
+def test_plot_settings_tab_labels_wrap_and_scroll_policy(
+    make_viewer_model, qtbot
+):
+    """Long, non-wrapping labels/comboboxes used to force the Plot Settings
+    tab (and its inner scroll area) far wider/taller than necessary before
+    a horizontal scrollbar would appear. Word-wrapping the long labels and
+    letting the scrollbar show "as needed" (instead of never) fixes that."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtWidgets import QLabel, QScrollArea
+
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+
+    # "Full Polar Plot (Spectral Phasor)" must wrap instead of setting a
+    # ~240px-wide floor on the settings grid's label column.
+    assert plotter.plotter_inputs_widget.label_5.wordWrap()
+
+    # "Load and Apply Settings from:" (above the Layer/OME-TIFF buttons)
+    # must also wrap rather than force the import row wide.
+    import_labels = [
+        label
+        for label in plotter.settings_tab.findChildren(QLabel)
+        if label.text() == "Load and Apply Settings from:"
+    ]
+    assert len(import_labels) == 1
+    assert import_labels[0].wordWrap()
+
+    # The inner scroll area around the settings grid must show its
+    # horizontal scrollbar only when needed, not be permanently suppressed.
+    scroll_area = plotter.settings_tab.findChild(QScrollArea)
+    assert scroll_area is not None
+    assert scroll_area.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
 
 
 def test_phasor_plotter_initialization_plot_not_called(make_viewer_model):

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -577,6 +577,45 @@ def test_adding_removing_layers_updates_plot(make_viewer_model):
     plotter.deleteLater()
 
 
+def test_switch_plot_type_after_removing_scatter_layer(make_viewer_model):
+    """Regression: SCATTER → remove layer → HISTOGRAM2D → add layer.
+
+    Removing the last layer calls ``artist._remove_artists()`` which empties
+    biaplotter's ``_mpl_artists`` but used to leave ``_color_indices``
+    populated. When a new layer was later added and the active artist was
+    switched, biaplotter's ``_colorize`` indexed into the now-empty
+    ``_mpl_artists`` and raised ``KeyError: 'scatter'``.
+    """
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+
+    # Draw a scatter plot so the Scatter artist gets real color indices.
+    layer_1 = create_image_layer_with_phasors()
+    viewer.add_layer(layer_1)
+    plotter.plot_type = 'SCATTER'
+    scatter_artist = plotter.canvas_widget.artists['SCATTER']
+    assert scatter_artist._color_indices is not None
+
+    # Remove the layer — this empties the mpl artists.
+    viewer.layers.remove(layer_1)
+    assert scatter_artist._mpl_artists == {}
+    # Invariant restored: no mpl artists => no stale color indices.
+    assert scatter_artist._color_indices is None
+
+    # Switch to density and import a new layer. Previously this raised
+    # KeyError: 'scatter' from biaplotter's _colorize.
+    plotter.plot_type = 'HISTOGRAM2D'
+    layer_2 = create_image_layer_with_phasors()
+    viewer.add_layer(layer_2)
+
+    assert plotter.plot_type == 'HISTOGRAM2D'
+    assert plotter.canvas_widget.active_artist.__class__.__name__ == (
+        'Histogram2D'
+    )
+
+    plotter.deleteLater()
+
+
 def test_layer_settings_persistence_across_layer_switches(make_viewer_model):
     """Test that settings persist when switching between layers."""
     viewer = make_viewer_model()

--- a/src/napari_phasors/_tests/test_plotter_features.py
+++ b/src/napari_phasors/_tests/test_plotter_features.py
@@ -11,6 +11,24 @@ from napari_phasors.plotter import (
 )
 
 
+def test_home_button_clears_stored_zoom(make_viewer_model):
+    """Pressing Home must clear the stored user zoom so later replots
+    (e.g. a colormap change) use the default limits, not the stale zoom."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+    toolbar = getattr(plotter.canvas_widget, "toolbar", None)
+    if toolbar is None or not getattr(toolbar, "_actions", {}).get("home"):
+        return
+
+    # Simulate a user zoom having been stored.
+    plotter._user_axes_limits = ((0.2, 0.4), (0.2, 0.4))
+
+    # Trigger the Home button exactly as a click would.
+    toolbar._actions["home"].trigger()
+
+    assert plotter._user_axes_limits is None
+
+
 def test_canvas_cleared_when_no_layer_selected(make_viewer_model):
     """Test that canvas phasor data is cleared but semicircle/circle remains when no layer is selected."""
     viewer = make_viewer_model()

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -30,8 +30,7 @@ def test_histogram_widget_update_data_and_clear(qtbot):
     assert -1.0 in widget._raw_valid_data
     assert np.all(np.isfinite(widget._raw_valid_data))
     assert widget._settings_button.isEnabled()
-    assert widget.save_png_button.isEnabled()
-    assert widget.save_csv_button.isEnabled()
+    assert widget.save_button.isEnabled()
 
     widget.clear()
 
@@ -41,8 +40,7 @@ def test_histogram_widget_update_data_and_clear(qtbot):
     assert widget._datasets == {}
     assert widget._raw_valid_data is None
     assert not widget._settings_button.isEnabled()
-    assert not widget.save_png_button.isEnabled()
-    assert not widget.save_csv_button.isEnabled()
+    assert not widget.save_button.isEnabled()
 
 
 def test_histogram_widget_save_csv(qtbot, tmp_path, monkeypatch):

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -3,6 +3,7 @@ import csv
 import numpy as np
 
 from napari_phasors._utils import (
+    CurrentPageStackedWidget,
     HistogramDockWidget,
     HistogramWidget,
     StatisticsDockWidget,
@@ -1198,6 +1199,30 @@ def test_file_order_dialog_reorder_and_getters(qtbot):
     assert dlg.get_ordered_paths() == ["/d/b.lsm", "/d/c.lsm", "/d/a.lsm"]
 
 
+def test_file_order_dialog_items_not_drop_enabled(qtbot):
+    """Items must not carry ``Qt.ItemIsDropEnabled``.
+
+    Combined with ``QAbstractItemView.InternalMove``, a per-item drop flag
+    lets Qt treat a drag as landing *on* another item instead of *between*
+    rows, which can make the dragged item vanish (``takeItem`` fires but the
+    reinsert doesn't land in the right spot). See the ``FileOrderDialog``
+    docstring / PR history for the reported bug.
+    """
+    from qtpy.QtCore import Qt
+
+    from napari_phasors._utils import FileOrderDialog
+
+    dlg = FileOrderDialog(["/d/a.lsm", "/d/b.lsm"], estimated_shape=(4, 4))
+    qtbot.addWidget(dlg)
+
+    for row in range(dlg.file_list.count()):
+        item = dlg.file_list.item(row)
+        assert not (item.flags() & Qt.ItemIsDropEnabled)
+        assert item.flags() & Qt.ItemIsDragEnabled
+        assert item.flags() & Qt.ItemIsSelectable
+        assert item.flags() & Qt.ItemIsEnabled
+
+
 def test_file_order_dialog_axis_label_defaults(qtbot):
     from napari_phasors._utils import FileOrderDialog
 
@@ -1606,6 +1631,113 @@ def test_histogram_widget_taller_default_canvas_height(qtbot):
     widget = HistogramWidget()
     qtbot.addWidget(widget)
     assert widget.fig.canvas.minimumHeight() >= 180
+
+
+def test_histogram_widget_save_menu_dispatches_to_png_and_csv(qtbot):
+    """The merged "Save Histogram…" button opens a menu that dispatches to
+    the correct export routine depending on which action is chosen."""
+    from unittest.mock import MagicMock, patch
+
+    widget = HistogramWidget(bins=4)
+    qtbot.addWidget(widget)
+    widget.update_data(np.array([1.0, 2.0, 3.0]))
+    assert widget.save_button.isEnabled()
+
+    def _mock_menu_returning(chosen_index):
+        mock_menu = MagicMock()
+        png_action = MagicMock(name="png_action")
+        csv_action = MagicMock(name="csv_action")
+        mock_menu.addAction.side_effect = [png_action, csv_action]
+        actions = [png_action, csv_action]
+        mock_menu.exec.return_value = (
+            actions[chosen_index] if chosen_index is not None else None
+        )
+        return mock_menu
+
+    # Choosing "Save as PNG" calls the PNG export only.
+    with (
+        patch.object(widget, '_save_histogram_png') as mock_png,
+        patch.object(widget, '_save_histogram_csv') as mock_csv,
+        patch('napari_phasors._utils.QMenu') as mock_menu_cls,
+    ):
+        mock_menu_cls.return_value = _mock_menu_returning(0)
+        widget._show_save_menu()
+        mock_png.assert_called_once()
+        mock_csv.assert_not_called()
+
+    # Choosing "Save as CSV" calls the CSV export only.
+    with (
+        patch.object(widget, '_save_histogram_png') as mock_png,
+        patch.object(widget, '_save_histogram_csv') as mock_csv,
+        patch('napari_phasors._utils.QMenu') as mock_menu_cls,
+    ):
+        mock_menu_cls.return_value = _mock_menu_returning(1)
+        widget._show_save_menu()
+        mock_csv.assert_called_once()
+        mock_png.assert_not_called()
+
+    # Dismissing the menu without a choice triggers neither export.
+    with (
+        patch.object(widget, '_save_histogram_png') as mock_png,
+        patch.object(widget, '_save_histogram_csv') as mock_csv,
+        patch('napari_phasors._utils.QMenu') as mock_menu_cls,
+    ):
+        mock_menu_cls.return_value = _mock_menu_returning(None)
+        widget._show_save_menu()
+        mock_png.assert_not_called()
+        mock_csv.assert_not_called()
+
+
+def test_histogram_widget_save_button_wired_to_save_menu(qtbot):
+    """The merged save button's ``clicked`` signal is wired to the
+    export-format menu handler (not to the old per-format buttons)."""
+    widget = HistogramWidget(bins=4)
+    qtbot.addWidget(widget)
+    widget.update_data(np.array([1.0, 2.0, 3.0]))
+
+    assert widget.save_button.receivers(widget.save_button.clicked) >= 1
+    assert not hasattr(widget, 'save_png_button')
+    assert not hasattr(widget, 'save_csv_button')
+
+
+def test_current_page_stacked_widget_sizes_to_active_page(qtbot):
+    """``CurrentPageStackedWidget`` must not let a hidden page's larger size
+    hint force the container wider than the currently active page needs.
+
+    Regression test for the FRET/Selection tab bug where a plain
+    ``QStackedWidget`` reported the max size hint across *all* pages
+    (including hidden ones), preventing the tab from shrinking below the
+    widest page even when a much narrower page was on display.
+    """
+    from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
+
+    stack = CurrentPageStackedWidget()
+    qtbot.addWidget(stack)
+
+    small_page = QLineEdit()
+
+    big_page = QWidget()
+    big_layout = QHBoxLayout(big_page)
+    big_layout.setContentsMargins(0, 0, 0, 0)
+    big_layout.addWidget(QLabel("A" * 60))
+    big_layout.addWidget(QLineEdit())
+    big_layout.addWidget(QLineEdit())
+
+    stack.addWidget(small_page)
+    stack.addWidget(big_page)
+    stack.show()
+
+    stack.setCurrentIndex(1)
+    big_page_min_width = stack.minimumSizeHint().width()
+    assert big_page_min_width > small_page.minimumSizeHint().width()
+
+    stack.setCurrentIndex(0)
+    # The stack's own hint must match the small page alone, not the max
+    # across all pages (the default QStackedWidget behavior).
+    assert (
+        stack.minimumSizeHint().width() == small_page.minimumSizeHint().width()
+    )
+    assert stack.minimumSizeHint().width() < big_page_min_width
 
 
 def test_statistics_dock_export_csv(qtbot, tmp_path, monkeypatch):

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -14,6 +14,20 @@ from napari_phasors._utils import (
 )
 
 
+def _clicked_receiver_count(button):
+    """Return the number of receivers connected to ``button.clicked``.
+
+    PyQt's ``QObject.receivers`` accepts the bound ``SignalInstance``
+    directly, while PySide6 requires the signal signature wrapped with the
+    ``SIGNAL`` macro (a bare instance or signature string returns 0 there).
+    """
+    try:
+        from qtpy.QtCore import SIGNAL  # PySide6 only
+    except ImportError:
+        return button.receivers(button.clicked)
+    return button.receivers(SIGNAL("clicked()"))
+
+
 def test_histogram_widget_update_data_and_clear(qtbot):
     """HistogramWidget should compute bins and reset cleanly."""
     widget = HistogramWidget(bins=8)
@@ -1695,7 +1709,7 @@ def test_histogram_widget_save_button_wired_to_save_menu(qtbot):
     qtbot.addWidget(widget)
     widget.update_data(np.array([1.0, 2.0, 3.0]))
 
-    assert widget.save_button.receivers(widget.save_button.clicked) >= 1
+    assert _clicked_receiver_count(widget.save_button) >= 1
     assert not hasattr(widget, 'save_png_button')
     assert not hasattr(widget, 'save_csv_button')
 

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -55,6 +55,7 @@ from qtpy.QtWidgets import (
     QMenu,
     QPushButton,
     QSizePolicy,
+    QStackedWidget,
     QStyle,
     QStyledItemDelegate,
     QStyleOptionButton,
@@ -97,6 +98,34 @@ def make_section(title):
     box = QGroupBox(title)
     layout = QVBoxLayout(box)
     return box, layout
+
+
+class CurrentPageStackedWidget(QStackedWidget):
+    """A ``QStackedWidget`` that sizes itself to the visible page only.
+
+    The default ``QStackedWidget`` reports a size hint wide enough for its
+    *widest* page even while that page is hidden, which stops a parent
+    layout (e.g. a ``QFormLayout`` field column) from shrinking below a page
+    the user cannot currently see. This subclass reports the current page's
+    size instead, so hidden pages no longer set a floor on the container's
+    width.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.currentChanged.connect(lambda _index: self.updateGeometry())
+
+    def sizeHint(self):
+        widget = self.currentWidget()
+        return widget.sizeHint() if widget is not None else super().sizeHint()
+
+    def minimumSizeHint(self):
+        widget = self.currentWidget()
+        return (
+            widget.minimumSizeHint()
+            if widget is not None
+            else super().minimumSizeHint()
+        )
 
 
 # Green-outlined "ready" look for a tab's primary action button. ``#27ae60``
@@ -2518,22 +2547,16 @@ class HistogramWidget(QWidget):
 
         controls_layout.addStretch()
 
-        self.save_png_button = QPushButton("Save Histogram as PNG")
-        self.save_png_button.setMinimumWidth(180)
-        self.save_png_button.clicked.connect(self._save_histogram_png)
-        controls_layout.addWidget(self.save_png_button)
-
-        self.save_csv_button = QPushButton("Save Histogram as CSV")
-        self.save_csv_button.setMinimumWidth(180)
-        self.save_csv_button.clicked.connect(self._save_histogram_csv)
-        controls_layout.addWidget(self.save_csv_button)
+        self.save_button = QPushButton("Save Histogram…")
+        self.save_button.setMinimumWidth(180)
+        self.save_button.clicked.connect(self._show_save_menu)
+        controls_layout.addWidget(self.save_button)
 
         layout.addLayout(controls_layout)
 
         # Buttons are disabled until data is loaded
         self._settings_button.setEnabled(False)
-        self.save_png_button.setEnabled(False)
-        self.save_csv_button.setEnabled(False)
+        self.save_button.setEnabled(False)
 
     def _filter_valid_values(self, data: np.ndarray) -> np.ndarray:
         """Return finite values, optionally excluding non-positive entries."""
@@ -2672,6 +2695,19 @@ class HistogramWidget(QWidget):
         self.range_slider.setValue((lo_s, hi_s))
         lo_out, hi_out = self.get_range()
         self.rangeChanged.emit(lo_out, hi_out)
+
+    def _show_save_menu(self):
+        """Show a menu to choose the histogram export format."""
+        menu = QMenu(self)
+        png_action = menu.addAction("Save as PNG")
+        csv_action = menu.addAction("Save as CSV")
+        action = menu.exec(
+            self.save_button.mapToGlobal(self.save_button.rect().bottomLeft())
+        )
+        if action == png_action:
+            self._save_histogram_png()
+        elif action == csv_action:
+            self._save_histogram_csv()
 
     def _save_histogram_png(self):
         """Save the histogram as a high-DPI PNG image."""
@@ -2892,8 +2928,7 @@ class HistogramWidget(QWidget):
             self._style_axes()
             self.fig.canvas.draw_idle()
             self._settings_button.setEnabled(False)
-            self.save_png_button.setEnabled(False)
-            self.save_csv_button.setEnabled(False)
+            self.save_button.setEnabled(False)
             self.show()
             self.dataChanged.emit()
             return
@@ -2912,8 +2947,7 @@ class HistogramWidget(QWidget):
 
         self._render()
         self._settings_button.setEnabled(True)
-        self.save_png_button.setEnabled(True)
-        self.save_csv_button.setEnabled(True)
+        self.save_button.setEnabled(True)
         self.show()
         self.dataChanged.emit()
 
@@ -2941,8 +2975,7 @@ class HistogramWidget(QWidget):
             self._style_axes()
             self.fig.canvas.draw_idle()
             self._settings_button.setEnabled(False)
-            self.save_png_button.setEnabled(False)
-            self.save_csv_button.setEnabled(False)
+            self.save_button.setEnabled(False)
             self.show()
             self.dataChanged.emit()
             return
@@ -2967,8 +3000,7 @@ class HistogramWidget(QWidget):
 
         self._render()
         self._settings_button.setEnabled(True)
-        self.save_png_button.setEnabled(True)
-        self.save_csv_button.setEnabled(True)
+        self.save_button.setEnabled(True)
         self.show()
         self.dataChanged.emit()
 
@@ -3030,8 +3062,7 @@ class HistogramWidget(QWidget):
         self._style_axes()
         self.fig.canvas.draw_idle()
         self._settings_button.setEnabled(False)
-        self.save_png_button.setEnabled(False)
-        self.save_csv_button.setEnabled(False)
+        self.save_button.setEnabled(False)
         self.dataChanged.emit()
 
     @property
@@ -4090,10 +4121,7 @@ class FileOrderDialog(QDialog):
             item.setToolTip(path)
             item.setData(Qt.UserRole, path)
             item.setFlags(
-                Qt.ItemIsSelectable
-                | Qt.ItemIsEnabled
-                | Qt.ItemIsDragEnabled
-                | Qt.ItemIsDropEnabled
+                Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsDragEnabled
             )
             self.file_list.addItem(item)
 

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -1510,8 +1510,10 @@ class FbdWidget(AdvancedOptionsWidget):
             "Default is -1. If this doesn't work, "
             "most probable laser factors are: 0.00022, 2.50012, 2.50016"
         )
-        self.laser_factor.setValidator(QDoubleValidator())
-        laser_factor_completer = QCompleter(["0.00022", "2.50012", "2.50016"])
+        self.laser_factor.setValidator(QDoubleValidator(self.laser_factor))
+        laser_factor_completer = QCompleter(
+            ["0.00022", "2.50012", "2.50016"], self.laser_factor
+        )
         self.laser_factor.setCompleter(laser_factor_completer)
         self.laser_factor.editingFinished.connect(
             lambda: self._update_signal_plot()

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -387,7 +387,7 @@ class ComponentsWidget(QWidget):
         # Scroll area
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         root_layout.addWidget(scroll_area)
 
         # Content widget inside scroll area

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -191,16 +191,19 @@ class FilterWidget(QWidget):
         )
         self.threshold_method_combobox.setCurrentText("None")
         threshold_method_layout.addWidget(self.threshold_method_combobox)
-
-        # Add log scale toggle to the same line as threshold method
-        threshold_method_layout.addSpacing(10)
-        self.log_scale_checkbox = QToggleSwitch("Log Scale Histogram")
-        self.log_scale_checkbox.onColor = QColor("#27ae60")  # Nice Green
-        self.log_scale_checkbox.setChecked(False)
-        threshold_method_layout.addWidget(self.log_scale_checkbox)
         threshold_method_layout.addStretch()
 
         threshold_box_layout.addLayout(threshold_method_layout)
+
+        # Log scale toggle on its own line so it doesn't force the section
+        # wider than the threshold method row needs.
+        log_scale_layout = QHBoxLayout()
+        self.log_scale_checkbox = QToggleSwitch("Log Scale Histogram")
+        self.log_scale_checkbox.onColor = QColor("#27ae60")  # Nice Green
+        self.log_scale_checkbox.setChecked(False)
+        log_scale_layout.addWidget(self.log_scale_checkbox)
+        log_scale_layout.addStretch()
+        threshold_box_layout.addLayout(log_scale_layout)
 
         # Threshold range slider with min/max edits
         theshold_slider_layout = QHBoxLayout()

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -24,7 +24,6 @@ from qtpy.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QSlider,
-    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -32,6 +31,7 @@ from superqt import QToggleSwitch
 
 from ._utils import (
     CheckableComboBox,
+    CurrentPageStackedWidget,
     HistogramWidget,
     analysis_section_stylesheet,
     make_section,
@@ -145,7 +145,7 @@ class FretWidget(QWidget):
         form.addRow("Donor lifetime source:", donor_source_row)
 
         # Donor lifetime stacked input
-        self.donor_stack = QStackedWidget()
+        self.donor_stack = CurrentPageStackedWidget()
 
         # Page 0: Manual lifetime
         donor_manual_page = QWidget()
@@ -251,7 +251,7 @@ class FretWidget(QWidget):
         form.addRow("Background source:", bg_source_row)
 
         # Background stacked input
-        self.bg_stack = QStackedWidget()
+        self.bg_stack = CurrentPageStackedWidget()
 
         # Page 0: Manual G,S
         bg_manual_page = QWidget()

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -340,7 +340,7 @@ class PhasorMappingWidget(QWidget):
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         # Create content widget for scroll area
         content_widget = QWidget()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1996,7 +1996,8 @@ class PlotterWidget(QWidget):
 
         import_buttons_layout.addStretch(1)
         import_box_layout.addLayout(import_buttons_layout)
-        self.settings_tab.layout().addWidget(import_box)
+
+        self._import_settings_box = import_box
 
         # Build the plotter inputs widget (formerly loaded from a .ui file)
         self.plotter_inputs_widget = self._build_plotter_inputs_widget()
@@ -4630,10 +4631,11 @@ class PlotterWidget(QWidget):
         and rearranged at runtime by :meth:`_reflow_plot_settings_rows`. Here
         we split them into three titled :class:`QGroupBox` sections — "Plot
         type & background", "Appearance" and "Phasor centers" — to match the
-        other analysis tabs. The Appearance grid becomes the reflow target
-        (``_plotter_settings_layout``); its reflowable rows keep their original
-        row indices (3-10) so the reflow logic is unchanged. The empty leading
-        rows collapse to zero height.
+        other analysis tabs, and place them below the "Load and apply
+        settings" section so all sections scroll together. The Appearance
+        grid becomes the reflow target (``_plotter_settings_layout``); its
+        reflowable rows keep their original row indices (3-10) so the reflow
+        logic is unchanged. The empty leading rows collapse to zero height.
         """
         piw = self.plotter_inputs_widget
         contents = piw.findChild(QWidget, "scrollAreaWidgetContents")
@@ -4691,6 +4693,7 @@ class PlotterWidget(QWidget):
         QWidget().setLayout(old_grid)
         sections_layout = QVBoxLayout(contents)
         sections_layout.setContentsMargins(0, 0, 0, 0)
+        sections_layout.addWidget(self._import_settings_box)
         sections_layout.addWidget(type_box)
         sections_layout.addWidget(appearance_box)
         sections_layout.addWidget(pc_box)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -6025,6 +6025,15 @@ class PlotterWidget(QWidget):
             self._harmonics_array = None
             for artist in self.canvas_widget.artists.values():
                 artist._remove_artists()
+                # ``_remove_artists`` empties ``_mpl_artists`` but leaves
+                # ``_color_indices`` populated. biaplotter's ``_colorize``
+                # (invoked when the active artist is later switched) then
+                # indexes into the now-empty ``_mpl_artists`` and raises
+                # ``KeyError``. Clear the stale indices to restore the
+                # invariant that an artist with no mpl artists has none.
+                artist._color_indices = None
+            self._last_histogram_color_indices = None
+            self._last_scatter_color_indices = None
             self._remove_colorbar()
             self._clear_all_tab_artists()
             self.set_axes_labels()
@@ -8460,5 +8469,25 @@ class PlotterWidget(QWidget):
 
         # Undo the viewer-wide bottom-corner reassignment made when docking.
         self._restore_bottom_corners()
+
+        # Remove the dock widgets this widget added to the napari window.
+        # They wrap our (now closing) child containers; if left registered,
+        # napari's own window teardown later tries to delete a dock whose
+        # inner widget has already been reparented/deleted, which double-frees
+        # under PySide6 and segfaults the xdist worker at end-of-file teardown.
+        window = getattr(self.viewer, 'window', None)
+        if window is not None:
+            for dock_attr in (
+                '_analysis_dock',
+                '_histogram_dock',
+                '_statistics_dock',
+            ):
+                dock = getattr(self, dock_attr, None)
+                if dock is not None:
+                    with contextlib.suppress(
+                        Exception  # noqa: BLE001 - teardown best-effort
+                    ):
+                        window.remove_dock_widget(dock)
+                    setattr(self, dock_attr, None)
 
         super().closeEvent(event)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -7253,15 +7253,30 @@ class PlotterWidget(QWidget):
 
             toolbar.release_pan = _release_pan_patched
 
-        if _original_home is not None:
+        def _reset_user_limits_to_home(*args, **kwargs):
+            # Clear user-defined limits so _redefine_axes_limits recomputes
+            # the correct default for the current mode (semi-circle vs full
+            # circle). This must persist so later replots (e.g. colormap
+            # changes) don't restore the stale zoom stored in
+            # _user_axes_limits.
+            plotter._user_axes_limits = None
+            # Re-apply the correct default limits for the current mode.
+            plotter._redefine_axes_limits()
+
+        # Matplotlib's Qt toolbar wires the Home button to the *bound*
+        # ``home`` method captured at toolbar construction time, so simply
+        # reassigning ``toolbar.home`` here would never run. Connect an extra
+        # slot to the Home QAction's ``triggered`` signal instead; Qt fires
+        # slots in connection order, so the original ``home`` (which resets
+        # the view) runs first, then our handler clears the stored zoom.
+        home_action = getattr(toolbar, '_actions', {}).get('home')
+        if home_action is not None:
+            home_action.triggered.connect(_reset_user_limits_to_home)
+        elif _original_home is not None:
 
             def _home_patched(*args, **kwargs):
-                # Clear user-defined limits so _redefine_axes_limits recomputes
-                # the correct default for the current mode (semi-circle vs full circle)
-                plotter._user_axes_limits = None
                 _original_home(*args, **kwargs)
-                # Re-apply the correct default limits for the current mode
-                plotter._redefine_axes_limits()
+                _reset_user_limits_to_home()
 
             toolbar.home = _home_patched
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1985,6 +1985,7 @@ class PlotterWidget(QWidget):
         import_buttons_layout.setSpacing(5)
 
         import_label = QLabel("Load and Apply Settings from:")
+        import_label.setWordWrap(True)
         import_buttons_layout.addWidget(import_label)
 
         self.import_from_layer_button = QPushButton("Layer")
@@ -3335,7 +3336,6 @@ class PlotterWidget(QWidget):
         layout.addWidget(QLabel("Select layer to import settings from:"))
 
         layer_combo = QComboBox()
-        selected_layer_names = set(self.get_selected_layer_names())
         available_layers = [
             layer.name
             for layer in self.viewer.layers
@@ -3344,7 +3344,6 @@ class PlotterWidget(QWidget):
                 key in layer.metadata
                 for key in ["G", "S", "G_original", "S_original"]
             )
-            and layer.name not in selected_layer_names
         ]
         layer_combo.addItems(available_layers)
         layout.addWidget(layer_combo)
@@ -4535,14 +4534,16 @@ class PlotterWidget(QWidget):
         outer = QGridLayout(widget)
 
         scroll_area = QScrollArea()
-        scroll_area.setMinimumHeight(200)
+        scroll_area.setMinimumHeight(120)
         scroll_area.setWidgetResizable(True)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
         contents = QWidget()
         contents.setObjectName("scrollAreaWidgetContents")
         grid = QGridLayout(contents)
 
         widget.label_5 = QLabel("Full Polar Plot (Spectral Phasor)")
+        widget.label_5.setWordWrap(True)
         widget.semi_circle_checkbox = QToggleSwitch()
 
         widget.label_6 = QLabel("White Background:")
@@ -4551,6 +4552,10 @@ class PlotterWidget(QWidget):
 
         widget.label_2 = QLabel("Plot Type:")
         widget.plot_type_combobox = QComboBox()
+        widget.plot_type_combobox.setMinimumContentsLength(10)
+        widget.plot_type_combobox.setSizeAdjustPolicy(
+            QComboBox.AdjustToMinimumContentsLengthWithIcon
+        )
 
         widget.label_3 = QLabel("Colormap:")
         widget.colormap_combobox = QComboBox()

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -33,7 +33,6 @@ from qtpy.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSpinBox,
-    QStackedWidget,
     QStyle,
     QTableWidget,
     QVBoxLayout,
@@ -42,6 +41,7 @@ from qtpy.QtWidgets import (
 from superqt import QToggleSwitch
 
 from ._utils import (
+    CurrentPageStackedWidget,
     analysis_section_stylesheet,
     colormap_to_dict,
     make_section,
@@ -135,7 +135,7 @@ class SelectionWidget(QWidget):
         layout.addWidget(mode_box)
 
         # Stacked widget to switch between modes
-        self.stacked_widget = QStackedWidget()
+        self.stacked_widget = CurrentPageStackedWidget()
         layout.addWidget(self.stacked_widget)
 
         # === Manual Selection Mode Widget ===


### PR DESCRIPTION
## Summary

Several UI bug fixes and small quality-of-life improvements in the phasor analysis widgets:

- **Fix 3D stack file reordering**: dragging a file to reorder it in the "Reorder Files for 3D Stack" dialog would sometimes make it disappear from the list instead of moving.
- **Fix Analysis tab widgets not shrinking properly**: the Filter, FRET, Plot Settings, and Selection tabs had minimum widths/heights far larger than necessary, showing a horizontal scrollbar much sooner than Calibration/Phasor Mapping did. Root causes:
  - `QStackedWidget` reports a size hint based on the *widest/tallest page*, even hidden ones — a hidden "From layer(s)" page in FRET, and a hidden "Automatic Clustering" page in Selection, were both inflating their tab's minimum size while a much smaller page was actually visible.
  - A few long labels (`"Full Polar Plot (Spectral Phasor)"`, `"Load and Apply Settings from:"`) and a wide combobox item (`"Density Plot (2D Histogram)"`) didn't wrap/elide, setting a hard floor on their containing row.
  - The Filter tab's "Log Scale Histogram" toggle was packed onto the same row as the "Threshold Method" combobox, summing their widths instead of stacking.
- **Restore the horizontal scrollbar where it belongs**: Plot Settings, Components, and Phasor Mapping tabs had their horizontal scrollbar permanently disabled (`ScrollBarAlwaysOff`), which silently clipped content once a tab hit its true minimum width instead of letting the user scroll to it. Switched to `ScrollBarAsNeeded`.
- **Fix "Copy Settings from layer" excluding valid source layers**: the source-layer dropdown filtered out any layer currently checked in the phasor-plot's image-layer combobox, so a layer selected for visualization could never be used as a settings source — even if it was the only layer with the desired reference settings.
- **Merge histogram export buttons**: "Save Histogram as PNG" and "Save Histogram as CSV" are now a single "Save Histogram…" button that opens a small menu to pick the format.

## Changes

- `_utils.py`
  - Added `CurrentPageStackedWidget`, a `QStackedWidget` subclass that sizes itself to only the currently visible page instead of the widest/tallest page across all pages.
  - `FileOrderDialog`: removed `Qt.ItemIsDropEnabled` from list item flags — combined with `InternalMove` drag mode, that flag let Qt treat a drag as a drop *onto* another item rather than *between* rows, which could make the dragged item vanish.
  - `HistogramWidget`: merged `save_png_button`/`save_csv_button` into a single `save_button` that opens a `QMenu` ("Save as PNG" / "Save as CSV") via a new `_show_save_menu` method.
- `fret_tab.py`, `selection_tab.py`: use `CurrentPageStackedWidget` for the mode-switching stacks (donor/background source, selection mode).
- `filter_tab.py`: moved the "Log Scale Histogram" toggle to its own row instead of sharing a row with the Threshold Method combobox.
- `plotter.py`:
  - Word-wrap the "Full Polar Plot (Spectral Phasor)" and "Load and Apply Settings from:" labels.
  - `plot_type_combobox` now elides long item text via `setMinimumContentsLength`/`AdjustToMinimumContentsLengthWithIcon` instead of sizing to its widest item.
  - Plot Settings' inner scroll area: reduced hardcoded minimum height (200 → 120px) and restored `ScrollBarAsNeeded`.
  - `_import_settings_from_layer`: removed the filter that excluded layers checked in the image-layer combobox from the source-layer dropdown.
- `components_tab.py`, `phasor_mapping_tab.py`: restored `ScrollBarAsNeeded` on the tab's scroll area.
