### PR TITLE
Add reference fluorophore list to the Calibration tab

### DIFF
--- a/docs/guides/calibration.md
+++ b/docs/guides/calibration.md
@@ -11,13 +11,27 @@ Phasor coordinates computed from raw FLIM data are affected by the instrument re
 1. Load both your sample image and the reference image
 2. Open the **Phasor Plot** widget and go to the **Calibration** tab
 3. Select the reference layer from the dropdown
-4. Enter the known lifetime of the reference fluorophore (in nanoseconds)
-5. Enter the laser frequency used in the experiment (in MHz)
+4. Enter the laser frequency used in the experiment (in MHz)
+5. Enter the known lifetime of the reference fluorophore (in nanoseconds)
 6. Click **Calibrate**
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/calibration.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/calibration.mp4" type="video/mp4">
 </video>
+
+## Reference fluorophore shortcut
+
+If you are using a commonly used fluorophore, you can use the
+**Reference fluorophore** dropdown in the **Reference parameters** section
+and pick your fluorophore (each entry alsoshows the solution it is prepared
+in). The **Lifetime (ns)** field is filled in automatically with the known
+value. You can still type a custom lifetime by hand at any time; doing so
+clears the dropdown selection.
+
+The same lifetime values are available programmatically through the API via
+{func}`napari_phasors.reference_lifetimes`, which returns the fluorophore name,
+lifetime (ns) and solvent for each reference. The values are taken from
+[ISS — Lifetime Data of Selected Fluorophores](https://iss.com/resources#lifetime-data-of-selected-fluorophores).
 
 ## Notes
 

--- a/src/napari_phasors/__init__.py
+++ b/src/napari_phasors/__init__.py
@@ -10,7 +10,7 @@ from ._sample_data import (
     embryo_FLIM_sample_data,
     paramecium_HSI_sample_data,
 )
-from ._utils import register_extra_colormaps
+from ._utils import reference_lifetimes, register_extra_colormaps
 from ._widget import PhasorTransform, WriterWidget
 from ._writer import export_layer_as_csv, export_layer_as_image, write_ome_tiff
 from .plotter import PlotterWidget
@@ -29,4 +29,5 @@ __all__ = (
     "PlotterWidget",
     "WriterWidget",
     "BatchAnalysisWidget",
+    "reference_lifetimes",
 )

--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -785,3 +785,40 @@ def test_close_event_unhooking(make_viewer_model, qtbot):
     # The event is accepted and a second close is harmless (already unhooked).
     widget.closeEvent(event)
     assert True  # accept() may be handled by base class
+
+
+def test_fluorophore_combobox_populates_lifetime(make_viewer_model, qtbot):
+    """Selecting a reference fluorophore fills the lifetime edit."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    combobox = widget.calibration_widget.fluorophore_combobox
+    lifetime_edit = widget.calibration_widget.lifetime_line_edit_widget
+
+    # First item is the placeholder and carries no lifetime.
+    assert combobox.itemData(0) is None
+    assert combobox.count() > 1
+
+    # Select the first real fluorophore entry.
+    combobox.setCurrentIndex(1)
+    expected = combobox.itemData(1)
+    assert lifetime_edit.text() == f"{expected:g}"
+
+
+def test_fluorophore_reset_on_manual_lifetime_edit(make_viewer_model, qtbot):
+    """Editing the lifetime by hand resets the fluorophore selection."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    combobox = widget.calibration_widget.fluorophore_combobox
+    lifetime_edit = widget.calibration_widget.lifetime_line_edit_widget
+
+    combobox.setCurrentIndex(1)
+    assert combobox.currentIndex() == 1
+
+    # Simulate a user editing the field (textEdited fires only on user input).
+    lifetime_edit.setText("2.5")
+    widget._on_lifetime_edited("2.5")
+    assert combobox.currentIndex() == 0

--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -11,6 +11,7 @@ from phasorpy.lifetime import (
 from phasorpy.phasor import phasor_center
 
 from napari_phasors._tests.test_plotter import create_image_layer_with_phasors
+from napari_phasors.calibration_tab import _HTML_LABEL_ROLE
 from napari_phasors.plotter import PlotterWidget
 
 
@@ -822,3 +823,95 @@ def test_fluorophore_reset_on_manual_lifetime_edit(make_viewer_model, qtbot):
     lifetime_edit.setText("2.5")
     widget._on_lifetime_edited("2.5")
     assert combobox.currentIndex() == 0
+
+
+def test_fluorophore_placeholder_selection_noop(make_viewer_model, qtbot):
+    """Selecting the placeholder entry leaves the lifetime edit untouched."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    lifetime_edit = widget.calibration_widget.lifetime_line_edit_widget
+
+    # Put a value in the lifetime edit, then select the placeholder (index 0,
+    # itemData is None). The handler should hit its early return and not touch
+    # the lifetime edit.
+    lifetime_edit.setText("3.14")
+    widget._on_fluorophore_selected(0)
+    assert lifetime_edit.text() == "3.14"
+
+
+def test_lifetime_edit_from_combo_does_not_reset(make_viewer_model, qtbot):
+    """Programmatic lifetime edits (from the combo) must not reset the combo."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    combobox = widget.calibration_widget.fluorophore_combobox
+
+    combobox.setCurrentIndex(1)
+    assert combobox.currentIndex() == 1
+
+    # While the guard flag is set (as it is during _on_fluorophore_selected),
+    # _on_lifetime_edited must early-return and leave the selection alone.
+    widget._setting_lifetime_from_combo = True
+    widget._on_lifetime_edited("9.9")
+    assert combobox.currentIndex() == 1
+
+
+def test_rich_text_delegate_paint_with_html(make_viewer_model, qtbot):
+    """The delegate renders an item's HTML label without raising."""
+    from qtpy.QtGui import QPainter, QPixmap
+    from qtpy.QtWidgets import QStyle, QStyleOptionViewItem
+
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    combobox = widget.calibration_widget.fluorophore_combobox
+    delegate = combobox.itemDelegate()
+    model = combobox.model()
+
+    pixmap = QPixmap(200, 20)
+    painter = QPainter(pixmap)
+    try:
+        option = QStyleOptionViewItem()
+        option.rect = pixmap.rect()
+
+        # Item 1 carries an HTML label -> the rich-text rendering branch.
+        html_index = model.index(1, 0)
+        assert html_index.data(_HTML_LABEL_ROLE) is not None
+        delegate.paint(painter, option, html_index)
+
+        # Same item painted while selected exercises the highlighted-text color.
+        option.state |= QStyle.State_Selected
+        delegate.paint(painter, option, html_index)
+    finally:
+        painter.end()
+
+
+def test_rich_text_delegate_paint_without_html(make_viewer_model, qtbot):
+    """Items without an HTML label fall back to the default painting path."""
+    from qtpy.QtGui import QPainter, QPixmap
+    from qtpy.QtWidgets import QStyleOptionViewItem
+
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.calibration_tab
+
+    combobox = widget.calibration_widget.fluorophore_combobox
+    delegate = combobox.itemDelegate()
+    model = combobox.model()
+
+    pixmap = QPixmap(200, 20)
+    painter = QPainter(pixmap)
+    try:
+        option = QStyleOptionViewItem()
+        option.rect = pixmap.rect()
+
+        # Item 0 is the placeholder and carries no HTML label -> super().paint.
+        plain_index = model.index(0, 0)
+        assert plain_index.data(_HTML_LABEL_ROLE) is None
+        delegate.paint(painter, option, plain_index)
+    finally:
+        painter.end()

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -4212,6 +4212,99 @@ def read_ome_tiff_settings(file_path):
     return settings
 
 
+#: Citation for the reference fluorophore lifetimes returned by
+#: :func:`reference_lifetimes`.
+REFERENCE_LIFETIMES_SOURCE = (
+    "ISS, Inc. — Lifetime Data of Selected Fluorophores. "
+    "https://iss.com/resources#lifetime-data-of-selected-fluorophores"
+)
+
+#: Known fluorescence lifetimes of common calibration reference fluorophores,
+#: as ``(name, lifetime_ns, solvent)`` tuples. Only fluorophores with a
+#: well-defined single lifetime value are included. Values are taken from
+#: :data:`REFERENCE_LIFETIMES_SOURCE`.
+_REFERENCE_LIFETIMES = (
+    ("ATTO 565", 3.4, "Water"),
+    ("ATTO 655", 3.6, "Water"),
+    ("Acridine Orange", 2.0, "PB pH 7.8"),
+    ("Alexa Fluor 488", 4.1, "PB pH 7.4"),
+    ("Alexa Fluor 546", 4.0, "PB pH 7.4"),
+    ("Alexa Fluor 633", 3.2, "Water"),
+    ("Alexa Fluor 647", 1.0, "Water"),
+    ("Alexa Fluor 680", 1.2, "PB pH 7.5"),
+    ("BODIPY FL", 5.7, "Methanol"),
+    ("BODIPY TR-X", 5.4, "Methanol"),
+    ("Coumarin 6", 2.5, "Ethanol"),
+    ("CY3", 0.3, "PBS"),
+    ("CY3.5", 0.5, "PBS"),
+    ("CY3B", 2.8, "PBS"),
+    ("CY5", 1.0, "PBS"),
+    ("CY5.5", 1.0, "PBS"),
+    ("DAPI", 0.16, "TRIS/EDTA"),
+    ("DAPI + ssDNA", 1.88, "TRIS/EDTA"),
+    ("DAPI + dsDNA", 2.20, "TRIS/EDTA"),
+    ("Ethidium Bromide - no DNA", 1.6, "TRIS/EDTA"),
+    ("Ethidium Bromide + ssDNA", 25.1, "TRIS/EDTA"),
+    ("Ethidium Bromide + dsDNA", 28.3, "TRIS/EDTA"),
+    ("FITC", 4.1, "PB pH 7.8"),
+    ("Fluorescein", 4.0, "PB pH 7.5"),
+    ("GFP", 3.2, "Buffer pH 8"),
+    ("HPTS", 5.4, "PB pH 7.8"),
+    ("Hoechst 33258 - no DNA", 0.2, "TRIS/EDTA"),
+    ("Hoechst 33258 + ssDNA", 1.22, "TRIS/EDTA"),
+    ("Hoechst 33258 + dsDNA", 1.94, "TRIS/EDTA"),
+    ("Hoechst 33342 - no DNA", 0.35, "TRIS/EDTA"),
+    ("Hoechst 33342 + ssDNA", 1.05, "TRIS/EDTA"),
+    ("Hoechst 33342 + dsDNA", 2.21, "TRIS/EDTA"),
+    ("Indocyanine Green", 0.52, "Water"),
+    ("Lucifer Yellow", 5.7, "Water"),
+    ("Oregon Green 488", 4.1, "Buffer pH 9"),
+    ("Oregon Green 500", 2.18, "Buffer pH 2"),
+    ("Prodan", 1.41, "Water"),
+    ("Rhodamine 101", 4.32, "Water"),
+    ("Rhodamine 110", 4.0, "Water"),
+    ("Rhodamine 6G", 4.08, "Water"),
+    ("Rhodamine B", 1.68, "Water"),
+    ("Ru(bpy)2(dcpby)[PF6]2", 375.0, "Buffer pH 7"),
+    ("Ru(bpy)3[PF6]2", 600.0, "Water"),
+    ("SeTau-380-NHS", 32.5, "Water"),
+    ("SeTau-404-NHS", 9.3, "Water"),
+    ("SeTau-405-NHS", 9.3, "Water"),
+    ("SeTau-425-NHS", 26.2, "Water"),
+    ("Texas Red", 4.2, "Water"),
+    ("TOTO-1", 2.2, "Water"),
+    ("YOYO-1 no DNA", 2.1, "TRIS/EDTA"),
+    ("YOYO-1 + ssDNA", 1.67, "TRIS/EDTA"),
+    ("YOYO-1 + dsDNA", 2.3, "TRIS/EDTA"),
+)
+
+
+def reference_lifetimes():
+    """Return known lifetimes of common calibration reference fluorophores.
+
+    These values can be used as the ``reference_lifetime`` when calibrating a
+    FLIM measurement against a homogeneous solution of a fluorophore with a
+    known fluorescence lifetime. Only fluorophores with a well-defined single
+    lifetime value are included.
+
+    Data source
+    -----------
+    ISS, Inc. "Lifetime Data of Selected Fluorophores."
+    https://iss.com/resources#lifetime-data-of-selected-fluorophores
+
+    Returns
+    -------
+    list of dict
+        One entry per fluorophore, sorted alphabetically by name, each with
+        keys ``name`` (str), ``lifetime`` (float, ns) and ``solvent`` (str,
+        the solution the reference is prepared in).
+    """
+    return [
+        {"name": name, "lifetime": lifetime, "solvent": solvent}
+        for name, lifetime, solvent in _REFERENCE_LIFETIMES
+    ]
+
+
 def compute_calibration_parameters(
     calibration_layer, frequency, reference_lifetime
 ):

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -1,4 +1,5 @@
 import contextlib
+from html import escape
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -6,7 +7,10 @@ from napari.layers import Image
 from napari.utils.notifications import show_error
 from phasorpy.lifetime import phasor_from_lifetime, polar_from_reference_phasor
 from phasorpy.phasor import phasor_center, phasor_transform
+from qtpy.QtCore import QRectF, QSize, Qt
+from qtpy.QtGui import QAbstractTextDocumentLayout, QPalette, QTextDocument
 from qtpy.QtWidgets import (
+    QApplication,
     QComboBox,
     QGridLayout,
     QLabel,
@@ -14,19 +18,92 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
+    QStyle,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
     QVBoxLayout,
     QWidget,
 )
 
 from ._utils import (
+    REFERENCE_LIFETIMES_SOURCE,
     analysis_section_stylesheet,
     apply_filter_and_threshold,
     make_section,
+    reference_lifetimes,
     setup_primary_button,
 )
 
 if TYPE_CHECKING:
     import napari
+
+#: Qt.ItemDataRole slot used to stash the HTML label rendered by
+#: ``_RichTextItemDelegate``, kept separate from the plain-text
+#: ``Qt.DisplayRole`` so ``currentText``/``itemText`` stay unaffected.
+_HTML_LABEL_ROLE = Qt.UserRole + 1
+
+
+class _RichTextItemDelegate(QStyledItemDelegate):
+    """Item delegate that renders an item's HTML label, if any, in a popup.
+
+    Only affects the dropdown popup list; the combobox's own closed-state
+    display always shows the plain-text ``Qt.DisplayRole``.
+    """
+
+    def paint(self, painter, option, index):
+        html = index.data(_HTML_LABEL_ROLE)
+        if html is None:
+            super().paint(painter, option, index)
+            return
+
+        options = QStyleOptionViewItem(option)
+        self.initStyleOption(options, index)
+        style = (
+            options.widget.style() if options.widget else QApplication.style()
+        )
+
+        doc = QTextDocument()
+        doc.setHtml(html)
+
+        options.text = ""
+        style.drawControl(
+            QStyle.CE_ItemViewItem, options, painter, options.widget
+        )
+
+        painter.save()
+        text_rect = style.subElementRect(
+            QStyle.SE_ItemViewItemText, options, options.widget
+        )
+        painter.translate(text_rect.topLeft())
+        doc.setTextWidth(text_rect.width())
+
+        # QTextDocument defaults to black text, ignoring the item's palette
+        # (e.g. white text in napari's dark theme). Drawing through the
+        # document layout with an explicit paint context, rather than
+        # doc.drawContents(), lets the correct themed color come through.
+        ctx = QAbstractTextDocumentLayout.PaintContext()
+        text_color = options.palette.color(
+            QPalette.HighlightedText
+            if options.state & QStyle.State_Selected
+            else QPalette.Text
+        )
+        ctx.palette.setColor(QPalette.Text, text_color)
+        ctx.clip = QRectF(0, 0, text_rect.width(), text_rect.height())
+        doc.documentLayout().draw(painter, ctx)
+        painter.restore()
+
+    def sizeHint(self, option, index):
+        html = index.data(_HTML_LABEL_ROLE)
+        if html is None:
+            return super().sizeHint(option, index)
+
+        options = QStyleOptionViewItem(option)
+        self.initStyleOption(options, index)
+        doc = QTextDocument()
+        doc.setHtml(html)
+        doc.setTextWidth(max(options.rect.width(), 1))
+        return QSize(int(doc.idealWidth()), int(doc.size().height()))
 
 
 class CalibrationWidget(QWidget):
@@ -57,6 +134,16 @@ class CalibrationWidget(QWidget):
         )
         self.calibration_widget.lifetime_line_edit_widget.textChanged.connect(
             lambda _=None: self._refresh_calibrate_button()
+        )
+
+        # Fill the lifetime edit when a reference fluorophore is picked, and
+        # clear the selection back to the placeholder if the user then edits
+        # the lifetime by hand (so the shown fluorophore never contradicts it).
+        self.calibration_widget.fluorophore_combobox.currentIndexChanged.connect(
+            self._on_fluorophore_selected
+        )
+        self.calibration_widget.lifetime_line_edit_widget.textEdited.connect(
+            self._on_lifetime_edited
         )
         self.calibration_widget.calibration_layer_combobox.currentTextChanged.connect(
             lambda _=None: self._refresh_calibrate_button()
@@ -115,19 +202,82 @@ class CalibrationWidget(QWidget):
         parameters_layout.addLayout(parameters_grid)
         widget.frequency_label_widget = QLabel("Frequency (MHz):")
         widget.frequency_input = QLineEdit()
+        widget.fluorophore_label_widget = QLabel("Reference fluorophore:")
+        widget.fluorophore_combobox = QComboBox()
         widget.lifetime_label_widget = QLabel("Lifetime (ns):")
         widget.lifetime_line_edit_widget = QLineEdit()
         parameters_grid.addWidget(widget.frequency_label_widget, 0, 0)
         parameters_grid.addWidget(widget.frequency_input, 0, 1)
-        parameters_grid.addWidget(widget.lifetime_label_widget, 1, 0)
-        parameters_grid.addWidget(widget.lifetime_line_edit_widget, 1, 1)
+        parameters_grid.addWidget(widget.fluorophore_label_widget, 1, 0)
+        parameters_grid.addWidget(widget.fluorophore_combobox, 1, 1)
+        parameters_grid.addWidget(widget.lifetime_label_widget, 2, 0)
+        parameters_grid.addWidget(widget.lifetime_line_edit_widget, 2, 1)
         layout.addWidget(parameters_box)
+
+        self._populate_fluorophore_combobox(widget.fluorophore_combobox)
 
         widget.calibrate_push_button = QPushButton("Calibrate")
         layout.addWidget(widget.calibrate_push_button)
 
         layout.addStretch(1)
         return widget
+
+    def _populate_fluorophore_combobox(self, combobox):
+        """Fill the reference-fluorophore combobox from the known lifetimes.
+
+        The first entry is a placeholder; each fluorophore entry stores its
+        lifetime (ns) as item data so selecting it can fill the lifetime edit.
+        """
+        combobox.setItemDelegate(_RichTextItemDelegate(combobox))
+
+        combobox.addItem("Select fluorophore (optional)", None)
+        for entry in reference_lifetimes():
+            name = escape(entry['name'])
+            rest = f"({escape(entry['solvent'])}): {entry['lifetime']:g} ns"
+            combobox.addItem(f"{entry['name']} {rest}", entry["lifetime"])
+            combobox.setItemData(
+                combobox.count() - 1,
+                f"<b>{name}</b> {rest}",
+                _HTML_LABEL_ROLE,
+            )
+        # Long fluorophore labels shouldn't force the combobox (and thus the
+        # whole tab) to widen; let it size to a modest content length and
+        # shrink/grow with the layout instead. The full label is still shown
+        # via the tooltip-less native elided text and the dropdown popup.
+        combobox.setMinimumContentsLength(8)
+        combobox.setSizeAdjustPolicy(
+            QComboBox.AdjustToMinimumContentsLengthWithIcon
+        )
+        combobox.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        combobox.setToolTip(
+            "Pick a reference fluorophore to fill in its known lifetime.\n"
+            f"Source: {REFERENCE_LIFETIMES_SOURCE}"
+        )
+
+    def _on_fluorophore_selected(self, index):
+        """Populate the lifetime edit with the selected fluorophore lifetime."""
+        lifetime = self.calibration_widget.fluorophore_combobox.itemData(index)
+        if lifetime is None:
+            return
+        lifetime_edit = self.calibration_widget.lifetime_line_edit_widget
+        # Setting the text programmatically must not reset the combobox, so
+        # guard against the ``_on_lifetime_edited`` handler (it only reacts to
+        # user edits, but stay explicit).
+        self._setting_lifetime_from_combo = True
+        try:
+            lifetime_edit.setText(f"{lifetime:g}")
+        finally:
+            self._setting_lifetime_from_combo = False
+
+    def _on_lifetime_edited(self, _text=None):
+        """Reset the fluorophore selection when the lifetime is edited by hand."""
+        if getattr(self, '_setting_lifetime_from_combo', False):
+            return
+        combobox = self.calibration_widget.fluorophore_combobox
+        if combobox.currentIndex() != 0:
+            combobox.blockSignals(True)
+            combobox.setCurrentIndex(0)
+            combobox.blockSignals(False)
 
     def _populate_comboboxes(self, event=None):
         """Populate calibration layer combobox with image layers."""


### PR DESCRIPTION
## Description

This PR introduces a reference fluorophore selection dropdown to the **Calibration** tab. Users can now pick a common calibration fluorophore from a pre-populated list to automatically fill in its known lifetime value, streamlining the calibration workflow.

### Key Changes

* **Reference Lifetimes Database & API (`src/napari_phasors/_utils.py`, `__init__.py`)**
  * Added `reference_lifetimes()` to expose known single-lifetime fluorophores (with `name`, `lifetime` in ns, and `solvent`) sourced from [ISS — Lifetime Data of Selected Fluorophores](https://iss.com/resources#lifetime-data-of-selected-fluorophores).
  * Exported `reference_lifetimes` in the public package interface.

* **Calibration UI Enhancements (`src/napari_phasors/calibration_tab.py`)**
  * Added a **Reference fluorophore** combobox in the Reference Parameters grid.
  * Implemented `_RichTextItemDelegate` to render bold fluorophore names and solvent/lifetime details inside the dropdown popup list while respecting active palette themes (e.g., napari dark mode).
  * Tied combobox selection directly to the **Lifetime (ns)** line edit widget.
  * Implemented auto-reset behavior: editing the lifetime field manually reverts the fluorophore dropdown back to the default placeholder.
  * Set size policy and minimum content length on the combobox to prevent long fluorophore names from stretching the widget width.

* **Documentation (`docs/guides/calibration.md`)**
  * Updated calibration guide steps and added a dedicated **Reference fluorophore shortcut** section explaining the dropdown and API usage.

* **Test Coverage (`src/napari_phasors/_tests/test_calibration_tab.py`)**
  * Added `test_fluorophore_combobox_populates_lifetime` to verify field population on selection.
  * Added `test_fluorophore_reset_on_manual_lifetime_edit` to ensure manual edits clear the dropdown selection.