### PR TITLE
Refactor CursorSelectionWidget and SelectionWidget for improved layout and visibility

### DIFF
--- a/src/napari_phasors/_tests/test_selection_tab.py
+++ b/src/napari_phasors/_tests/test_selection_tab.py
@@ -386,7 +386,7 @@ def test_cursor_add_polar_defaults(make_viewer_model, qtbot):
 
 
 def test_cursor_type_change_field_visibility(make_viewer_model, qtbot):
-    """Changing the row shape combobox shows/hides the matching fields."""
+    """Changing the shape combobox shows/hides the matching editor fields."""
     viewer = make_viewer_model()
     intensity_image_layer = create_image_layer_with_phasors()
     viewer.add_layer(intensity_image_layer)
@@ -399,23 +399,23 @@ def test_cursor_type_change_field_visibility(make_viewer_model, qtbot):
     assert isinstance(combo, QComboBox)
 
     # Circular: center fields shown, others hidden.
-    assert cursor['center_widget'].isVisibleTo(cursor['row'])
-    assert not cursor['elliptic_widget'].isVisibleTo(cursor['row'])
-    assert not cursor['polar_widget'].isVisibleTo(cursor['row'])
+    assert cursor['center_widget'].isVisibleTo(cursor['detail'])
+    assert not cursor['elliptic_widget'].isVisibleTo(cursor['detail'])
+    assert not cursor['polar_widget'].isVisibleTo(cursor['detail'])
 
     # Switch to elliptical.
     combo.setCurrentIndex(combo.findData("elliptic"))
     assert cursor['type'] == 'elliptic'
-    assert cursor['center_widget'].isVisibleTo(cursor['row'])
-    assert cursor['elliptic_widget'].isVisibleTo(cursor['row'])
-    assert not cursor['polar_widget'].isVisibleTo(cursor['row'])
+    assert cursor['center_widget'].isVisibleTo(cursor['detail'])
+    assert cursor['elliptic_widget'].isVisibleTo(cursor['detail'])
+    assert not cursor['polar_widget'].isVisibleTo(cursor['detail'])
 
     # Switch to polar.
     combo.setCurrentIndex(combo.findData("polar"))
     assert cursor['type'] == 'polar'
-    assert not cursor['center_widget'].isVisibleTo(cursor['row'])
-    assert not cursor['elliptic_widget'].isVisibleTo(cursor['row'])
-    assert cursor['polar_widget'].isVisibleTo(cursor['row'])
+    assert not cursor['center_widget'].isVisibleTo(cursor['detail'])
+    assert not cursor['elliptic_widget'].isVisibleTo(cursor['detail'])
+    assert cursor['polar_widget'].isVisibleTo(cursor['detail'])
 
 
 def test_cursor_remove(make_viewer_model, qtbot):

--- a/src/napari_phasors/_tests/test_selection_tab.py
+++ b/src/napari_phasors/_tests/test_selection_tab.py
@@ -418,6 +418,96 @@ def test_cursor_type_change_field_visibility(make_viewer_model, qtbot):
     assert cursor['polar_widget'].isVisibleTo(cursor['detail'])
 
 
+def test_cursor_selection_follows_add_and_row_click(make_viewer_model, qtbot):
+    """Adding a cursor selects it; left-clicking a row selects that cursor."""
+    viewer = make_viewer_model()
+    viewer.add_layer(create_image_layer_with_phasors())
+    parent = PlotterWidget(viewer)
+    widget = parent.selection_tab.cursor_selection_widget
+
+    # No cursors yet: the editor is hidden.
+    assert widget._selected_cursor is None
+    assert not widget._editor_box.isVisible()
+
+    # Adding a cursor selects it and shows its editor page.
+    widget._add_cursor()
+    first = widget._cursors[0]
+    assert widget._selected_cursor is first
+    assert widget._details_stack.currentWidget() is first['detail']
+    assert first['row'].property("selected")
+
+    # Adding a second cursor moves the selection to the new cursor.
+    widget._add_cursor()
+    second = widget._cursors[1]
+    assert widget._selected_cursor is second
+    assert not first['row'].property("selected")
+    assert second['row'].property("selected")
+
+    # Left-clicking the first cursor's row selects it again (exercises
+    # ClickableFrame.mousePressEvent -> clicked -> _select_cursor).
+    qtbot.mouseClick(first['row'], Qt.LeftButton)
+    assert widget._selected_cursor is first
+    assert first['row'].property("selected")
+    assert widget._details_stack.currentWidget() is first['detail']
+    # The editor title reflects the selected cursor's number and shape.
+    assert "Circular" in widget._editor_box.title()
+
+
+def test_select_cursor_ignores_foreign_cursor(make_viewer_model, qtbot):
+    """``_select_cursor`` ignores a cursor dict that is not in the list."""
+    viewer = make_viewer_model()
+    viewer.add_layer(create_image_layer_with_phasors())
+    parent = PlotterWidget(viewer)
+    widget = parent.selection_tab.cursor_selection_widget
+
+    widget._add_cursor()
+    selected = widget._selected_cursor
+    assert selected is not None
+
+    # Passing a dict that is not one of the widget's cursors is a no-op.
+    widget._select_cursor({'not': 'a real cursor'})
+    assert widget._selected_cursor is selected
+
+
+def test_refresh_editor_title_without_selection(make_viewer_model, qtbot):
+    """``_refresh_editor_title`` is a no-op when nothing is selected."""
+    viewer = make_viewer_model()
+    viewer.add_layer(create_image_layer_with_phasors())
+    parent = PlotterWidget(viewer)
+    widget = parent.selection_tab.cursor_selection_widget
+
+    # No cursors -> no selection: must not raise.
+    assert widget._selected_cursor is None
+    widget._refresh_editor_title()
+
+
+def test_editor_title_updates_with_shape(make_viewer_model, qtbot):
+    """The editor title tracks the selected cursor's shape."""
+    viewer = make_viewer_model()
+    viewer.add_layer(create_image_layer_with_phasors())
+    parent = PlotterWidget(viewer)
+    widget = parent.selection_tab.cursor_selection_widget
+
+    widget._add_cursor()
+    cursor = widget._cursors[0]
+    assert "Circular" in widget._editor_box.title()
+
+    combo = cursor['type_combo']
+    combo.setCurrentIndex(combo.findData("polar"))
+    assert "Polar" in widget._editor_box.title()
+
+
+def test_make_spinbox_default_width_ref(make_viewer_model, qtbot):
+    """``_make_spinbox`` sizes itself from its own range when no ref given."""
+    from napari_phasors.selection_tab import CursorSelectionWidget
+
+    spin = CursorSelectionWidget._make_spinbox(-1.5, 1.5, 0.5, 2, 0.01)
+    assert isinstance(spin, QDoubleSpinBox)
+    assert spin.value() == 0.5
+    # A width was derived and applied as a hard minimum (default ref path).
+    assert spin.minimumWidth() >= 70
+
+
 def test_cursor_remove(make_viewer_model, qtbot):
     """Test removing cursors by index."""
     viewer = make_viewer_model()

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -116,7 +116,25 @@ class SelectionWidget(QWidget):
 
         # Main layout
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
         self.setStyleSheet(analysis_section_stylesheet())
