### PR TITLE
Fix threshold slider minimum and clear histogram on layer deselection

### DIFF
--- a/src/napari_phasors/_tests/test_filter_tab.py
+++ b/src/napari_phasors/_tests/test_filter_tab.py
@@ -1257,3 +1257,157 @@ def test_filter_on_image_layer_changed_restores_full_settings(
     assert fw.median_filter_repetition_spinbox.value() == 2
     assert fw.wavelet_sigma_spinbox.value() == 3.0
     assert fw.wavelet_levels_spinbox.value() == 4
+
+
+def test_slider_minimum_tracks_data_minimum(make_viewer_model, qtbot):
+    """An image whose intensities start above zero bounds the slider minimum.
+
+    Regression: importing an already-thresholded image left the lower
+    threshold line to the left of the visible histogram because the slider
+    minimum was hard-coded to zero.
+    """
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    # Simulate an already-thresholded intensity image: nothing below 5.0.
+    mean = layer.metadata["original_mean"].astype(float)
+    mean[:] = np.linspace(5.0, 40.0, mean.size).reshape(mean.shape)
+    layer.metadata["original_mean"] = mean
+    layer.metadata["settings"] = {}  # no stored threshold
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    fw = parent.filter_tab
+    fw._on_image_layer_changed()
+
+    expected_min = int(5.0 * fw.threshold_factor)
+    assert fw.threshold_slider.minimum() == expected_min
+    lower_val, _ = fw.threshold_slider.value()
+    assert lower_val == expected_min
+    assert fw.min_threshold_edit.text() == f"{5.0:.2f}"
+
+
+def test_apply_stores_none_for_unconstrained_bounds(make_viewer_model, qtbot):
+    """Threshold handles left at the slider extremes persist as ``None``.
+
+    Regression: leaving the max handle at the top stored the current data max
+    as an explicit ``threshold_upper``. While a mask was active this froze the
+    reduced max, which then persisted after the mask was removed.
+    """
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    fw = parent.filter_tab
+
+    # Manual thresholding with both handles left at their extremes.
+    fw.threshold_slider.setValue(
+        (fw.threshold_slider.minimum(), fw.threshold_slider.maximum())
+    )
+    fw.threshold_method_combobox.setCurrentText("Manual")
+
+    with patch(
+        'napari_phasors.filter_tab.apply_filter_and_threshold'
+    ) as mock_apply:
+        fw.apply_button_clicked()
+        call_kwargs = mock_apply.call_args[1]
+        assert call_kwargs['threshold'] is None
+        assert call_kwargs['threshold_upper'] is None
+
+    # A constrained max should still be persisted as a concrete value.
+    upper = fw.threshold_slider.maximum() - 1
+    fw.threshold_slider.setValue((fw.threshold_slider.minimum(), upper))
+    with patch(
+        'napari_phasors.filter_tab.apply_filter_and_threshold'
+    ) as mock_apply:
+        fw.apply_button_clicked()
+        call_kwargs = mock_apply.call_args[1]
+        assert call_kwargs['threshold_upper'] == upper / fw.threshold_factor
+
+
+def test_unconstrained_upper_sits_at_slider_maximum(make_viewer_model, qtbot):
+    """A ``None`` stored upper threshold pins the handle to the slider maximum.
+
+    Regression: because the slider maximum is ``ceil``-rounded while the upper
+    value was ``int``-truncated, an unconstrained max landed one tick below the
+    maximum, was mistaken for a user constraint, and got frozen.
+    """
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    layer.metadata["settings"] = {
+        "threshold": 0.05,
+        "threshold_upper": None,
+        "threshold_method": "Manual",
+    }
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    fw = parent.filter_tab
+    fw._on_image_layer_changed()
+
+    _, upper_val = fw.threshold_slider.value()
+    assert upper_val == fw.threshold_slider.maximum()
+
+
+def test_max_threshold_restored_after_mask_removed(make_viewer_model, qtbot):
+    """Removing a mask restores the unconstrained max to the full-data max.
+
+    Regression: masking lowered the slider maximum, and the reduced max stuck
+    after the mask was removed instead of returning to the original range.
+    """
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    layer.metadata["settings"] = {
+        "threshold": 0.05,
+        "threshold_method": "Manual",
+    }
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    fw = parent.filter_tab
+    fw._on_image_layer_changed()
+
+    om = layer.metadata["original_mean"]
+    full_max_real = np.nanmax(om)
+    full_factor = fw.threshold_factor
+    full_max = fw.threshold_slider.maximum()
+    _, upper_full = fw.threshold_slider.value()
+    # Unconstrained upper pinned to the maximum (real units ~ data max).
+    assert upper_full == full_max
+
+    # Mask in only the below-median pixels so the visible max drops.
+    masked_max_real = np.nanmax(om[om <= np.median(om)])
+    layer.metadata["mask"] = (om <= np.median(om)).astype(int)
+    fw._on_image_layer_changed()
+
+    # The visible max drops in real units (the scaled value is not comparable
+    # because ``threshold_factor`` rescales with the magnitude).
+    assert masked_max_real < full_max_real
+    _, upper_masked = fw.threshold_slider.value()
+    assert upper_masked == fw.threshold_slider.maximum()
+    assert upper_masked / fw.threshold_factor < full_max_real
+
+    # Remove the mask: the full range and unconstrained max must return.
+    del layer.metadata["mask"]
+    fw._on_image_layer_changed()
+
+    assert fw.threshold_factor == full_factor
+    assert fw.threshold_slider.maximum() == full_max
+    _, upper_restored = fw.threshold_slider.value()
+    assert upper_restored == full_max
+
+
+def test_histogram_cleared_when_no_layer_selected(make_viewer_model, qtbot):
+    """Deselecting all phasor layers clears the intensity histogram."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    fw = parent.filter_tab
+    fw._on_image_layer_changed()
+    fw.plot_mean_histogram()
+    assert fw._histogram_data is not None
+    assert len(fw.hist_ax.patches) > 0
+
+    # Simulate all layers deselected in the phasor-layer combobox.
+    with patch.object(parent, 'get_selected_layers', return_value=[]):
+        fw._on_image_layer_changed()
+
+    assert fw._histogram_data is None
+    assert len(fw.hist_ax.patches) == 0

--- a/src/napari_phasors/_tests/test_selection_tab.py
+++ b/src/napari_phasors/_tests/test_selection_tab.py
@@ -1748,6 +1748,40 @@ def test_automatic_clustering_apply_gmm(make_viewer_model, qtbot):
     assert layer_name in [layer.name for layer in viewer.layers]
 
 
+def test_automatic_clustering_table_has_no_internal_scrollbar(
+    make_viewer_model, qtbot
+):
+    """The cluster table should never scroll internally.
+
+    It must grow to fit all rows so the tab's own scroll area is what
+    scrolls the table into view, instead of nesting a second scrollbar.
+    """
+    viewer = make_viewer_model()
+    intensity_image_layer = create_image_layer_with_phasors()
+    viewer.add_layer(intensity_image_layer)
+    parent = PlotterWidget(viewer)
+    widget = parent.selection_tab.automatic_clustering_widget
+
+    assert (
+        widget.cluster_table.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+    )
+
+    empty_height = widget.cluster_table.maximumHeight()
+
+    widget.num_clusters_spinbox.setValue(5)
+    widget._apply_clustering()
+
+    assert widget.cluster_table.rowCount() == 5
+    populated_height = widget.cluster_table.maximumHeight()
+    assert populated_height > empty_height
+
+    widget._clear_clusters()
+    # Allow a small tolerance for frame-metric jitter across Qt style
+    # recalculations; the important invariant is that it shrinks back down
+    # instead of staying at the populated height.
+    assert widget.cluster_table.maximumHeight() <= empty_height + 5
+
+
 def test_automatic_clustering_clear_clusters(make_viewer_model, qtbot):
     """Test clearing automatic clusters."""
     viewer = make_viewer_model()

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -427,11 +427,14 @@ class FilterWidget(QWidget):
 
         method = self.threshold_method_combobox.currentText()
         max_value = self.threshold_slider.maximum()
+        min_value = self.threshold_slider.minimum()
 
         if method == "None":
             self._updating_threshold = True
-            self.threshold_slider.setValue((0, max_value))
-            self.min_threshold_edit.setText("0.00")
+            self.threshold_slider.setValue((min_value, max_value))
+            self.min_threshold_edit.setText(
+                f'{min_value / self.threshold_factor:.2f}'
+            )
             self.max_threshold_edit.setText(
                 f'{max_value / self.threshold_factor:.2f}'
             )
@@ -480,28 +483,40 @@ class FilterWidget(QWidget):
         self._refresh_apply_button()
         selected_layers = self.parent_widget.get_selected_layers()
         if not selected_layers:
+            self._clear_histogram()
+            self._histogram_needs_update = False
             return
 
         # Use primary layer metadata for settings restoration
         primary_layer = selected_layers[0]
         layer_metadata = primary_layer.metadata
 
-        # Calculate max mean value across all selected layers
+        # Calculate min and max mean values across all selected layers.
+        # The minimum is used to bound the slider so the lower-threshold line
+        # never falls to the left of the visible histogram range (which happens
+        # when an already-thresholded image is imported and its intensities
+        # start well above zero).
         max_mean_values = []
+        min_mean_values = []
         for layer in selected_layers:
             mean_data = layer.metadata.get("original_mean")
             if mean_data is None:
                 continue
             if 'mask' in layer.metadata:
-                max_val = np.nanmax(mean_data[layer.metadata['mask'] > 0])
+                valid_data = mean_data[layer.metadata['mask'] > 0]
             else:
-                max_val = np.nanmax(mean_data)
-            max_mean_values.append(max_val)
+                valid_data = mean_data
+            valid_data = valid_data[np.isfinite(valid_data)]
+            if valid_data.size == 0:
+                continue
+            max_mean_values.append(np.nanmax(valid_data))
+            min_mean_values.append(np.nanmin(valid_data))
 
         if not max_mean_values:
             return
 
         max_mean_value = max(max_mean_values)
+        min_mean_value = min(min_mean_values)
         if max_mean_value > 0:
             magnitude = int(log10(max_mean_value))
             self.threshold_factor = (
@@ -510,9 +525,13 @@ class FilterWidget(QWidget):
         else:
             self.threshold_factor = 1
 
+        # Scaled slider bounds. ``slider_min`` is the smallest selectable
+        # threshold and doubles as the "no lower threshold" default.
+        slider_min = int(min_mean_value * self.threshold_factor)
         self.threshold_slider.setMaximum(
             ceil(max_mean_value * self.threshold_factor)
         )
+        self.threshold_slider.setMinimum(slider_min)
 
         self._updating_threshold = True
 
@@ -526,12 +545,23 @@ class FilterWidget(QWidget):
             else:
                 self.threshold_method_combobox.setCurrentText("None")
 
-            if "threshold" in settings:
-                lower_val = int(settings["threshold"] * self.threshold_factor)
-                upper_val = int(
-                    (settings.get("threshold_upper") or max_mean_value)
-                    * self.threshold_factor
+            if "threshold" in settings and settings["threshold"] is not None:
+                lower_val = max(
+                    slider_min,
+                    int(settings["threshold"] * self.threshold_factor),
                 )
+                # An absent/None upper is "no limit": pin the handle exactly to
+                # the (ceil-rounded) slider maximum so it is not mistaken for a
+                # user-constrained value and frozen across mask changes.
+                if settings.get("threshold_upper") is not None:
+                    upper_val = min(
+                        int(
+                            settings["threshold_upper"] * self.threshold_factor
+                        ),
+                        self.threshold_slider.maximum(),
+                    )
+                else:
+                    upper_val = self.threshold_slider.maximum()
                 self.threshold_slider.setValue((lower_val, upper_val))
                 self.min_threshold_edit.setText(
                     f'{lower_val / self.threshold_factor:.2f}'
@@ -540,7 +570,7 @@ class FilterWidget(QWidget):
                     f'{upper_val / self.threshold_factor:.2f}'
                 )
             else:
-                lower_val = 0
+                lower_val = slider_min
                 upper_val = self.threshold_slider.maximum()
                 self.threshold_slider.setValue((lower_val, upper_val))
                 self.min_threshold_edit.setText(
@@ -602,7 +632,7 @@ class FilterWidget(QWidget):
             self.median_filter_repetition_spinbox.setValue(1)
             self.wavelet_sigma_spinbox.setValue(2.0)
             self.wavelet_levels_spinbox.setValue(1)
-            lower_val = 0
+            lower_val = slider_min
             upper_val = self.threshold_slider.maximum()
             self.threshold_slider.setValue((lower_val, upper_val))
             self.min_threshold_edit.setText(
@@ -635,7 +665,7 @@ class FilterWidget(QWidget):
 
             if not (
                 current_method == "None"
-                and lower_val == 0
+                and lower_val == self.threshold_slider.minimum()
                 and upper_val == self.threshold_slider.maximum()
             ):
                 self.threshold_method_combobox.setCurrentText("Manual")
@@ -665,8 +695,9 @@ class FilterWidget(QWidget):
             _, upper_val = self.threshold_slider.value()
 
             slider_max = self.threshold_slider.maximum()
+            slider_min = self.threshold_slider.minimum()
             new_slider_value = max(
-                0, min(new_slider_value, upper_val, slider_max)
+                slider_min, min(new_slider_value, upper_val, slider_max)
             )
 
             self._updating_threshold = True
@@ -679,7 +710,7 @@ class FilterWidget(QWidget):
             current_method = self.threshold_method_combobox.currentText()
             if current_method not in ["Manual"] and not (
                 current_method == "None"
-                and new_slider_value == 0
+                and new_slider_value == self.threshold_slider.minimum()
                 and upper_val == self.threshold_slider.maximum()
             ):
                 self.threshold_method_combobox.setCurrentText("Manual")
@@ -715,7 +746,7 @@ class FilterWidget(QWidget):
             current_method = self.threshold_method_combobox.currentText()
             if current_method not in ["Manual"] and not (
                 current_method == "None"
-                and lower_val == 0
+                and lower_val == self.threshold_slider.minimum()
                 and new_slider_value == self.threshold_slider.maximum()
             ):
                 self.threshold_method_combobox.setCurrentText("Manual")
@@ -756,10 +787,26 @@ class FilterWidget(QWidget):
         else:
             self.hist_ax.set_yscale('linear')
 
+    def _clear_histogram(self):
+        """Clear the histogram plot and its threshold overlays.
+
+        Used when no phasor layer is selected so the canvas does not keep
+        showing stale data from a previously selected layer.
+        """
+        self._histogram_data = None
+        self.hist_ax.clear()
+        self.threshold_line_lower = None
+        self.threshold_line_upper = None
+        self.threshold_area_lower = None
+        self.threshold_area_upper = None
+        self.style_histogram_axes()
+        self.hist_fig.canvas.draw_idle()
+
     def plot_mean_histogram(self):
         """Plot the histogram of the mean intensity data from all selected layers."""
         selected_layers = self.parent_widget.get_selected_layers()
         if not selected_layers:
+            self._clear_histogram()
             return
 
         # Collect mean data from all selected layers
@@ -940,8 +987,14 @@ class FilterWidget(QWidget):
         threshold_upper = None
         if threshold_method != "None":
             lower_val, upper_val = self.threshold_slider.value()
-            threshold_lower = lower_val / self.threshold_factor
-            threshold_upper = upper_val / self.threshold_factor
+            # Only persist a bound the user actually constrained. Leaving a
+            # handle at the slider extreme means "no limit" and must be stored
+            # as ``None`` so it can't get frozen to a transient data min/max
+            # (e.g. the reduced max while a mask is active).
+            if lower_val > self.threshold_slider.minimum():
+                threshold_lower = lower_val / self.threshold_factor
+            if upper_val < self.threshold_slider.maximum():
+                threshold_upper = upper_val / self.threshold_factor
 
         current_filter_method = (
             self.filter_method_combobox.currentText().lower()

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -3578,6 +3578,8 @@ class PlotterWidget(QWidget):
             self.components_tab.clear_artists()
         if hasattr(self, 'fret_tab'):
             self.fret_tab.clear_artists()
+        if hasattr(self, 'filter_tab'):
+            self.filter_tab._clear_histogram()
         self._clear_phasor_center_artists()
 
     def _show_tab_artists(self, current_tab):

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -32,6 +32,7 @@ from qtpy.QtWidgets import (
     QLabel,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QSpinBox,
     QStyle,
     QTableWidget,
@@ -1087,6 +1088,13 @@ class AutomaticClusteringWidget(QWidget):
         self.cluster_table.setColumnWidth(6, 60)
         self.cluster_table.setColumnWidth(7, 40)
         self.cluster_table.verticalHeader().setVisible(False)
+        # The table should grow to show every row instead of scrolling
+        # internally — the outer tab scroll area handles scrolling instead.
+        self.cluster_table.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.cluster_table.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Fixed
+        )
+        self._update_cluster_table_height()
         layout.addWidget(self.cluster_table)
 
         # Clear button
@@ -1234,6 +1242,23 @@ class AutomaticClusteringWidget(QWidget):
         if self.parent_widget is not None:
             self.parent_widget.canvas_widget.canvas.draw_idle()
 
+    def _update_cluster_table_height(self):
+        """Resize the table to exactly fit its header and rows.
+
+        The table's own vertical scrollbar is disabled (see ``_setup_ui``) so
+        it never scrolls internally; instead it reports a fixed height that
+        fits all rows, and the enclosing tab's scroll area scrolls the whole
+        table into view.
+        """
+        self.cluster_table.resizeRowsToContents()
+        header_height = self.cluster_table.horizontalHeader().height()
+        rows_height = sum(
+            self.cluster_table.rowHeight(row)
+            for row in range(self.cluster_table.rowCount())
+        )
+        frame = 2 * self.cluster_table.frameWidth()
+        self.cluster_table.setFixedHeight(header_height + rows_height + frame)
+
     def _populate_cluster_table(self):
         """Populate the table with cluster information."""
         self.cluster_table.setRowCount(0)
@@ -1288,6 +1313,8 @@ class AutomaticClusteringWidget(QWidget):
                 lambda _, idx=cluster_idx: self._remove_cluster(idx)
             )
             self.cluster_table.setCellWidget(table_row, 7, remove_button)
+
+        self._update_cluster_table_height()
 
     def _on_cluster_color_changed(self, cluster_idx, new_color):
         """Handle color change for a cluster."""
@@ -1597,6 +1624,7 @@ class AutomaticClusteringWidget(QWidget):
         if not clear_patches_only:
             # Clear table
             self.cluster_table.setRowCount(0)
+            self._update_cluster_table_height()
 
             # Remove all labels layers
             self._clear_all_labels_layers()


### PR DESCRIPTION
## Summary

Fixes three related bugs in the Filter tab's intensity threshold slider and histogram (`FilterWidget`), all stemming from the slider assuming `0` was always the valid minimum and the current data max was always safe to persist as a concrete value:

- **Threshold line off-plot on import**: importing an already-thresholded image (intensities starting well above 0) left the lower-threshold red line to the left of the visible histogram, because the slider minimum was hard-coded to `0` instead of the data's actual minimum.
- **Masked max threshold sticking after mask removal**: leaving the upper threshold unconstrained, then masking the image (which lowers the visible max) and later removing the mask, left the *masked* max frozen instead of restoring the original unconstrained max. This was caused by two compounding issues:
  - `apply_button_clicked` persisted the *current* data max as a concrete `threshold_upper` even when the user never touched the upper handle.
  - Even after fixing that, the restore logic used `int(max * factor)` for the upper bound while the slider's own maximum used `ceil(max * factor)`, so an unconstrained handle could land one tick below the maximum and be mistaken for a user-set value.
- **Stale histogram after deselecting all layers**: unchecking every phasor layer in the main combobox left the last-plotted histogram and threshold lines on screen instead of clearing the plot.

## Changes

- `filter_tab.py`:
  - Track the data minimum alongside the max when computing slider bounds (`slider_min`), and use it as the slider's `minimum()` instead of hard-coded `0`, keeping the "no lower threshold" default and restore logic consistent with the actual data range.
  - When restoring settings, pin an unconstrained (`None`) upper threshold exactly to `threshold_slider.maximum()` instead of recomputing it from the data max, so it can't drift below the maximum and get mistaken for a constraint.
  - `apply_button_clicked` now stores `None` for a threshold handle left at its slider extreme (min or max) instead of the current data bound, so an unconstrained threshold can't get "frozen" to a transient value (e.g. a mask-reduced max).
  - Added `_clear_histogram()` to reset the histogram plot, threshold lines, and shaded regions when no phasor layer is selected; wired into `plot_mean_histogram()` and `_on_image_layer_changed()`.
- `plotter.py`:
  - `_clear_all_tab_artists()` now also clears the filter tab's histogram when all phasor layers are deselected.
- `test_filter_tab.py`: added regression tests covering all three fixes (slider minimum tracking data min, unconstrained upper pinned to slider maximum, full mask add/remove round-trip restoring the original max, and histogram clearing on empty selection).