### PR TITLE
Enhance post-install script to activate conda environment for linux installer

### DIFF
--- a/installer/post_install.sh
+++ b/installer/post_install.sh
@@ -2,12 +2,17 @@
 # Post-install script: install napari-phasors and create launchers
 "${PREFIX}/bin/pip" install napari-phasors
 
-# Create a launcher script
+# Create a launcher script. Activate the conda environment before starting
+# napari so Qt can find its platform plugins and libraries. Without
+# activation, the environment's activate.d scripts (which set QT_PLUGIN_PATH,
+# FONTCONFIG_PATH, GSETTINGS_SCHEMA_DIR, LD_LIBRARY_PATH, ...) never run and
+# napari aborts on launch with "could not load the Qt platform plugin 'xcb'".
 cat > "${PREFIX}/napari-phasors" << 'LAUNCHER'
 #!/bin/bash
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export PATH="${DIR}/bin:${DIR}/lib:${PATH}"
-exec "${DIR}/bin/napari" "$@"
+# shellcheck disable=SC1091
+source "${DIR}/bin/activate" "${DIR}"
+exec "${DIR}/bin/python" -m napari "$@"
 LAUNCHER
 chmod +x "${PREFIX}/napari-phasors"
 


### PR DESCRIPTION
## Fix Linux installer failing to launch napari

### Problem
The Linux standalone installer installed correctly, but clicking the desktop/app icon didn't open the napari viewer — nothing happened.

### Root cause
The Linux launcher created by `installer/post_install.sh` never activated the conda environment. It only set `PATH` and ran `bin/napari` directly:

```bash
export PATH="${DIR}/bin:${DIR}/lib:${PATH}"
exec "${DIR}/bin/napari" "$@"
```

napari is a Qt app, and conda's Qt relies on the environment's `activate.d` scripts to set `QT_PLUGIN_PATH`, `FONTCONFIG_PATH`, `GSETTINGS_SCHEMA_DIR`, `LD_LIBRARY_PATH`, etc. Without activation, Qt can't find its `xcb` platform plugin and napari aborts on startup. Because the `.desktop` file uses `Terminal=false`, the error was invisible — so it looked like clicking did nothing.

### Fix
Rewrote the Linux launcher to activate the conda environment before starting napari, mirroring what the macOS `.app` launcher already does:

```bash
source "${DIR}/bin/activate" "${DIR}"
exec "${DIR}/bin/python" -m napari "$@"
```

### macOS & Windows unaffected
- **macOS**: the DMG uses its own `.app` launcher (defined in `build-installer.yml`), which already activates the env. The `${PREFIX}/napari-phasors` script is unused on macOS.
- **Windows**: driven entirely by `post_install.bat`, which is untouched.

The change is scoped to the Linux launcher body in `post_install.sh`, so only the Linux GUI launch behavior changes.