+
+        # Everything (mode selector + whichever mode's controls are active)
+        # lives inside a scroll area, so a tall cursor list scrolls together
+        # with the mode selector instead of growing this tab's minimum size
+        # (which would squeeze the other tabs and docks). A horizontal
+        # scrollbar appears if the dock is narrower than the content needs,
+        # instead of clipping fields.
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameShape(QFrame.NoFrame)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        layout.addWidget(scroll_area)
+
+        content = QWidget()
+        scroll_area.setWidget(content)
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
 
         # Selection mode combobox at the top
         mode_box, mode_box_layout = make_section("Selection mode")
@@ -132,11 +150,11 @@ class SelectionWidget(QWidget):
         )
         mode_layout.addWidget(self.selection_mode_combobox, 1)
         mode_box_layout.addLayout(mode_layout)
-        layout.addWidget(mode_box)
+        content_layout.addWidget(mode_box)
 
         # Stacked widget to switch between modes
         self.stacked_widget = CurrentPageStackedWidget()
-        layout.addWidget(self.stacked_widget)
+        content_layout.addWidget(self.stacked_widget)
 
         # === Manual Selection Mode Widget ===
         self.manual_selection_widget = QWidget()
@@ -1852,9 +1870,15 @@ class CursorSelectionWidget(QWidget):
     # ------------------------------------------------------------------ UI
     def _setup_ui(self):
         """Set up the user interface."""
+        self.setStyleSheet(analysis_section_stylesheet())
+
+        # This widget's content is scrolled by the ``QScrollArea`` that
+        # ``SelectionWidget`` wraps around the mode selector and the whole
+        # stacked mode widget, so a long list of cursors scrolls together
+        # with the mode selector instead of growing this widget's minimum
+        # height (which would squeeze the other tabs and docks).
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 5, 0, 0)
-        self.setStyleSheet(analysis_section_stylesheet())
 
         # Cursors section ----------------------------------------------------
         cursors_box, cursors_box_layout = make_section("Cursors")
@@ -1948,14 +1972,47 @@ class CursorSelectionWidget(QWidget):
             return (xlim[0] + xlim[1]) / 2.0, (ylim[0] + ylim[1]) / 2.0
         return 0.5, 0.5
 
-    @staticmethod
-    def _make_spinbox(low, high, value, decimals, step):
+    # napari's QSS (00_base.qss) pads QAbstractSpinBox by 10px on each side
+    # and draws a 20px-wide up-button and down-button on the right/left
+    # edges (unlike plain Qt, where both arrows stack in one ~16px column on
+    # the right only) — wider chrome than a generic Qt spinbox needs. This is
+    # fed into an inline "min-width" rule (see ``_make_spinbox``); Qt's CSS
+    # box model then adds the 20px of left+right padding *again* on top of
+    # that value, so this constant is deliberately smaller than the ~60px of
+    # true on-screen chrome to compensate and avoid an oversized box.
+    SPINBOX_CHROME = 46
+
+    # Common value string used to size every editor spinbox to the same
+    # width, so fields line up vertically between the two rows of the
+    # elliptical and polar layouts. It is the widest value any field shows
+    # ("-360.0" for the angle/phase fields).
+    UNIFORM_SPIN_REF = "-360.0"
+
+    @classmethod
+    def _make_spinbox(cls, low, high, value, decimals, step, width_ref=None):
         spin = QDoubleSpinBox()
         spin.setRange(low, high)
         spin.setSingleStep(step)
         spin.setDecimals(decimals)
         spin.setValue(value)
-        spin.setMaximumWidth(75)
+        # Size the box from ``width_ref`` (a shared widest-value string, so a
+        # group of boxes ends up identical) or, if not given, from this
+        # field's own widest possible value — plus napari's real
+        # button/padding chrome, so all decimals stay visible.
+        if width_ref is None:
+            width_ref = max(
+                f"{low:.{decimals}f}", f"{high:.{decimals}f}", key=len
+            )
+        text_width = spin.fontMetrics().horizontalAdvance(width_ref)
+        width = max(70, text_width + cls.SPINBOX_CHROME)
+        # The inline stylesheet has the highest cascade priority and pins the
+        # on-screen box size even when Qt re-polishes the widget (napari's
+        # app-level QSS otherwise wins). ``setMinimumWidth`` additionally
+        # feeds the widget's minimum into the QGridLayout column sizing —
+        # the CSS ``min-width`` alone does not, so without it the box
+        # overflows its grid cell and covers the next label.
+        spin.setStyleSheet(f"min-width: {width}px; max-width: {width + 12}px;")
+        spin.setMinimumWidth(width)
         return spin
 
     # ------------------------------------------------------------- add row
@@ -2123,138 +2180,164 @@ class CursorSelectionWidget(QWidget):
             "Color of this cursor's region in the selection overlay."
         )
 
-        # Compact shape indicator for the list row (the editable combo lives
-        # in the editor page below the list).
-        shape_label = QLabel(type_combo.currentText())
-        shape_label.setToolTip(type_combo.toolTip())
+        # ---- Editor page field groups ----------------------------------
+        # All parameter spinboxes share one width (UNIFORM_SPIN_REF) so they
+        # line up vertically between the two rows of the elliptical and polar
+        # grids below.
+        ref = self.UNIFORM_SPIN_REF
 
-        # ---- Editor page field groups (one line each) -------------------
-        # Shape line (always visible).
-        shape_widget = QWidget()
-        shape_line = QHBoxLayout(shape_widget)
-        shape_line.setContentsMargins(0, 0, 0, 0)
-        shape_line.setSpacing(2)
-        _labeled(shape_line, "Shape:", type_combo, type_combo.toolTip())
-        shape_line.addStretch()
+        def _grid_label(text, spin, tooltip):
+            """QLabel sharing ``tooltip`` with its spin, for a grid cell."""
+            lbl = QLabel(text)
+            lbl.setToolTip(tooltip)
+            spin.setToolTip(tooltip)
+            return lbl
 
-        # Center fields (circular + elliptic).
-        center_widget = QWidget()
-        center_line = QHBoxLayout(center_widget)
-        center_line.setContentsMargins(0, 0, 0, 0)
-        center_line.setSpacing(2)
-        g_spin = self._make_spinbox(-1.5, 1.5, cursor['g'], 2, 0.01)
-        s_spin = self._make_spinbox(-1.5, 1.5, cursor['s'], 2, 0.01)
-        _labeled(
-            center_line,
-            "Center G:",
-            g_spin,
-            "G coordinate (horizontal axis) of the cursor center.",
+        g_spin = self._make_spinbox(-1.5, 1.5, cursor['g'], 2, 0.01, ref)
+        s_spin = self._make_spinbox(-1.5, 1.5, cursor['s'], 2, 0.01, ref)
+        radius_spin = self._make_spinbox(
+            0.001, 1.0, cursor['radius'], 3, 0.01, ref
         )
-        _labeled(
-            center_line,
-            "S:",
-            s_spin,
-            "S coordinate (vertical axis) of the cursor center.",
+        radius_minor_spin = self._make_spinbox(
+            0.001, 1.0, cursor['radius_minor'], 3, 0.01, ref
         )
-        center_line.addStretch()
+        angle_spin = self._make_spinbox(
+            -360.0, 360.0, cursor['angle'], 1, 1.0, ref
+        )
 
-        # Radius field (circular + elliptic).
-        radius_widget = QWidget()
-        radius_line = QHBoxLayout(radius_widget)
-        radius_line.setContentsMargins(0, 0, 0, 0)
-        radius_line.setSpacing(2)
-        radius_spin = self._make_spinbox(0.001, 1.0, cursor['radius'], 3, 0.01)
-        _labeled(
-            radius_line,
+        radius_label = _grid_label(
             "Radius:",
             radius_spin,
             "Radius of the circular cursor, or the major-axis radius of the "
             "elliptical cursor.",
         )
-        radius_line.addStretch()
+        radius_minor_label = _grid_label(
+            "rₘ:",
+            radius_minor_spin,
+            "Minor-axis radius of the elliptical cursor.",
+        )
 
-        # Elliptic-only fields.
+        # Circular + elliptic grid. Row 0 is the centre (G, S); for elliptic
+        # cursors the radius, minor radius (rₘ) and angle occupy row 1,
+        # column-aligned under G/S. For circular cursors the radius is moved
+        # up beside G/S onto row 0 (repositioning happens in
+        # ``_apply_type_visibility``). The spinboxes' uniform minimum width
+        # (set in ``_make_spinbox``) makes each column the same size, so the
+        # two rows line up.
+        center_widget = QWidget()
+        ce_grid = QGridLayout(center_widget)
+        ce_grid.setContentsMargins(0, 0, 0, 0)
+        ce_grid.setHorizontalSpacing(4)
+        ce_grid.setVerticalSpacing(2)
+        ce_grid.addWidget(
+            _grid_label(
+                "Center G:",
+                g_spin,
+                "G coordinate (horizontal axis) of the cursor center.",
+            ),
+            0,
+            0,
+        )
+        ce_grid.addWidget(g_spin, 0, 1)
+        ce_grid.addWidget(
+            _grid_label(
+                "S:",
+                s_spin,
+                "S coordinate (vertical axis) of the cursor center.",
+            ),
+            0,
+            2,
+        )
+        ce_grid.addWidget(s_spin, 0, 3)
+        ce_grid.addWidget(radius_minor_label, 1, 2)
+        ce_grid.addWidget(radius_minor_spin, 1, 3)
+        ce_grid.setColumnStretch(6, 1)
+
+        # Angle field (elliptic only), spanning the third column pair of the
+        # grid so it aligns to the right of rₘ.
         elliptic_widget = QWidget()
         elliptic_line = QHBoxLayout(elliptic_widget)
         elliptic_line.setContentsMargins(0, 0, 0, 0)
         elliptic_line.setSpacing(2)
-        radius_minor_spin = self._make_spinbox(
-            0.001, 1.0, cursor['radius_minor'], 3, 0.01
-        )
-        angle_spin = self._make_spinbox(-360.0, 360.0, cursor['angle'], 1, 1.0)
-        _labeled(
-            elliptic_line,
-            "Minor radius:",
-            radius_minor_spin,
-            "Minor-axis radius of the elliptical cursor.",
-        )
         _labeled(
             elliptic_line,
             "Angle (°):",
             angle_spin,
             "Rotation angle of the elliptical cursor, in degrees.",
         )
-        elliptic_line.addStretch()
+        ce_grid.addWidget(elliptic_widget, 1, 4, 1, 2)
 
-        # Polar-only fields: phase range and modulation range lines.
-        polar_widget = QWidget()
-        polar_line = QHBoxLayout(polar_widget)
-        polar_line.setContentsMargins(0, 0, 0, 0)
-        polar_line.setSpacing(2)
-        modulation_widget = QWidget()
-        modulation_line = QHBoxLayout(modulation_widget)
-        modulation_line.setContentsMargins(0, 0, 0, 0)
-        modulation_line.setSpacing(2)
+        # Polar grid: phase range on row 0, modulation range on row 1, with
+        # the min/max spinboxes column-aligned between the two rows.
         phase_min_spin = self._make_spinbox(
-            -360.0, 360.0, cursor['phase_min'], 1, 1.0
+            -360.0, 360.0, cursor['phase_min'], 1, 1.0, ref
         )
         phase_max_spin = self._make_spinbox(
-            -360.0, 360.0, cursor['phase_max'], 1, 1.0
+            -360.0, 360.0, cursor['phase_max'], 1, 1.0, ref
         )
         mod_min_spin = self._make_spinbox(
-            0.0, 1.0, cursor['modulation_min'], 2, 0.01
+            0.0, 1.0, cursor['modulation_min'], 2, 0.01, ref
         )
         mod_max_spin = self._make_spinbox(
-            0.0, 1.0, cursor['modulation_max'], 2, 0.01
+            0.0, 1.0, cursor['modulation_max'], 2, 0.01, ref
         )
-        _labeled(
-            polar_line,
-            "Phase (°):",
-            phase_min_spin,
-            "Lower phase bound of the polar cursor, in degrees.",
+        polar_widget = QWidget()
+        polar_grid = QGridLayout(polar_widget)
+        polar_grid.setContentsMargins(0, 0, 0, 0)
+        polar_grid.setHorizontalSpacing(4)
+        polar_grid.setVerticalSpacing(2)
+        polar_grid.addWidget(
+            _grid_label(
+                "Phase (°):",
+                phase_min_spin,
+                "Lower phase bound of the polar cursor, in degrees.",
+            ),
+            0,
+            0,
         )
-        _labeled(
-            polar_line,
-            "to",
-            phase_max_spin,
-            "Upper phase bound of the polar cursor, in degrees.",
+        polar_grid.addWidget(phase_min_spin, 0, 1)
+        polar_grid.addWidget(
+            _grid_label(
+                "to",
+                phase_max_spin,
+                "Upper phase bound of the polar cursor, in degrees.",
+            ),
+            0,
+            2,
         )
-        polar_line.addStretch()
-        _labeled(
-            modulation_line,
-            "Modulation:",
-            mod_min_spin,
-            "Lower modulation (radial distance) bound of the polar cursor.",
+        polar_grid.addWidget(phase_max_spin, 0, 3)
+        polar_grid.addWidget(
+            _grid_label(
+                "Modulation:",
+                mod_min_spin,
+                "Lower modulation (radial distance) bound of the polar "
+                "cursor.",
+            ),
+            1,
+            0,
         )
-        _labeled(
-            modulation_line,
-            "to",
-            mod_max_spin,
-            "Upper modulation (radial distance) bound of the polar cursor.",
+        polar_grid.addWidget(mod_min_spin, 1, 1)
+        polar_grid.addWidget(
+            _grid_label(
+                "to",
+                mod_max_spin,
+                "Upper modulation (radial distance) bound of the polar "
+                "cursor.",
+            ),
+            1,
+            2,
         )
-        modulation_line.addStretch()
+        polar_grid.addWidget(mod_max_spin, 1, 3)
+        polar_grid.setColumnStretch(4, 1)
 
-        # Assemble the editor page.
+        # Assemble the editor page. The radius label/spin are placed onto the
+        # circular+elliptic grid by ``_apply_type_visibility``.
         detail = QWidget()
         detail_layout = QVBoxLayout(detail)
         detail_layout.setContentsMargins(0, 0, 0, 0)
         detail_layout.setSpacing(2)
-        detail_layout.addWidget(shape_widget)
         detail_layout.addWidget(center_widget)
-        detail_layout.addWidget(radius_widget)
-        detail_layout.addWidget(elliptic_widget)
         detail_layout.addWidget(polar_widget)
-        detail_layout.addWidget(modulation_widget)
 
         count_label = QLabel("-")
         count_label.setAlignment(Qt.AlignCenter)
@@ -2284,10 +2367,11 @@ class CursorSelectionWidget(QWidget):
         remove_button.setFixedSize(25, 25)
         remove_button.setToolTip("Remove this cursor.")
 
-        # Assemble the compact list row.
+        # Assemble the compact list row. The shape combobox lives here so the
+        # cursor's type can be changed without opening the editor.
         row_layout.addWidget(number_label)
         row_layout.addWidget(color_button)
-        row_layout.addWidget(shape_label)
+        row_layout.addWidget(type_combo)
         row_layout.addStretch()
         row_layout.addWidget(n_label)
         row_layout.addWidget(count_label)
@@ -2300,20 +2384,20 @@ class CursorSelectionWidget(QWidget):
             {
                 'row': frame,
                 'detail': detail,
-                'shape_label': shape_label,
                 'number_label': number_label,
                 'type_combo': type_combo,
                 'color_button': color_button,
                 'center_widget': center_widget,
+                'ce_grid': ce_grid,
                 'g_spin': g_spin,
                 's_spin': s_spin,
-                'radius_widget': radius_widget,
+                'radius_label': radius_label,
                 'radius_spin': radius_spin,
-                'elliptic_widget': elliptic_widget,
+                'radius_minor_label': radius_minor_label,
                 'radius_minor_spin': radius_minor_spin,
+                'elliptic_widget': elliptic_widget,
                 'angle_spin': angle_spin,
                 'polar_widget': polar_widget,
-                'modulation_widget': modulation_widget,
                 'phase_min_spin': phase_min_spin,
                 'phase_max_spin': phase_max_spin,
                 'mod_min_spin': mod_min_spin,
@@ -2332,6 +2416,10 @@ class CursorSelectionWidget(QWidget):
 
         # Wire signals (lambdas capture the cursor dict directly).
         frame.clicked.connect(lambda c=cursor: self._select_cursor(c))
+        # Interacting with the row's shape combo also selects the cursor.
+        type_combo.activated.connect(
+            lambda _=0, c=cursor: self._select_cursor(c)
+        )
         type_combo.currentIndexChanged.connect(
             lambda _=0, c=cursor: self._on_cursor_type_changed(c)
         )
@@ -2396,13 +2484,32 @@ class CursorSelectionWidget(QWidget):
             self._update_cursor_statistics()
 
     def _apply_type_visibility(self, cursor):
-        """Show/hide the shape-specific field groups for a cursor row."""
+        """Show/hide (and re-place) the shape-specific fields for a cursor."""
         cursor_type = cursor['type']
-        cursor['center_widget'].setVisible(cursor_type != "polar")
-        cursor['radius_widget'].setVisible(cursor_type != "polar")
-        cursor['elliptic_widget'].setVisible(cursor_type == "elliptic")
+        grid = cursor['ce_grid']
+        radius_label = cursor['radius_label']
+        radius = cursor['radius_spin']
+        # The radius sits beside G/S on row 0 for circular cursors, and on
+        # row 1 (column-aligned under G) for elliptical cursors. Detach then
+        # re-add it at the position for the current shape.
+        grid.removeWidget(radius_label)
+        grid.removeWidget(radius)
+        if cursor_type == "elliptic":
+            grid.addWidget(radius_label, 1, 0)
+            grid.addWidget(radius, 1, 1)
+        else:  # circular (shown on row 0) or polar (added then hidden)
+            grid.addWidget(radius_label, 0, 4)
+            grid.addWidget(radius, 0, 5)
+
+        show_center = cursor_type != "polar"
+        show_elliptic = cursor_type == "elliptic"
+        cursor['center_widget'].setVisible(show_center)
+        radius_label.setVisible(show_center)
+        radius.setVisible(show_center)
+        cursor['radius_minor_label'].setVisible(show_elliptic)
+        cursor['radius_minor_spin'].setVisible(show_elliptic)
+        cursor['elliptic_widget'].setVisible(show_elliptic)
         cursor['polar_widget'].setVisible(cursor_type == "polar")
-        cursor['modulation_widget'].setVisible(cursor_type == "polar")
 
     # ------------------------------------------------------------ selection
     def _select_cursor(self, cursor):
@@ -2480,7 +2587,6 @@ class CursorSelectionWidget(QWidget):
     def _on_cursor_type_changed(self, cursor):
         """Handle the shape combobox changing for a cursor."""
         cursor['type'] = cursor['type_combo'].currentData()
-        cursor['shape_label'].setText(cursor['type_combo'].currentText())
         if cursor is self._selected_cursor:
             self._refresh_editor_title()
         self._apply_type_visibility(cursor)

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -1784,15 +1784,28 @@ class ColorButton(QPushButton):
         self._update_style()
 
 
+class ClickableFrame(QFrame):
+    """A ``QFrame`` that emits ``clicked`` when pressed with the left button."""
+
+    clicked = Signal()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit()
+        super().mousePressEvent(event)
+
+
 class CursorSelectionWidget(QWidget):
     """
     Unified widget for cursor-based selection in phasor plots.
 
-    Provides a single list of cursor "rows". The first element of each row
-    is a shape combobox (Circular / Elliptical / Polar); the remaining fields
-    in the row are shown or hidden dynamically based on the chosen shape. All
-    cursors (regardless of shape) contribute to a single combined
-    ``Cursor Selection: <image>`` labels layer.
+    Uses a master/detail layout: a compact list of cursor rows (color,
+    shape, pixel statistics, visibility and remove controls) and a single
+    "Selected Cursor" editor below it showing the selected cursor's
+    parameters. Clicking a row — or dragging a cursor on the plot — selects
+    it. The shape-specific parameter fields are shown or hidden dynamically
+    based on the chosen shape. All cursors (regardless of shape) contribute
+    to a single combined ``Cursor Selection: <image>`` labels layer.
 
     Parameters
     ----------
@@ -1815,6 +1828,7 @@ class CursorSelectionWidget(QWidget):
 
         # Each cursor is a dict carrying both its data and its row widgets.
         self._cursors = []
+        self._selected_cursor = None
         self._phasors_selected_layer = None
 
         # Dragging state
@@ -1859,6 +1873,15 @@ class CursorSelectionWidget(QWidget):
         self.add_cursor_button.clicked.connect(lambda: self._add_cursor())
         cursors_box_layout.addWidget(self.add_cursor_button)
         layout.addWidget(cursors_box)
+
+        # Editor for the selected cursor's parameters. One page per cursor
+        # (so each cursor keeps its own spinboxes and signal wiring); only
+        # the selected cursor's page is shown.
+        self._editor_box, editor_layout = make_section("Selected Cursor")
+        self._details_stack = CurrentPageStackedWidget()
+        editor_layout.addWidget(self._details_stack)
+        self._editor_box.setVisible(False)
+        layout.addWidget(self._editor_box)
 
         # Prominent "Calculate" button — the primary action of the tab.
         self.calculate_button = QPushButton("Calculate Selection")
@@ -2035,6 +2058,7 @@ class CursorSelectionWidget(QWidget):
         self._cursors.append(cursor)
 
         self._update_row_visibility()
+        self._select_cursor(cursor)
         self._update_cursor_patch(cursor)
         self._refresh_calculate_button_if_ready()
 
@@ -2043,8 +2067,27 @@ class CursorSelectionWidget(QWidget):
         else:
             self._update_cursor_statistics()
 
+    # Rounded box around each cursor row; the selected row gets an accent
+    # border. rgba keeps both legible in the light and dark napari themes.
+    ROW_STYLE = (
+        "QFrame#cursorRow {"
+        "  border: 1px solid rgba(128, 128, 128, 0.35);"
+        "  border-radius: 4px;"
+        "}"
+        'QFrame#cursorRow[selected="true"] {'
+        "  border: 1px solid rgba(108, 158, 217, 0.9);"
+        "  background-color: rgba(108, 158, 217, 0.12);"
+        "}"
+    )
+
     def _build_row(self, cursor):
-        """Construct the QFrame row and store widget refs on ``cursor``."""
+        """Construct a compact list row plus an editor page for ``cursor``.
+
+        The row shows identity, statistics and actions; the parameter
+        fields live on a separate page of ``self._details_stack`` that is
+        shown only while this cursor is selected. Widget refs are stored
+        on ``cursor``.
+        """
 
         def _labeled(layout, text, widget, tooltip):
             """Add a ``text`` label + ``widget`` to ``layout``, sharing tooltip."""
@@ -2054,10 +2097,13 @@ class CursorSelectionWidget(QWidget):
             layout.addWidget(label)
             layout.addWidget(widget)
 
-        frame = QFrame()
-        frame.setFrameShape(QFrame.StyledPanel)
+        frame = ClickableFrame()
+        frame.setObjectName("cursorRow")
+        frame.setStyleSheet(self.ROW_STYLE)
+        frame.setToolTip("Click to select this cursor and edit it below.")
+        frame.setCursor(Qt.PointingHandCursor)
         row_layout = QHBoxLayout(frame)
-        row_layout.setContentsMargins(4, 2, 4, 2)
+        row_layout.setContentsMargins(6, 2, 4, 2)
         row_layout.setSpacing(4)
 
         number_label = QLabel("")
@@ -2077,6 +2123,20 @@ class CursorSelectionWidget(QWidget):
             "Color of this cursor's region in the selection overlay."
         )
 
+        # Compact shape indicator for the list row (the editable combo lives
+        # in the editor page below the list).
+        shape_label = QLabel(type_combo.currentText())
+        shape_label.setToolTip(type_combo.toolTip())
+
+        # ---- Editor page field groups (one line each) -------------------
+        # Shape line (always visible).
+        shape_widget = QWidget()
+        shape_line = QHBoxLayout(shape_widget)
+        shape_line.setContentsMargins(0, 0, 0, 0)
+        shape_line.setSpacing(2)
+        _labeled(shape_line, "Shape:", type_combo, type_combo.toolTip())
+        shape_line.addStretch()
+
         # Center fields (circular + elliptic).
         center_widget = QWidget()
         center_line = QHBoxLayout(center_widget)
@@ -2084,26 +2144,34 @@ class CursorSelectionWidget(QWidget):
         center_line.setSpacing(2)
         g_spin = self._make_spinbox(-1.5, 1.5, cursor['g'], 2, 0.01)
         s_spin = self._make_spinbox(-1.5, 1.5, cursor['s'], 2, 0.01)
-        radius_spin = self._make_spinbox(0.001, 1.0, cursor['radius'], 3, 0.01)
         _labeled(
             center_line,
-            "G",
+            "Center G:",
             g_spin,
             "G coordinate (horizontal axis) of the cursor center.",
         )
         _labeled(
             center_line,
-            "S",
+            "S:",
             s_spin,
             "S coordinate (vertical axis) of the cursor center.",
         )
+        center_line.addStretch()
+
+        # Radius field (circular + elliptic).
+        radius_widget = QWidget()
+        radius_line = QHBoxLayout(radius_widget)
+        radius_line.setContentsMargins(0, 0, 0, 0)
+        radius_line.setSpacing(2)
+        radius_spin = self._make_spinbox(0.001, 1.0, cursor['radius'], 3, 0.01)
         _labeled(
-            center_line,
-            "r",
+            radius_line,
+            "Radius:",
             radius_spin,
             "Radius of the circular cursor, or the major-axis radius of the "
             "elliptical cursor.",
         )
+        radius_line.addStretch()
 
         # Elliptic-only fields.
         elliptic_widget = QWidget()
@@ -2116,22 +2184,27 @@ class CursorSelectionWidget(QWidget):
         angle_spin = self._make_spinbox(-360.0, 360.0, cursor['angle'], 1, 1.0)
         _labeled(
             elliptic_line,
-            "rₘ",
+            "Minor radius:",
             radius_minor_spin,
             "Minor-axis radius of the elliptical cursor.",
         )
         _labeled(
             elliptic_line,
-            "∠",
+            "Angle (°):",
             angle_spin,
             "Rotation angle of the elliptical cursor, in degrees.",
         )
+        elliptic_line.addStretch()
 
-        # Polar-only fields.
+        # Polar-only fields: phase range and modulation range lines.
         polar_widget = QWidget()
         polar_line = QHBoxLayout(polar_widget)
         polar_line.setContentsMargins(0, 0, 0, 0)
         polar_line.setSpacing(2)
+        modulation_widget = QWidget()
+        modulation_line = QHBoxLayout(modulation_widget)
+        modulation_line.setContentsMargins(0, 0, 0, 0)
+        modulation_line.setSpacing(2)
         phase_min_spin = self._make_spinbox(
             -360.0, 360.0, cursor['phase_min'], 1, 1.0
         )
@@ -2146,28 +2219,42 @@ class CursorSelectionWidget(QWidget):
         )
         _labeled(
             polar_line,
-            "φ₋",
+            "Phase (°):",
             phase_min_spin,
             "Lower phase bound of the polar cursor, in degrees.",
         )
         _labeled(
             polar_line,
-            "φ₊",
+            "to",
             phase_max_spin,
             "Upper phase bound of the polar cursor, in degrees.",
         )
+        polar_line.addStretch()
         _labeled(
-            polar_line,
-            "m₋",
+            modulation_line,
+            "Modulation:",
             mod_min_spin,
             "Lower modulation (radial distance) bound of the polar cursor.",
         )
         _labeled(
-            polar_line,
-            "m₊",
+            modulation_line,
+            "to",
             mod_max_spin,
             "Upper modulation (radial distance) bound of the polar cursor.",
         )
+        modulation_line.addStretch()
+
+        # Assemble the editor page.
+        detail = QWidget()
+        detail_layout = QVBoxLayout(detail)
+        detail_layout.setContentsMargins(0, 0, 0, 0)
+        detail_layout.setSpacing(2)
+        detail_layout.addWidget(shape_widget)
+        detail_layout.addWidget(center_widget)
+        detail_layout.addWidget(radius_widget)
+        detail_layout.addWidget(elliptic_widget)
+        detail_layout.addWidget(polar_widget)
+        detail_layout.addWidget(modulation_widget)
 
         count_label = QLabel("-")
         count_label.setAlignment(Qt.AlignCenter)
@@ -2197,12 +2284,10 @@ class CursorSelectionWidget(QWidget):
         remove_button.setFixedSize(25, 25)
         remove_button.setToolTip("Remove this cursor.")
 
+        # Assemble the compact list row.
         row_layout.addWidget(number_label)
-        row_layout.addWidget(type_combo)
         row_layout.addWidget(color_button)
-        row_layout.addWidget(center_widget)
-        row_layout.addWidget(elliptic_widget)
-        row_layout.addWidget(polar_widget)
+        row_layout.addWidget(shape_label)
         row_layout.addStretch()
         row_layout.addWidget(n_label)
         row_layout.addWidget(count_label)
@@ -2214,17 +2299,21 @@ class CursorSelectionWidget(QWidget):
         cursor.update(
             {
                 'row': frame,
+                'detail': detail,
+                'shape_label': shape_label,
                 'number_label': number_label,
                 'type_combo': type_combo,
                 'color_button': color_button,
                 'center_widget': center_widget,
                 'g_spin': g_spin,
                 's_spin': s_spin,
+                'radius_widget': radius_widget,
                 'radius_spin': radius_spin,
                 'elliptic_widget': elliptic_widget,
                 'radius_minor_spin': radius_minor_spin,
                 'angle_spin': angle_spin,
                 'polar_widget': polar_widget,
+                'modulation_widget': modulation_widget,
                 'phase_min_spin': phase_min_spin,
                 'phase_max_spin': phase_max_spin,
                 'mod_min_spin': mod_min_spin,
@@ -2237,10 +2326,12 @@ class CursorSelectionWidget(QWidget):
         )
 
         self._rows_layout.addWidget(frame)
+        self._details_stack.addWidget(detail)
         self._apply_type_visibility(cursor)
         self._update_visibility_button(cursor)
 
         # Wire signals (lambdas capture the cursor dict directly).
+        frame.clicked.connect(lambda c=cursor: self._select_cursor(c))
         type_combo.currentIndexChanged.connect(
             lambda _=0, c=cursor: self._on_cursor_type_changed(c)
         )
@@ -2308,8 +2399,42 @@ class CursorSelectionWidget(QWidget):
         """Show/hide the shape-specific field groups for a cursor row."""
         cursor_type = cursor['type']
         cursor['center_widget'].setVisible(cursor_type != "polar")
+        cursor['radius_widget'].setVisible(cursor_type != "polar")
         cursor['elliptic_widget'].setVisible(cursor_type == "elliptic")
         cursor['polar_widget'].setVisible(cursor_type == "polar")
+        cursor['modulation_widget'].setVisible(cursor_type == "polar")
+
+    # ------------------------------------------------------------ selection
+    def _select_cursor(self, cursor):
+        """Show ``cursor``'s editor page and highlight its list row.
+
+        Passing ``None`` hides the editor (no cursors on this harmonic).
+        """
+        if cursor is not None and cursor not in self._cursors:
+            return
+        self._selected_cursor = cursor
+        for c in self._cursors:
+            selected = c is cursor
+            row = c['row']
+            if row.property("selected") != selected:
+                row.setProperty("selected", selected)
+                row.style().unpolish(row)
+                row.style().polish(row)
+        if cursor is None:
+            self._editor_box.setVisible(False)
+            return
+        self._details_stack.setCurrentWidget(cursor['detail'])
+        self._editor_box.setVisible(True)
+        self._refresh_editor_title()
+
+    def _refresh_editor_title(self):
+        """Sync the editor box title with the selected cursor's identity."""
+        cursor = self._selected_cursor
+        if cursor is None:
+            return
+        number = cursor['number_label'].text().rstrip('.')
+        shape = cursor['type_combo'].currentText()
+        self._editor_box.setTitle(f"Cursor {number} — {shape}")
 
     def _resolve_cursor(self, cursor_or_idx):
         """Accept either a cursor dict or its index in ``self._cursors``."""
@@ -2332,6 +2457,15 @@ class CursorSelectionWidget(QWidget):
             if visible:
                 cursor['number_label'].setText(f"{number}.")
                 number += 1
+        # Keep the selection on a visible row: after a harmonic switch the
+        # selected cursor's row may have been hidden.
+        harmonic_cursors = self._current_harmonic_cursors()
+        if self._selected_cursor not in harmonic_cursors:
+            self._select_cursor(
+                harmonic_cursors[0] if harmonic_cursors else None
+            )
+        else:
+            self._refresh_editor_title()
 
     def _current_harmonic_cursors(self):
         current_harmonic = (
@@ -2344,8 +2478,11 @@ class CursorSelectionWidget(QWidget):
         ]
 
     def _on_cursor_type_changed(self, cursor):
-        """Handle the shape combobox changing for a row."""
+        """Handle the shape combobox changing for a cursor."""
         cursor['type'] = cursor['type_combo'].currentData()
+        cursor['shape_label'].setText(cursor['type_combo'].currentText())
+        if cursor is self._selected_cursor:
+            self._refresh_editor_title()
         self._apply_type_visibility(cursor)
         self._update_cursor_patch(cursor)
         if self._dragging_cursor is None:
@@ -2392,9 +2529,19 @@ class CursorSelectionWidget(QWidget):
 
         cursor['row'].setParent(None)
         cursor['row'].deleteLater()
+        self._details_stack.removeWidget(cursor['detail'])
+        cursor['detail'].deleteLater()
+        was_selected = cursor is self._selected_cursor
         self._cursors.remove(cursor)
+        if was_selected:
+            self._selected_cursor = None
 
         self._update_row_visibility()
+        if was_selected:
+            harmonic_cursors = self._current_harmonic_cursors()
+            self._select_cursor(
+                harmonic_cursors[-1] if harmonic_cursors else None
+            )
         self._refresh_calculate_button_if_ready()
 
         if not self._cursors:
@@ -2416,7 +2563,10 @@ class CursorSelectionWidget(QWidget):
                     cursor['patch'].remove()
             cursor['row'].setParent(None)
             cursor['row'].deleteLater()
+            self._details_stack.removeWidget(cursor['detail'])
+            cursor['detail'].deleteLater()
         self._cursors.clear()
+        self._select_cursor(None)
         self._remove_selection_layer()
         self._selection_active = False
         if self.parent_widget is not None:
@@ -2887,6 +3037,9 @@ class CursorSelectionWidget(QWidget):
         for cursor in self._cursors:
             if cursor.get('patch') == event.artist:
                 self._dragging_cursor = cursor
+                # Editing on the plot selects the cursor, so its parameters
+                # are shown in the editor while dragging.
+                self._select_cursor(cursor)
                 click_pos = (event.mouseevent.xdata, event.mouseevent.ydata)
                 modifiers = QApplication.keyboardModifiers()
                 is_shift = bool(modifiers & Qt.ShiftModifier)

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -119,12 +119,6 @@ class SelectionWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setStyleSheet(analysis_section_stylesheet())
 
-        # Everything (mode selector + whichever mode's controls are active)
-        # lives inside a scroll area, so a tall cursor list scrolls together
-        # with the mode selector instead of growing this tab's minimum size
-        # (which would squeeze the other tabs and docks). A horizontal
-        # scrollbar appears if the dock is narrower than the content needs,
-        # instead of clipping fields.
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_area.setFrameShape(QFrame.NoFrame)
@@ -1872,11 +1866,6 @@ class CursorSelectionWidget(QWidget):
         """Set up the user interface."""
         self.setStyleSheet(analysis_section_stylesheet())
 
-        # This widget's content is scrolled by the ``QScrollArea`` that
-        # ``SelectionWidget`` wraps around the mode selector and the whole
-        # stacked mode widget, so a long list of cursors scrolls together
-        # with the mode selector instead of growing this widget's minimum
-        # height (which would squeeze the other tabs and docks).
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 5, 0, 0)
 
@@ -1898,9 +1887,7 @@ class CursorSelectionWidget(QWidget):
         cursors_box_layout.addWidget(self.add_cursor_button)
         layout.addWidget(cursors_box)
 
-        # Editor for the selected cursor's parameters. One page per cursor
-        # (so each cursor keeps its own spinboxes and signal wiring); only
-        # the selected cursor's page is shown.
+        # Editor for the selected cursor's parameters.
         self._editor_box, editor_layout = make_section("Selected Cursor")
         self._details_stack = CurrentPageStackedWidget()
         editor_layout.addWidget(self._details_stack)
@@ -1972,20 +1959,8 @@ class CursorSelectionWidget(QWidget):
             return (xlim[0] + xlim[1]) / 2.0, (ylim[0] + ylim[1]) / 2.0
         return 0.5, 0.5
 
-    # napari's QSS (00_base.qss) pads QAbstractSpinBox by 10px on each side
-    # and draws a 20px-wide up-button and down-button on the right/left
-    # edges (unlike plain Qt, where both arrows stack in one ~16px column on
-    # the right only) — wider chrome than a generic Qt spinbox needs. This is
-    # fed into an inline "min-width" rule (see ``_make_spinbox``); Qt's CSS
-    # box model then adds the 20px of left+right padding *again* on top of
-    # that value, so this constant is deliberately smaller than the ~60px of
-    # true on-screen chrome to compensate and avoid an oversized box.
     SPINBOX_CHROME = 46
 
-    # Common value string used to size every editor spinbox to the same
-    # width, so fields line up vertically between the two rows of the
-    # elliptical and polar layouts. It is the widest value any field shows
-    # ("-360.0" for the angle/phase fields).
     UNIFORM_SPIN_REF = "-360.0"
 
     @classmethod
@@ -1995,27 +1970,16 @@ class CursorSelectionWidget(QWidget):
         spin.setSingleStep(step)
         spin.setDecimals(decimals)
         spin.setValue(value)
-        # Size the box from ``width_ref`` (a shared widest-value string, so a
-        # group of boxes ends up identical) or, if not given, from this
-        # field's own widest possible value — plus napari's real
-        # button/padding chrome, so all decimals stay visible.
         if width_ref is None:
             width_ref = max(
                 f"{low:.{decimals}f}", f"{high:.{decimals}f}", key=len
             )
         text_width = spin.fontMetrics().horizontalAdvance(width_ref)
         width = max(70, text_width + cls.SPINBOX_CHROME)
-        # The inline stylesheet has the highest cascade priority and pins the
-        # on-screen box size even when Qt re-polishes the widget (napari's
-        # app-level QSS otherwise wins). ``setMinimumWidth`` additionally
-        # feeds the widget's minimum into the QGridLayout column sizing —
-        # the CSS ``min-width`` alone does not, so without it the box
-        # overflows its grid cell and covers the next label.
         spin.setStyleSheet(f"min-width: {width}px; max-width: {width + 12}px;")
         spin.setMinimumWidth(width)
         return spin
 
-    # ------------------------------------------------------------- add row
     def _add_cursor(
         self,
         cursor_type="circular",
@@ -2124,8 +2088,6 @@ class CursorSelectionWidget(QWidget):
         else:
             self._update_cursor_statistics()
 
-    # Rounded box around each cursor row; the selected row gets an accent
-    # border. rgba keeps both legible in the light and dark napari themes.
     ROW_STYLE = (
         "QFrame#cursorRow {"
         "  border: 1px solid rgba(128, 128, 128, 0.35);"
@@ -2180,10 +2142,6 @@ class CursorSelectionWidget(QWidget):
             "Color of this cursor's region in the selection overlay."
         )
 
-        # ---- Editor page field groups ----------------------------------
-        # All parameter spinboxes share one width (UNIFORM_SPIN_REF) so they
-        # line up vertically between the two rows of the elliptical and polar
-        # grids below.
         ref = self.UNIFORM_SPIN_REF
 
         def _grid_label(text, spin, tooltip):
@@ -2217,13 +2175,6 @@ class CursorSelectionWidget(QWidget):
             "Minor-axis radius of the elliptical cursor.",
         )
 
-        # Circular + elliptic grid. Row 0 is the centre (G, S); for elliptic
-        # cursors the radius, minor radius (rₘ) and angle occupy row 1,
-        # column-aligned under G/S. For circular cursors the radius is moved
-        # up beside G/S onto row 0 (repositioning happens in
-        # ``_apply_type_visibility``). The spinboxes' uniform minimum width
-        # (set in ``_make_spinbox``) makes each column the same size, so the
-        # two rows line up.
         center_widget = QWidget()
         ce_grid = QGridLayout(center_widget)
         ce_grid.setContentsMargins(0, 0, 0, 0)
@@ -2253,8 +2204,6 @@ class CursorSelectionWidget(QWidget):
         ce_grid.addWidget(radius_minor_spin, 1, 3)
         ce_grid.setColumnStretch(6, 1)
 
-        # Angle field (elliptic only), spanning the third column pair of the
-        # grid so it aligns to the right of rₘ.
         elliptic_widget = QWidget()
         elliptic_line = QHBoxLayout(elliptic_widget)
         elliptic_line.setContentsMargins(0, 0, 0, 0)
@@ -2267,8 +2216,6 @@ class CursorSelectionWidget(QWidget):
         )
         ce_grid.addWidget(elliptic_widget, 1, 4, 1, 2)
 
-        # Polar grid: phase range on row 0, modulation range on row 1, with
-        # the min/max spinboxes column-aligned between the two rows.
         phase_min_spin = self._make_spinbox(
             -360.0, 360.0, cursor['phase_min'], 1, 1.0, ref
         )
@@ -2357,8 +2304,6 @@ class CursorSelectionWidget(QWidget):
             "Percentage of valid pixels inside this cursor's region."
         )
 
-        # A plain (non-checkable) button so its background always matches the
-        # neighbouring "×" remove button; the icon conveys the visible state.
         visibility_button = QPushButton()
         visibility_button.setFixedSize(25, 25)
         visibility_button.setIconSize(QSize(18, 18))
@@ -2367,8 +2312,6 @@ class CursorSelectionWidget(QWidget):
         remove_button.setFixedSize(25, 25)
         remove_button.setToolTip("Remove this cursor.")
 
-        # Assemble the compact list row. The shape combobox lives here so the
-        # cursor's type can be changed without opening the editor.
         row_layout.addWidget(number_label)
         row_layout.addWidget(color_button)
         row_layout.addWidget(type_combo)
@@ -2489,9 +2432,7 @@ class CursorSelectionWidget(QWidget):
         grid = cursor['ce_grid']
         radius_label = cursor['radius_label']
         radius = cursor['radius_spin']
-        # The radius sits beside G/S on row 0 for circular cursors, and on
-        # row 1 (column-aligned under G) for elliptical cursors. Detach then
-        # re-add it at the position for the current shape.
+
         grid.removeWidget(radius_label)
         grid.removeWidget(radius)
         if cursor_type == "elliptic":
@@ -2511,7 +2452,6 @@ class CursorSelectionWidget(QWidget):
         cursor['elliptic_widget'].setVisible(show_elliptic)
         cursor['polar_widget'].setVisible(cursor_type == "polar")
 
-    # ------------------------------------------------------------ selection
     def _select_cursor(self, cursor):
         """Show ``cursor``'s editor page and highlight its list row.
 
@@ -2551,7 +2491,6 @@ class CursorSelectionWidget(QWidget):
             return self._cursors[cursor_or_idx]
         return None
 
-    # --------------------------------------------------------- row updates
     def _update_row_visibility(self):
         """Show only rows belonging to the current harmonic and renumber."""
         current_harmonic = (
@@ -2678,7 +2617,6 @@ class CursorSelectionWidget(QWidget):
         if self.parent_widget is not None:
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
-    # ------------------------------------------------------------- patches
     def _update_cursor_patch(self, cursor_or_idx):
         """Update or create the matplotlib patch for a cursor."""
         cursor = self._resolve_cursor(cursor_or_idx)
@@ -2774,7 +2712,6 @@ class CursorSelectionWidget(QWidget):
         else:
             self._update_cursor_statistics()
 
-    # ----------------------------------------------------------- selection
     def _get_current_layer(self):
         """Helper to get the currently selected image layer."""
         if self.parent_widget is None:
@@ -3124,7 +3061,6 @@ class CursorSelectionWidget(QWidget):
         if self.parent_widget is not None:
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
-    # --------------------------------------------------------------- drag
     def _connect_drag_events(self):
         """Connect matplotlib events for dragging cursors."""
         if self.parent_widget is None:


### PR DESCRIPTION
## Redesign the Cursors section of the Selection tab

Reworks the cursor-based selection UI in the Selection tab to fix excessive
row width (especially for elliptical cursors) and prevent a long cursor
list from squeezing the other tabs/docks, while improving readability and
usability.

### What changed

**Master/detail layout for cursors**
- Replaced the old single-row-per-cursor layout (which crammed shape combo,
  color, all parameter fields, stats, and actions into one wide `QHBoxLayout`)
  with a compact list + a single "Selected Cursor" editor panel below it.
- Each list row now shows: number, color swatch, shape combobox, pixel
  count/percentage, visibility toggle, and remove button — a fixed width
  regardless of cursor shape.
- Clicking a row (or dragging a cursor on the phasor plot) selects it and
  shows its parameters in the editor panel below, with a highlighted border
  on the selected row.
- Each cursor keeps its own editor page (`QStackedWidget`) so per-cursor
  spinboxes and signal wiring are preserved; only the selected cursor's page
  is shown.

**Editor field layout**
- Circular: `Center G / S / Radius` on one row.
- Elliptical: `Center G / S` on one row; `Radius / rₘ / Angle (°)` on a
  second row, using a `QGridLayout` so the G↔Radius and S↔rₘ columns line up
  vertically between the two rows.
- Polar: `Phase (°) min/max` on one row, `Modulation min/max` on a second
  row, similarly column-aligned.
- All editor spinboxes now share a uniform width, and full-word labels
  (`Center G:`, `Radius:`, `Angle (°):`, etc.) replace the old glyphs.
- A visible rounded border now surrounds each cursor row (previously invisible
  under napari's theme).

**Spinbox sizing fix**
- Spinbox width was previously a flat pixel cap that clipped the last decimal
  digit under napari's actual theme (napari's QSS draws 20px-wide up/down
  buttons on *both* sides plus 10px padding on each side — much wider chrome
  than a generic Qt spinbox, and CSS `min-width` adds the padding a second
  time on top of any inline value). Spinboxes are now sized from their
  widest possible value plus a calibrated chrome constant, verified against
  napari's real stylesheet so all three decimals stay visible.

**Scrolling**
- The "Selection mode" combobox and the whole stacked mode widget (cursor
  selection / automatic clustering / manual selection) are now wrapped in a
  single scroll area at the `SelectionWidget` level.
- A long cursor list scrolls internally together with the mode selector
  instead of growing the tab's minimum height and squeezing neighboring
  docks.
- A horizontal scrollbar appears (matching the pattern used in other
  analysis tabs) when the dock is narrower than the content needs, instead
  of clipping fields.