### PR TITLE
Fix components layer renaming bug and refactor UI

### DIFF
--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -1159,13 +1159,14 @@ def test_components_histogram_multi_layer_linear_projection(
     comp_widget.update_component_histogram()
 
     # All selected layers are pooled into a single merged histogram (rather
-    # than a per-layer mean +/- SD that looks like just one layer).
-    assert set(comp_widget.histogram_widget._datasets.keys()) == {"Layer"}
+    # than a per-layer mean +/- SD that looks like just one layer). The pooled
+    # dataset is named after the analysed component, not the intensity image.
+    assert set(comp_widget.histogram_widget._datasets.keys()) == {name1}
     assert comp_widget.histogram_widget._show_sd is False
 
     # The range slider clips every layer and keeps the merged histogram.
     comp_widget._on_fraction_range_changed(0.2, 0.8)
-    assert set(comp_widget.histogram_widget._datasets.keys()) == {"Layer"}
+    assert set(comp_widget.histogram_widget._datasets.keys()) == {name1}
 
     # Early returns: an empty and an unresolved selection are both no-ops.
     comp_widget.histogram_component_combobox.blockSignals(True)

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -1158,15 +1158,18 @@ def test_components_histogram_multi_layer_linear_projection(
     comp_widget.histogram_component_combobox.setCurrentText(name1)
     comp_widget.update_component_histogram()
 
-    # All selected layers are pooled into a single merged histogram (rather
-    # than a per-layer mean +/- SD that looks like just one layer). The pooled
-    # dataset is named after the analysed component, not the intensity image.
-    assert set(comp_widget.histogram_widget._datasets.keys()) == {name1}
-    assert comp_widget.histogram_widget._show_sd is False
+    # Each selected layer feeds its own dataset (as in the FRET tab), so the
+    # Merged / Individual layers / Grouped display modes and per-row
+    # statistics all work. Rows are named after the analysis fraction layers.
+    expected_keys = {
+        f"{name1} fractions: layer_a",
+        f"{name1} fractions: layer_b",
+    }
+    assert set(comp_widget.histogram_widget._datasets.keys()) == expected_keys
 
-    # The range slider clips every layer and keeps the merged histogram.
+    # The range slider clips every layer and keeps the per-layer datasets.
     comp_widget._on_fraction_range_changed(0.2, 0.8)
-    assert set(comp_widget.histogram_widget._datasets.keys()) == {name1}
+    assert set(comp_widget.histogram_widget._datasets.keys()) == expected_keys
 
     # Early returns: an empty and an unresolved selection are both no-ops.
     comp_widget.histogram_component_combobox.blockSignals(True)
@@ -2999,3 +3002,258 @@ def test_draw_components_overlay_draws_fraction_histogram():
         mock_draw.assert_called_once()
     finally:
         plt.close(fig)
+
+
+def _setup_component_fit(comp, coords=(("0.2", "0.1"), ("0.8", "0.5"))):
+    """Configure components and run a Component Fit analysis."""
+    comp.analysis_type_combo.setCurrentText("Component Fit")
+    for i, (g, s) in enumerate(coords):
+        comp.components[i].g_edit.setText(g)
+        comp.components[i].s_edit.setText(s)
+        comp._on_component_coords_changed(i)
+    comp._run_analysis()
+
+
+def _setup_two_image_layers(make_viewer_model):
+    """Two phasor image layers plus a plotter, for multi-layer tests."""
+    viewer = make_viewer_model()
+    layer_a = create_image_layer_with_phasors()
+    layer_a.name = "img_a"
+    layer_b = create_image_layer_with_phasors()
+    layer_b.name = "img_b"
+    layer_a.metadata["settings"] = {"frequency": 80.0}
+    layer_b.metadata["settings"] = {"frequency": 80.0}
+    viewer.add_layer(layer_a)
+    viewer.add_layer(layer_b)
+    parent = PlotterWidget(viewer)
+    comp = parent.components_tab
+    parent.tab_widget.setCurrentWidget(comp)
+    return viewer, layer_a, layer_b, parent, comp
+
+
+def test_component_fit_rename_replaces_layers(make_viewer_model, qtbot):
+    """Renaming components between runs relabels the fraction layers instead
+    of leaving stale default-named duplicates behind."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_component_fit(comp)
+    first_run = sorted(
+        lyr.name for lyr in viewer.layers if " fraction: " in lyr.name
+    )
+    assert len(first_run) == 2
+
+    comp.components[0].name_edit.setText("Alpha")
+    comp._on_component_name_changed(0)
+    comp.components[1].name_edit.setText("Beta")
+    comp._on_component_name_changed(1)
+    comp._run_analysis()
+
+    second_run = sorted(
+        lyr.name for lyr in viewer.layers if " fraction: " in lyr.name
+    )
+    assert len(second_run) == 2, second_run
+    assert all("Alpha" in n or "Beta" in n for n in second_run)
+    assert not any(
+        "Component 1" in n or "Component 2" in n for n in second_run
+    )
+
+
+def test_manually_renamed_fraction_layer_updated_in_place(
+    make_viewer_model, qtbot
+):
+    """A manually renamed fraction layer is matched by its metadata tag on
+    re-run: data updates in place, the custom name is kept, no duplicate."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_component_fit(comp)
+
+    tagged = [
+        lyr
+        for lyr in viewer.layers
+        if lyr.metadata.get('phasor_component_fraction')
+    ]
+    assert len(tagged) == 2
+    target = tagged[1]
+    assert target.metadata['phasor_component_fraction']['component_index'] == 1
+    target.name = "MyRenamedFractions"
+    data_before = np.array(target.data, copy=True)
+
+    # Nudge a component and re-run: the renamed layer must be found via
+    # _find_component_fraction_layer's tag path and replaced in place.
+    comp.components[1].g_edit.setText("0.75")
+    comp._on_component_coords_changed(1)
+    comp._run_analysis()
+
+    names = [lyr.name for lyr in viewer.layers]
+    assert "MyRenamedFractions" in names
+    tagged_after = [
+        lyr
+        for lyr in viewer.layers
+        if lyr.metadata.get('phasor_component_fraction')
+    ]
+    assert len(tagged_after) == 2, [lyr.name for lyr in tagged_after]
+    renamed = viewer.layers["MyRenamedFractions"]
+    assert (
+        renamed.metadata['phasor_component_fraction']['component_index'] == 1
+    )
+    assert not np.array_equal(renamed.data, data_before)
+
+
+def test_source_rename_updates_fraction_tags(make_viewer_model, qtbot):
+    """rename_layer keeps the metadata tag's source_layer in sync, including
+    for fraction layers the user renamed manually."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_component_fit(comp)
+    fracs = [
+        lyr
+        for lyr in viewer.layers
+        if lyr.metadata.get('phasor_component_fraction')
+    ]
+    fracs[0].name = "CustomFrac"
+
+    old = layer.name
+    comp.rename_layer(old, "renamed_source")
+    layer.name = "renamed_source"
+
+    for lyr in [viewer.layers["CustomFrac"], fracs[1]]:
+        tag = lyr.metadata['phasor_component_fraction']
+        assert tag['source_layer'] == "renamed_source", (lyr.name, tag)
+    # Default-named layer's name suffix followed the source rename too.
+    assert fracs[1].name.endswith(" fraction: renamed_source")
+
+    # Re-run: the custom-named layer is still matched (no duplicate).
+    comp.components[1].g_edit.setText("0.75")
+    comp._on_component_coords_changed(1)
+    comp._run_analysis()
+    tagged = [
+        lyr
+        for lyr in viewer.layers
+        if lyr.metadata.get('phasor_component_fraction')
+    ]
+    assert len(tagged) == 2, [lyr.name for lyr in tagged]
+    assert "CustomFrac" in [lyr.name for lyr in viewer.layers]
+
+
+def test_renamed_fraction_layer_stays_in_histogram_combobox(
+    make_viewer_model, qtbot
+):
+    """Discovery and resolution are metadata-aware: a renamed fraction layer
+    keeps its component listed and selectable in the histogram combobox."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    _setup_component_fit(comp)
+
+    frac2 = comp._get_fraction_layers_for_component("Component 2")
+    target = next(iter(frac2.values()))
+    target.name = "SomethingCustom"
+
+    assert "Component 2" in comp._get_component_names_from_fraction_layers()
+    resolved = comp._get_fraction_layers_for_component("Component 2")
+    assert any(lyr.name == "SomethingCustom" for lyr in resolved.values())
+
+    comp._update_histogram_combobox()
+    assert comp.histogram_component_combobox.findText("Component 2") >= 0
+    comp.histogram_component_combobox.setCurrentText("Component 2")
+    comp.update_component_histogram()
+    assert list(comp.histogram_widget._datasets.keys()) == ["SomethingCustom"]
+
+
+def test_component_display_name_from_tag(make_viewer_model, qtbot):
+    """Unit checks for the tag → display-name resolution helper."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    # Non-dict tags resolve to None.
+    assert comp._component_display_name_from_tag(None) is None
+    assert comp._component_display_name_from_tag("bogus") is None
+    # Default name when the source layer has no custom component name.
+    tag = {'source_layer': layer.name, 'component_index': 1}
+    assert comp._component_display_name_from_tag(tag) == "Component 2"
+    # Custom name from the source layer's component settings.
+    _setup_component_fit(comp)
+    comp.components[1].name_edit.setText("Bound")
+    comp._on_component_name_changed(1)
+    assert comp._component_display_name_from_tag(tag) == "Bound"
+    # Unknown component index without a source falls back to the default.
+    assert (
+        comp._component_display_name_from_tag({'component_index': 4})
+        == "Component 5"
+    )
+
+
+def test_find_component_fraction_layer_paths(make_viewer_model, qtbot):
+    """_find_component_fraction_layer matches by tag, falls back to the
+    default name, and returns None when nothing matches."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    assert (
+        comp._find_component_fraction_layer(layer.name, 0, "missing") is None
+    )
+    _setup_component_fit(comp)
+    default_name = f"Component 1 fraction: {layer.name}"
+    found = comp._find_component_fraction_layer(layer.name, 0, default_name)
+    assert found is not None and found.name == default_name
+    # Tag path: still found after a manual rename.
+    found.name = "Camouflaged"
+    refound = comp._find_component_fraction_layer(layer.name, 0, default_name)
+    assert refound is not None and refound.name == "Camouflaged"
+    # Fallback path: an untagged layer matching the default name is found.
+    del refound.metadata['phasor_component_fraction']
+    refound.name = default_name
+    fallback = comp._find_component_fraction_layer(layer.name, 0, default_name)
+    assert fallback is not None and fallback.name == default_name
+
+
+def test_plot_settings_dialog_histogram_group_disabled_in_component_fit(
+    make_viewer_model, qtbot
+):
+    """The fraction-histogram overlay group is only enabled for a
+    two-component Linear Projection."""
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    comp.analysis_type_combo.setCurrentText("Linear Projection")
+    comp._open_plot_settings_dialog()
+    assert comp.fraction_histogram_checkbox.isEnabled()
+    comp.plot_dialog.close()
+    comp.plot_dialog = None
+
+    comp.analysis_type_combo.setCurrentText("Component Fit")
+    comp._open_plot_settings_dialog()
+    assert not comp.fraction_histogram_checkbox.isEnabled()
+    comp.plot_dialog.close()
+
+
+def test_component_fit_multi_layer_per_row_datasets(make_viewer_model, qtbot):
+    """Multi-image Component Fit feeds one histogram dataset per image,
+    labelled after the analysis fraction layers."""
+    viewer, layer_a, layer_b, parent, comp = _setup_two_image_layers(
+        make_viewer_model
+    )
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_a, layer_b]
+    ):
+        _setup_component_fit(comp)
+    comp.histogram_component_combobox.setCurrentText("Component 1")
+    comp.update_component_histogram()
+    assert set(comp.histogram_widget._datasets.keys()) == {
+        "Component 1 fraction: img_a",
+        "Component 1 fraction: img_b",
+    }
+
+
+def test_linear_projection_second_component_per_row(make_viewer_model, qtbot):
+    """The Linear Projection second component (fraction = 1 - first) gets
+    per-image datasets with virtual '<component> fractions: <image>' labels."""
+    viewer, layer_a, layer_b, parent, comp = _setup_two_image_layers(
+        make_viewer_model
+    )
+    comp.analysis_type_combo.setCurrentText("Linear Projection")
+    for i, (g, s) in enumerate([("0.2", "0.1"), ("0.8", "0.5")]):
+        comp.components[i].g_edit.setText(g)
+        comp.components[i].s_edit.setText(s)
+        comp._on_component_coords_changed(i)
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_a, layer_b]
+    ):
+        comp._run_analysis()
+    name1, name2 = comp._linear_projection_component_names()
+    comp._update_histogram_combobox()
+    comp.histogram_component_combobox.setCurrentText(name2)
+    comp.update_component_histogram()
+    assert set(comp.histogram_widget._datasets.keys()) == {
+        f"{name2} fractions: img_a",
+        f"{name2} fractions: img_b",
+    }

--- a/src/napari_phasors/_tests/test_components_tab.py
+++ b/src/napari_phasors/_tests/test_components_tab.py
@@ -3257,3 +3257,48 @@ def test_linear_projection_second_component_per_row(make_viewer_model, qtbot):
         f"{name2} fractions: img_a",
         f"{name2} fractions: img_b",
     }
+
+
+def test_switch_to_linear_projection_hides_stale_component_fit(
+    make_viewer_model, qtbot
+):
+    viewer, layer, parent, comp = _setup_components(make_viewer_model)
+    # 3-component fit -> Component 1/2/3 fraction layers (tagged).
+    comp._add_component()
+    _setup_component_fit(
+        comp, coords=(("0.2", "0.1"), ("0.5", "0.3"), ("0.8", "0.5"))
+    )
+    assert len(comp.fraction_layers) == 3
+
+    # In Component Fit mode all three components are offered.
+    comp._update_histogram_combobox()
+    fit_names = [
+        comp.histogram_component_combobox.itemText(i)
+        for i in range(comp.histogram_component_combobox.count())
+    ]
+    assert {"Component 1", "Component 2", "Component 3"} <= set(fit_names)
+
+    # Drop the 3rd component so Linear Projection becomes available, switch,
+    # and run it. The component-fit fraction layers remain in the viewer.
+    comp._remove_component()
+    comp._update_analysis_options()
+    comp.analysis_type_combo.setCurrentText("Linear Projection")
+    assert comp.analysis_type == "Linear Projection"
+    comp._run_analysis()
+
+    comp._update_histogram_combobox()
+    lp_names = [
+        comp.histogram_component_combobox.itemText(i)
+        for i in range(comp.histogram_component_combobox.count())
+    ]
+    assert "Component 1" in lp_names
+    assert "Component 2" in lp_names
+    assert "Component 3" not in lp_names
+
+    # Component 2 must resolve to the complementary (invert=True) using the
+    # linear-projection Component 1 layer, NOT the stale component-fit layer.
+    fmap, invert = comp._resolve_histogram_component("Component 2")
+    assert invert is True, "Component 2 should be the complementary fraction"
+    only_layer = next(iter(fmap.values()))
+    assert only_layer.metadata.get('phasor_component_fraction') is None
+    assert only_layer.name.startswith("Component 1 fractions: ")

--- a/src/napari_phasors/_tests/test_fret_tab.py
+++ b/src/napari_phasors/_tests/test_fret_tab.py
@@ -2353,3 +2353,29 @@ def test_draw_fret_trajectory_overlay_uses_jet_colormap_by_default():
         assert len(ax.patches) == 2
     finally:
         plt.close(fig)
+
+
+def test_single_layer_histogram_named_after_fret_layer(
+    make_viewer_model, qtbot
+):
+    """With one selected layer the histogram dataset is labelled with the
+    FRET output layer's name, not a generic 'Layer'."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    widget = parent.fret_tab
+
+    test_layer = create_image_layer_with_phasors()
+    test_layer.name = "test_layer"
+    viewer.add_layer(test_layer)
+
+    widget.donor_line_edit.setText("2.0")
+    widget.frequency_input.setText("80")
+    widget.calculate_fret_efficiency_button.click()
+
+    fret_layer_name = "FRET efficiency: test_layer"
+    assert fret_layer_name in [layer.name for layer in viewer.layers]
+    assert list(widget.histogram_widget._datasets.keys()) == [fret_layer_name]
+
+    # The range-changed path re-labels the same way.
+    widget._on_fret_range_changed(0.1, 0.9)
+    assert list(widget.histogram_widget._datasets.keys()) == [fret_layer_name]

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -2311,3 +2311,107 @@ def test_get_mesh_grid_resolution_exception_fallback(make_viewer_model, qtbot):
     ax.get_window_extent.side_effect = RuntimeError("boom")
 
     assert mapping_widget._get_mesh_grid_resolution(ax) == 1000
+
+
+def test_histogram_datasets_named_after_output_layers(
+    make_viewer_model, qtbot
+):
+    """Histogram datasets are keyed by the analysis output layer name
+    (e.g. 'Apparent Phase Lifetime: <image>'), not the intensity image."""
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    mt = parent.phasor_mapping_tab
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+    mt._on_image_layer_changed()
+    mt.frequency_input.setText("80.0")
+    mt._on_frequency_changed()
+    mt.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
+    mt._on_calculate_lifetime_clicked()
+
+    keys = list(mt.histogram_widget._datasets.keys())
+    layer_names = {lyr.name for lyr in viewer.layers}
+    assert keys, "histogram should have a dataset"
+    assert keys[0] != layer.name
+    assert keys[0] in layer_names, (keys, layer_names)
+    parent.deleteLater()
+
+
+def test_histogram_multi_layer_datasets_named_after_output_layers(
+    make_viewer_model, qtbot
+):
+    """With multiple selected layers, each output layer feeds its own
+    histogram dataset via update_multi_data."""
+    viewer = make_viewer_model()
+    layer_1 = create_image_layer_with_phasors()
+    layer_1.name = "img_one"
+    layer_2 = create_image_layer_with_phasors()
+    layer_2.name = "img_two"
+    viewer.add_layer(layer_1)
+    viewer.add_layer(layer_2)
+    parent = PlotterWidget(viewer)
+    mt = parent.phasor_mapping_tab
+    with patch.object(
+        parent, "get_selected_layers", return_value=[layer_1, layer_2]
+    ):
+        mt.frequency_input.setText("80.0")
+        mt._on_frequency_changed()
+        mt.lifetime_type_combobox.setCurrentText("Apparent Phase Lifetime")
+        mt._on_calculate_lifetime_clicked()
+
+    keys = set(mt.histogram_widget._datasets.keys())
+    assert keys == {
+        "Apparent Phase Lifetime: img_one",
+        "Apparent Phase Lifetime: img_two",
+    }, keys
+    parent.deleteLater()
+
+
+def test_coloring_box_visibility_follows_output_mode(make_viewer_model, qtbot):
+    """The Coloring section is hidden for Lifetime output and shown for
+    Phase / Modulation."""
+    viewer = make_viewer_model()
+    parent = PlotterWidget(viewer)
+    mt = parent.phasor_mapping_tab
+
+    mt.output_mode_combobox.setCurrentText("Lifetime")
+    assert mt.coloring_box.isVisible() is False or mt.coloring_box.isHidden()
+
+    mt.output_mode_combobox.setCurrentText("Phase")
+    assert not mt.coloring_box.isHidden()
+
+    mt.output_mode_combobox.setCurrentText("Modulation")
+    assert not mt.coloring_box.isHidden()
+
+    mt.output_mode_combobox.setCurrentText("Lifetime")
+    assert mt.coloring_box.isHidden()
+    parent.deleteLater()
+
+
+def test_restore_on_layer_change_refreshes_primary_button(
+    make_viewer_model, qtbot
+):
+    """The deferred restore path re-evaluates the primary button so it shows
+    the green ready style when the frequency was restored from metadata."""
+    from napari_phasors._utils import (
+        _PRIMARY_BUTTON_BLOCKED_QSS,
+        _PRIMARY_BUTTON_READY_QSS,
+    )
+
+    viewer = make_viewer_model()
+    layer = create_image_layer_with_phasors()
+    layer.metadata["settings"] = {"frequency": 80.0}
+    viewer.add_layer(layer)
+    parent = PlotterWidget(viewer)
+    mt = parent.phasor_mapping_tab
+
+    # Force a stale blocked style, then run the deferred restore path.
+    mt.calculate_lifetime_button.setStyleSheet(_PRIMARY_BUTTON_BLOCKED_QSS)
+    parent.image_layer_with_phasor_features_combobox.setCurrentText(layer.name)
+    mt._restore_on_layer_change()
+    assert mt._mapping_validation() is None
+    assert (
+        mt.calculate_lifetime_button.styleSheet() == _PRIMARY_BUTTON_READY_QSS
+    )
+    parent.deleteLater()

--- a/src/napari_phasors/_tests/test_phasor_mapping_tab.py
+++ b/src/napari_phasors/_tests/test_phasor_mapping_tab.py
@@ -2263,10 +2263,9 @@ def test_draw_phasor_mesh_falls_back_when_interpolation_stage_unsupported(
 def test_get_output_colormap_name_branches():
     """_get_output_colormap_name returns the colormap per output type and
     falls back to 'plasma' for lifetime-style (or any other) outputs."""
-    assert PhasorMappingWidget._get_output_colormap_name("Phase") == "jet"
+    assert PhasorMappingWidget._get_output_colormap_name("Phase") == "cool"
     assert (
-        PhasorMappingWidget._get_output_colormap_name("Modulation")
-        == "viridis"
+        PhasorMappingWidget._get_output_colormap_name("Modulation") == "PiYG"
     )
     assert (
         PhasorMappingWidget._get_output_colormap_name("Normal Lifetime")

--- a/src/napari_phasors/_tests/test_plotter.py
+++ b/src/napari_phasors/_tests/test_plotter.py
@@ -423,15 +423,16 @@ def test_plot_settings_tab_labels_wrap_and_scroll_policy(
     # ~240px-wide floor on the settings grid's label column.
     assert plotter.plotter_inputs_widget.label_5.wordWrap()
 
-    # "Load and Apply Settings from:" (above the Layer/OME-TIFF buttons)
-    # must also wrap rather than force the import row wide.
+    # "Load and Apply Settings from:" sits inline with the Layer/OME-TIFF
+    # buttons on a single row (bold, no title), so it is intentionally not
+    # word-wrapped. The scroll policy below keeps that row from forcing the
+    # tab permanently wide.
     import_labels = [
         label
         for label in plotter.settings_tab.findChildren(QLabel)
         if label.text() == "Load and Apply Settings from:"
     ]
     assert len(import_labels) == 1
-    assert import_labels[0].wordWrap()
 
     # The inner scroll area around the settings grid must show its
     # horizontal scrollbar only when needed, not be permanently suppressed.

--- a/src/napari_phasors/_tests/test_plotter_features.py
+++ b/src/napari_phasors/_tests/test_plotter_features.py
@@ -1855,3 +1855,77 @@ def test_dock_helpers_are_safe_without_window(make_viewer_model):
     # No hosting dock -> the parent walk returns None and split returns early.
     assert plotter._find_plotter_dock() is None
     plotter._split_analysis_below_plotter()
+
+
+def test_canvas_size_for_ratio_overhead_model(make_viewer_model, qtbot):
+    """The canvas is sized from the aspect-locked axes plus fixed pixel
+    overheads, so the plot fills the container tightly."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+
+    # Give the canvas a realistic drawn size so the overhead path runs.
+    plotter.canvas_widget.resize(520, 470)
+    plotter.canvas_widget.canvas.resize(500, 400)
+
+    w, h = plotter._canvas_size_for_ratio(1.0, 800, 700)
+    assert 0 < w <= 800
+    assert 0 < h <= 700
+    # The horizontal overhead (y-label + colorbar) exceeds the vertical one,
+    # so a square plot needs a wider-than-tall canvas.
+    assert w > h
+
+    # Semicircle ratio also stays within the available box.
+    w2, h2 = plotter._canvas_size_for_ratio(1.5, 800, 700)
+    assert 0 < w2 <= 800 and 0 < h2 <= 700
+
+
+def test_canvas_size_for_ratio_fallbacks(make_viewer_model, qtbot):
+    """Aspect-fit fallbacks: undrawn figure, no room for the axes, and a
+    canvas that cannot report numeric sizes."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+
+    def fit(ratio, aw, ah):
+        if aw / ah >= ratio:
+            return ah * ratio, ah
+        return aw, aw / ratio
+
+    # fig_w <= 0 → plain aspect fit (wide and tall containers).
+    with patch.object(plotter.canvas_widget.canvas, 'width', return_value=0):
+        assert plotter._canvas_size_for_ratio(1.0, 900, 300) == fit(
+            1.0, 900, 300
+        )
+        assert plotter._canvas_size_for_ratio(1.5, 300, 900) == fit(
+            1.5, 300, 900
+        )
+
+    # Available space smaller than the overheads → aspect fit.
+    plotter.canvas_widget.canvas.resize(500, 400)
+    assert plotter._canvas_size_for_ratio(1.0, 60, 40) == fit(1.0, 60, 40)
+
+    # Non-numeric canvas size (e.g. mocked in tests) → aspect fit.
+    with patch.object(
+        plotter.canvas_widget.canvas, 'width', return_value="bogus"
+    ):
+        assert plotter._canvas_size_for_ratio(1.0, 900, 300) == fit(
+            1.0, 900, 300
+        )
+
+
+def test_resize_canvas_to_available_space_sets_fixed_size(
+    make_viewer_model, qtbot
+):
+    """_resize_canvas_to_available_space fixes the canvas within its
+    container using the computed target size."""
+    viewer = make_viewer_model()
+    plotter = PlotterWidget(viewer)
+    qtbot.addWidget(plotter)
+
+    plotter.canvas_container.resize(500, 400)
+    plotter.canvas_widget.canvas.resize(480, 350)
+    plotter._resize_canvas_to_available_space()
+
+    assert 0 < plotter.canvas_widget.width() <= 500
+    assert 0 < plotter.canvas_widget.height() <= 400

--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -1970,3 +1970,19 @@ def test_popout_window_mixin_with_napari_viewer(qtbot):
 
     assert widget.viewer.window.removed_widget is widget
     assert widget.parent() is widget.viewer.window._qt_window
+
+
+def test_update_data_label_parameter(qtbot):
+    """update_data stores the dataset under the given label (defaulting to
+    'Layer'), which drives the statistics Name column."""
+    widget = HistogramWidget(bins=8)
+    qtbot.addWidget(widget)
+    data = np.linspace(0.0, 1.0, 50)
+
+    widget.update_data(data)
+    assert list(widget._datasets.keys()) == ["Layer"]
+    assert list(widget._counts_per_dataset.keys()) == ["Layer"]
+
+    widget.update_data(data, label="Lifetime: my image")
+    assert list(widget._datasets.keys()) == ["Lifetime: my image"]
+    assert list(widget._counts_per_dataset.keys()) == ["Lifetime: my image"]

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -100,26 +100,6 @@ def make_section(title):
     return box, layout
 
 
-def make_flat_section(title):
-    """Return ``(container, layout)`` for a borderless titled section.
-
-    Like :func:`make_section` but without the ``QGroupBox`` frame, so the
-    section takes less vertical space (no border, title margin or padding).
-    A bold title label sits directly above the content layout. Used for the
-    first section of a tab, where the frame is redundant.
-    """
-    container = QWidget()
-    outer = QVBoxLayout(container)
-    outer.setContentsMargins(0, 0, 0, 0)
-    outer.setSpacing(2)
-    label = QLabel(title)
-    label.setStyleSheet("font-weight: 600;")
-    outer.addWidget(label)
-    layout = QVBoxLayout()
-    outer.addLayout(layout)
-    return container, layout
-
-
 class CurrentPageStackedWidget(QStackedWidget):
     """A ``QStackedWidget`` that sizes itself to the visible page only.
 

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -100,6 +100,26 @@ def make_section(title):
     return box, layout
 
 
+def make_flat_section(title):
+    """Return ``(container, layout)`` for a borderless titled section.
+
+    Like :func:`make_section` but without the ``QGroupBox`` frame, so the
+    section takes less vertical space (no border, title margin or padding).
+    A bold title label sits directly above the content layout. Used for the
+    first section of a tab, where the frame is redundant.
+    """
+    container = QWidget()
+    outer = QVBoxLayout(container)
+    outer.setContentsMargins(0, 0, 0, 0)
+    outer.setSpacing(2)
+    label = QLabel(title)
+    label.setStyleSheet("font-weight: 600;")
+    outer.addWidget(label)
+    layout = QVBoxLayout()
+    outer.addLayout(layout)
+    return container, layout
+
+
 class CurrentPageStackedWidget(QStackedWidget):
     """A ``QStackedWidget`` that sizes itself to the visible page only.
 
@@ -2908,7 +2928,7 @@ class HistogramWidget(QWidget):
                 self._render()
             self.dataChanged.emit()
 
-    def update_data(self, data: np.ndarray) -> None:
+    def update_data(self, data: np.ndarray, label: str = "Layer") -> None:
         """Compute histogram from *data* and render.
 
         NaN/Inf values are always excluded. Non-positive values are
@@ -2920,6 +2940,10 @@ class HistogramWidget(QWidget):
         ----------
         data : np.ndarray
             Scalar data array (any shape – will be flattened internally).
+        label : str, optional
+            Name shown for this dataset (e.g. in the statistics Name
+            column). Defaults to ``"Layer"``; callers should pass the
+            analyzed image layer's name so it matches the multi-layer view.
         """
         valid = self._filter_valid_values(data)
 
@@ -2933,7 +2957,7 @@ class HistogramWidget(QWidget):
             self.dataChanged.emit()
             return
 
-        self._datasets = {"Layer": valid}
+        self._datasets = {label: valid}
         self._raw_valid_data = valid
         self._previous_dataset_count = 0
 
@@ -2943,7 +2967,7 @@ class HistogramWidget(QWidget):
         )
         self.bin_centers = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2
 
-        self._counts_per_dataset = {"Layer": self.counts}
+        self._counts_per_dataset = {label: self.counts}
 
         self._render()
         self._settings_button.setEnabled(True)

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -30,7 +30,6 @@ from ._utils import (
     REFERENCE_LIFETIMES_SOURCE,
     analysis_section_stylesheet,
     apply_filter_and_threshold,
-    make_flat_section,
     make_section,
     reference_lifetimes,
     setup_primary_button,
@@ -186,13 +185,16 @@ class CalibrationWidget(QWidget):
         layout = QVBoxLayout(widget)
 
         # Calibration reference -------------------------------------------
-        # Borderless to save vertical space (it is the first section).
-        reference_box, reference_layout = make_flat_section(
-            "Calibration reference"
-        )
+        # Borderless, no section title: just a bold label + the layer combobox.
+        reference_box = QWidget()
+        reference_layout = QVBoxLayout(reference_box)
+        reference_layout.setContentsMargins(0, 0, 0, 0)
         reference_grid = QGridLayout()
         reference_layout.addLayout(reference_grid)
         widget.calibration_layer_label_widget = QLabel("Calibration Layer:")
+        widget.calibration_layer_label_widget.setStyleSheet(
+            "font-weight: 600;"
+        )
         widget.calibration_layer_combobox = QComboBox()
         reference_grid.addWidget(widget.calibration_layer_label_widget, 0, 0)
         reference_grid.addWidget(widget.calibration_layer_combobox, 0, 1)

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -30,6 +30,7 @@ from ._utils import (
     REFERENCE_LIFETIMES_SOURCE,
     analysis_section_stylesheet,
     apply_filter_and_threshold,
+    make_flat_section,
     make_section,
     reference_lifetimes,
     setup_primary_button,
@@ -185,7 +186,10 @@ class CalibrationWidget(QWidget):
         layout = QVBoxLayout(widget)
 
         # Calibration reference -------------------------------------------
-        reference_box, reference_layout = make_section("Calibration reference")
+        # Borderless to save vertical space (it is the first section).
+        reference_box, reference_layout = make_flat_section(
+            "Calibration reference"
+        )
         reference_grid = QGridLayout()
         reference_layout.addLayout(reference_grid)
         widget.calibration_layer_label_widget = QLabel("Calibration Layer:")

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -53,6 +53,7 @@ from ._utils import (
     CheckableComboBox,
     HistogramWidget,
     analysis_section_stylesheet,
+    make_flat_section,
     make_section,
     required_component_harmonics,
     setup_primary_button,
@@ -398,16 +399,19 @@ class ComponentsWidget(QWidget):
         layout = QVBoxLayout()
         content_widget.setLayout(layout)
 
-        # Analysis type section
-        analysis_box, analysis_box_layout = make_section("Analysis type")
+        # Analysis method section. Borderless to save vertical space (it is
+        # the first section).
+        analysis_box, analysis_box_layout = make_flat_section(
+            "Analysis Method"
+        )
         analysis_layout = QHBoxLayout()
-        analysis_layout.addWidget(QLabel("Analysis Type:"))
+        analysis_layout.addWidget(QLabel("Analysis Method:"))
         self.analysis_type_combo = QComboBox()
         self.analysis_type_combo.currentTextChanged.connect(
             self._on_analysis_type_changed
         )
         self.analysis_type_combo.setToolTip(
-            "Select the type of component analysis to perform."
+            "Select the method of component analysis to perform."
         )
         analysis_layout.addWidget(self.analysis_type_combo)
         analysis_layout.addStretch()
@@ -469,7 +473,7 @@ class ComponentsWidget(QWidget):
             self.calculate_button,
             self._components_validation,
             self._run_analysis,
-            ready_tooltip="Run the selected analysis type on the defined "
+            ready_tooltip="Run the selected analysis method on the defined "
             "components.",
         )
         layout.addWidget(self.calculate_button)
@@ -1808,6 +1812,17 @@ class ComponentsWidget(QWidget):
             "magnitude is the distance from the line.",
         )
         hist_layout.addLayout(hist_offset_row)
+
+        # The fraction histogram overlay is only meaningful for a two-component
+        # Linear Projection. Disable the whole group in Component Fit mode so
+        # its controls cannot be edited when they have no effect.
+        histogram_available = self.analysis_type == "Linear Projection"
+        hist_group.setEnabled(histogram_available)
+        if not histogram_available:
+            hist_group.setToolTip(
+                "Fraction histogram overlay is only available in "
+                "two-component Linear Projection mode."
+            )
         vbox.addWidget(hist_group)
 
         # Buttons
@@ -4839,6 +4854,46 @@ class ComponentsWidget(QWidget):
         self._update_component_colors()
         self.draw_line_between_components()
 
+    def _find_component_fraction_layer(
+        self, source_layer_name, component_index, fallback_name
+    ):
+        """Return the existing Component Fit fraction layer for a component.
+
+        Matches on the ``phasor_component_fraction`` metadata tag (source
+        image + component index) so a layer the user renamed manually is still
+        recognised on the next run and updated in place rather than duplicated.
+        Falls back to the default-name lookup for layers created before the
+        tag existed.
+
+        Parameters
+        ----------
+        source_layer_name : str
+            Name of the analysed image layer.
+        component_index : int
+            Zero-based component index.
+        fallback_name : str
+            Default ``"<component> fraction: <image>"`` name to match when no
+            tagged layer is found.
+
+        Returns
+        -------
+        napari.layers.Image or None
+        """
+        for lyr in self.viewer.layers:
+            if not isinstance(lyr, Image):
+                continue
+            tag = lyr.metadata.get('phasor_component_fraction')
+            if (
+                isinstance(tag, dict)
+                and tag.get('analysis_type') == 'Component Fit'
+                and tag.get('source_layer') == source_layer_name
+                and tag.get('component_index') == component_index
+            ):
+                return lyr
+        if fallback_name in self.viewer.layers:
+            return self.viewer.layers[fallback_name]
+        return None
+
     def _run_component_fit(self):
         """Run multi-component analysis using phasor_component_fit on all selected layers."""
         selected_layers = self.parent_widget.get_selected_layers()
@@ -5024,7 +5079,25 @@ class ComponentsWidget(QWidget):
             for i, (fraction, name) in enumerate(
                 zip(fractions, component_names, strict=False)
             ):
-                fraction_layer_name = f"{name} fraction: {layer.name}"
+                default_name = f"{name} fraction: {layer.name}"
+
+                # Locate a previous fraction layer for this component, matching
+                # on metadata so a manually renamed layer is still recognised.
+                existing_layer = self._find_component_fraction_layer(
+                    layer.name, i, default_name
+                )
+                # Keep the user's custom name if they renamed the layer;
+                # otherwise use (and keep updating to) the default name so
+                # renaming a component still relabels its layer.
+                if (
+                    existing_layer is not None
+                    and not existing_layer.name.endswith(
+                        f" fraction: {layer.name}"
+                    )
+                ):
+                    fraction_layer_name = existing_layer.name
+                else:
+                    fraction_layer_name = default_name
 
                 colormap = None
                 gamma = None
@@ -5039,13 +5112,12 @@ class ComponentsWidget(QWidget):
                     contrast_limits = (0, 1)
                 idx_str = str(i)
 
-                # If the fraction layer is already displayed (the user clicked
-                # the button again), preserve its current colormap, contrast
-                # limits and gamma. This takes precedence over the stored
-                # defaults so manual display tweaks - including colormaps
-                # propagated from other analyzed images - survive a re-display.
-                if fraction_layer_name in self.viewer.layers:
-                    existing_layer = self.viewer.layers[fraction_layer_name]
+                # If the fraction layer already exists (the user clicked the
+                # button again), preserve its current colormap, contrast limits
+                # and gamma. This takes precedence over the stored defaults so
+                # manual display tweaks - including colormaps propagated from
+                # other analyzed images - survive a re-display.
+                if existing_layer is not None:
                     colormap = existing_layer.colormap
                     contrast_limits = existing_layer.contrast_limits
                     gamma = existing_layer.gamma
@@ -5088,6 +5160,12 @@ class ComponentsWidget(QWidget):
                     else:
                         colormap = 'viridis'
 
+                # Remove the previous layer for this component (found via
+                # metadata, so a rename does not leave a duplicate) and any
+                # layer already occupying the target name.
+                if existing_layer is not None:
+                    with contextlib.suppress(ValueError):
+                        self.viewer.layers.remove(existing_layer)
                 with contextlib.suppress(KeyError):
                     self.viewer.layers.remove(
                         self.viewer.layers[fraction_layer_name]
@@ -5099,6 +5177,14 @@ class ComponentsWidget(QWidget):
                     colormap=colormap,
                 )
                 new_layer.metadata['fraction_data_original'] = fraction.copy()
+                # Tag the layer so it can be recognised on the next run even if
+                # the user renames it manually.
+                new_layer.metadata['phasor_component_fraction'] = {
+                    'source_layer': layer.name,
+                    'component_index': i,
+                    'harmonic': current_harmonic,
+                    'analysis_type': 'Component Fit',
+                }
 
                 new_layer.contrast_limits = contrast_limits
                 if gamma is not None:
@@ -5161,6 +5247,29 @@ class ComponentsWidget(QWidget):
                         'gamma'
                     ] = new_layer.gamma
 
+            # Remove any leftover fraction layers from a previous run of this
+            # image that were not recreated this time (e.g. the component count
+            # was reduced, or names changed between runs). A layer belongs to
+            # this image's component fit if it carries the metadata tag or, for
+            # older untagged layers, matches the default name suffix. Keep the
+            # layers we just created (compared by identity so custom-named ones
+            # survive).
+            suffix = f" fraction: {layer.name}"
+            for existing in list(self.viewer.layers):
+                if not isinstance(existing, Image):
+                    continue
+                if existing in self.fraction_layers:
+                    continue
+                tag = existing.metadata.get('phasor_component_fraction')
+                belongs = (
+                    isinstance(tag, dict)
+                    and tag.get('analysis_type') == 'Component Fit'
+                    and tag.get('source_layer') == layer.name
+                ) or existing.name.endswith(suffix)
+                if belongs:
+                    with contextlib.suppress(KeyError, ValueError):
+                        self.viewer.layers.remove(existing)
+
             self._update_component_colors()
 
         except Exception as e:  # noqa: BLE001
@@ -5176,6 +5285,12 @@ class ComponentsWidget(QWidget):
                 if name.endswith(sep + old_name):
                     comp_part = name[: -len(sep + old_name)]
                     layer.name = f"{comp_part}{sep}{new_name}"
+            # Keep the identifying metadata tag in sync too. Matched by tag
+            # (not name) so fraction layers the user renamed manually still
+            # follow their source image.
+            tag = layer.metadata.get('phasor_component_fraction')
+            if isinstance(tag, dict) and tag.get('source_layer') == old_name:
+                tag['source_layer'] = new_name
 
         # Keep each component's remembered phasor-center selection in sync so a
         # renamed layer stays selected instead of being dropped.
@@ -5463,6 +5578,10 @@ class ComponentsWidget(QWidget):
         # Pool the (clipped) data from every selected layer into a single
         # merged histogram so all layers contribute, rather than showing a
         # per-layer mean +/- SD that visually resembles a single layer.
+        # Name the histogram dataset after the analysis (fraction) layer, not
+        # the intensity image layer, matching the statistics Name column to the
+        # created layers (as in the FRET tab). Pooled multi-image data is
+        # labelled with the component's display name.
         if len(clipped_data) > 1:
             pooled = np.concatenate(
                 [
@@ -5470,10 +5589,13 @@ class ComponentsWidget(QWidget):
                     for d in clipped_data.values()
                 ]
             )
-            self.histogram_widget.update_data(pooled)
+            self.histogram_widget.update_data(pooled, label=selected_text)
         else:
+            first_layer = next(iter(fraction_layers_map.values()))
             first_data = next(iter(clipped_data.values()))
-            self.histogram_widget.update_data(first_data)
+            self.histogram_widget.update_data(
+                first_data, label=first_layer.name
+            )
 
         self.draw_line_between_components()
 
@@ -5565,6 +5687,12 @@ class ComponentsWidget(QWidget):
         # Pool the data from every selected layer into a single merged
         # histogram so all layers contribute, rather than showing a per-layer
         # mean +/- SD that visually resembles a single layer.
+        # Name the histogram dataset after the analysis (fraction) layer -
+        # e.g. "Component 2 fraction: <image>" - rather than the intensity
+        # image layer, so the statistics Name column matches the created
+        # layers (as in the FRET tab). Multiple selected images are pooled
+        # into one merged histogram, so it is labelled with the component's
+        # display name.
         if len(fraction_layers_map) > 1:
             pooled_layers = [
                 (
@@ -5574,12 +5702,14 @@ class ComponentsWidget(QWidget):
                 ).ravel()
                 for fl in fraction_layers_map.values()
             ]
-            self.histogram_widget.update_data(np.concatenate(pooled_layers))
+            self.histogram_widget.update_data(
+                np.concatenate(pooled_layers), label=selected_text
+            )
         else:
             data = first_layer.data
             if invert:
                 data = 1.0 - np.asarray(data, dtype=float)
-            self.histogram_widget.update_data(data)
+            self.histogram_widget.update_data(data, label=first_layer.name)
 
         self.histogram_widget.show()
 

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -5509,6 +5509,42 @@ class ComponentsWidget(QWidget):
 
         return {}, False
 
+    def _label_fraction_datasets(
+        self, data_by_image, fraction_layers_map, selected_text, invert
+    ):
+        """Label per-image fraction data after the analysis (fraction) layer.
+
+        Parameters
+        ----------
+        data_by_image : dict
+            ``{image_layer_name: np.ndarray}`` fraction data per source image
+            (already inverted for the Linear Projection second component).
+        fraction_layers_map : dict
+            ``{image_layer_name: napari.layers.Image}`` underlying fraction
+            layers.
+        selected_text : str
+            The component display name selected in the combobox.
+        invert : bool
+            True when showing the Linear Projection second component, whose
+            fraction is ``1 - first`` and has no layer of its own. In that
+            case a virtual ``"<component> fractions: <image>"`` label is
+            built, since the underlying layer belongs to the first component.
+
+        Returns
+        -------
+        dict
+            ``{analysis_layer_name: flattened np.ndarray}``.
+        """
+        labeled = {}
+        for img_name, data in data_by_image.items():
+            if invert:
+                label = f"{selected_text} fractions: {img_name}"
+            else:
+                fl = fraction_layers_map.get(img_name)
+                label = fl.name if fl is not None else img_name
+            labeled[label] = np.asarray(data, dtype=float).ravel()
+        return labeled
+
     def _update_histogram_combobox(self):
         """Populate the component selector comboboxes with fraction layers.
 
@@ -5631,27 +5667,18 @@ class ComponentsWidget(QWidget):
             gamma=first_layer.gamma,
         )
 
-        # Pool the (clipped) data from every selected layer into a single
-        # merged histogram so all layers contribute, rather than showing a
-        # per-layer mean +/- SD that visually resembles a single layer.
-        # Name the histogram dataset after the analysis (fraction) layer, not
-        # the intensity image layer, matching the statistics Name column to the
-        # created layers (as in the FRET tab). Pooled multi-image data is
-        # labelled with the component's display name.
-        if len(clipped_data) > 1:
-            pooled = np.concatenate(
-                [
-                    np.asarray(d, dtype=float).ravel()
-                    for d in clipped_data.values()
-                ]
-            )
-            self.histogram_widget.update_data(pooled, label=selected_text)
+        # Feed the histogram one dataset per selected layer (labelled after
+        # the analysis fraction layer, as in the FRET tab) so the Merged /
+        # Individual layers / Grouped display modes and per-row statistics
+        # all work.
+        per_layer = self._label_fraction_datasets(
+            clipped_data, fraction_layers_map, selected_text, invert
+        )
+        if len(per_layer) > 1:
+            self.histogram_widget.update_multi_data(per_layer)
         else:
-            first_layer = next(iter(fraction_layers_map.values()))
-            first_data = next(iter(clipped_data.values()))
-            self.histogram_widget.update_data(
-                first_data, label=first_layer.name
-            )
+            label, data = next(iter(per_layer.items()))
+            self.histogram_widget.update_data(data, label=label)
 
         self.draw_line_between_components()
 
@@ -5740,32 +5767,26 @@ class ComponentsWidget(QWidget):
                 slider_max=data_max,
             )
 
-        # Pool the data from every selected layer into a single merged
-        # histogram so all layers contribute, rather than showing a per-layer
-        # mean +/- SD that visually resembles a single layer.
-        # Name the histogram dataset after the analysis (fraction) layer -
-        # e.g. "Component 2 fraction: <image>" - rather than the intensity
-        # image layer, so the statistics Name column matches the created
-        # layers (as in the FRET tab). Multiple selected images are pooled
-        # into one merged histogram, so it is labelled with the component's
-        # display name.
-        if len(fraction_layers_map) > 1:
-            pooled_layers = [
-                (
-                    1.0 - np.asarray(fl.data, dtype=float)
-                    if invert
-                    else np.asarray(fl.data, dtype=float)
-                ).ravel()
-                for fl in fraction_layers_map.values()
-            ]
-            self.histogram_widget.update_data(
-                np.concatenate(pooled_layers), label=selected_text
+        # Feed the histogram one dataset per selected layer (labelled after
+        # the analysis fraction layer - e.g. "Component 2 fraction: <image>" -
+        # as in the FRET tab) so the Merged / Individual layers / Grouped
+        # display modes and per-row statistics all work.
+        raw_data = {
+            img_name: (
+                1.0 - np.asarray(fl.data, dtype=float)
+                if invert
+                else np.asarray(fl.data, dtype=float)
             )
+            for img_name, fl in fraction_layers_map.items()
+        }
+        per_layer = self._label_fraction_datasets(
+            raw_data, fraction_layers_map, selected_text, invert
+        )
+        if len(per_layer) > 1:
+            self.histogram_widget.update_multi_data(per_layer)
         else:
-            data = first_layer.data
-            if invert:
-                data = 1.0 - np.asarray(data, dtype=float)
-            self.histogram_widget.update_data(data, label=first_layer.name)
+            label, data = next(iter(per_layer.items()))
+            self.histogram_widget.update_data(data, label=label)
 
         self.histogram_widget.show()
 

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -5337,13 +5337,32 @@ class ComponentsWidget(QWidget):
             return f"Component {idx + 1}"
         return None
 
+    def _layer_matches_analysis_type(self, layer):
+        """Return True if ``layer`` is a fraction layer of the current method.
+
+        Component Fit layers carry the ``phasor_component_fraction`` tag and
+        use the singular ``"<comp> fraction: <image>"`` name; Linear Projection
+        layers are untagged and use the plural ``"<comp> fractions: <image>"``.
+        Filtering by the active ``analysis_type`` keeps the histogram selector
+        showing only the current method's components, even when stale layers
+        from the other method are still present in the viewer.
+        """
+        has_tag = isinstance(
+            layer.metadata.get('phasor_component_fraction'), dict
+        )
+        if self.analysis_type == "Component Fit":
+            return has_tag or " fraction: " in layer.name
+        # Linear Projection
+        return (not has_tag) and " fractions: " in layer.name
+
     def _get_fraction_layers_for_component(self, component_name):
         """Get all fraction layers in the viewer for a given component name.
 
         Searches the viewer for fraction layers matching the component name,
-        regardless of which image layer they belong to. Component-fit layers
-        are matched first by their ``phasor_component_fraction`` metadata tag
-        (so manually renamed layers are still found), then by name pattern.
+        regardless of which image layer they belong to, restricted to the
+        current analysis method. Component-fit layers are matched first by
+        their ``phasor_component_fraction`` metadata tag (so manually renamed
+        layers are still found), then by name pattern.
 
         Parameters
         ----------
@@ -5361,6 +5380,8 @@ class ComponentsWidget(QWidget):
         # Component fit:     "<comp_name> fraction: <layer_name>"
         for layer in self.viewer.layers:
             if not isinstance(layer, Image):
+                continue
+            if not self._layer_matches_analysis_type(layer):
                 continue
             tag = layer.metadata.get('phasor_component_fraction')
             if (
@@ -5395,6 +5416,10 @@ class ComponentsWidget(QWidget):
         layer_based_names = {}
         for layer in self.viewer.layers:
             if not isinstance(layer, Image):
+                continue
+            # Only surface components of the current analysis method, so stale
+            # layers from the other method are not offered in the combobox.
+            if not self._layer_matches_analysis_type(layer):
                 continue
             # Component-fit layers carry an identifying tag: resolve their
             # display name from it so a manually renamed layer still surfaces

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -53,7 +53,6 @@ from ._utils import (
     CheckableComboBox,
     HistogramWidget,
     analysis_section_stylesheet,
-    make_flat_section,
     make_section,
     required_component_harmonics,
     setup_primary_button,
@@ -399,13 +398,15 @@ class ComponentsWidget(QWidget):
         layout = QVBoxLayout()
         content_widget.setLayout(layout)
 
-        # Analysis method section. Borderless to save vertical space (it is
-        # the first section).
-        analysis_box, analysis_box_layout = make_flat_section(
-            "Analysis Method"
-        )
+        # Analysis method row: a bold label + the method combobox on a single
+        # borderless row (no section title).
+        analysis_box = QWidget()
+        analysis_box.setLayout(QVBoxLayout())
+        analysis_box.layout().setContentsMargins(0, 0, 0, 0)
         analysis_layout = QHBoxLayout()
-        analysis_layout.addWidget(QLabel("Analysis Method:"))
+        analysis_method_label = QLabel("Analysis Method:")
+        analysis_method_label.setStyleSheet("font-weight: 600;")
+        analysis_layout.addWidget(analysis_method_label)
         self.analysis_type_combo = QComboBox()
         self.analysis_type_combo.currentTextChanged.connect(
             self._on_analysis_type_changed
@@ -415,7 +416,7 @@ class ComponentsWidget(QWidget):
         )
         analysis_layout.addWidget(self.analysis_type_combo)
         analysis_layout.addStretch()
-        analysis_box_layout.addLayout(analysis_layout)
+        analysis_box.layout().addLayout(analysis_layout)
         layout.addWidget(analysis_box)
 
         # Components section
@@ -5306,11 +5307,43 @@ class ComponentsWidget(QWidget):
                     comp.idx, comp.phasor_center_layers
                 )
 
+        # Refresh the histogram/statistics component selectors so a renamed
+        # fraction layer keeps its component listed (discovery is metadata
+        # aware). The current selection is preserved by name.
+        self._update_histogram_combobox()
+
+    def _component_display_name_from_tag(self, tag):
+        """Return a component's display name from its fraction-layer tag.
+
+        Uses the custom name stored in the source image's component settings,
+        falling back to the default ``"Component <n>"`` label. This lets the
+        histogram combobox recognise component-fit fraction layers even when
+        the user has renamed them manually (the tag survives the rename).
+        """
+        if not isinstance(tag, dict):
+            return None
+        idx = tag.get('component_index')
+        source = tag.get('source_layer')
+        if source and source in self.viewer.layers:
+            settings = (
+                self.viewer.layers[source]
+                .metadata.get('settings', {})
+                .get('component_analysis', {})
+            )
+            comp = settings.get('components', {}).get(str(idx))
+            if isinstance(comp, dict) and comp.get('name'):
+                return comp['name']
+        if isinstance(idx, int):
+            return f"Component {idx + 1}"
+        return None
+
     def _get_fraction_layers_for_component(self, component_name):
         """Get all fraction layers in the viewer for a given component name.
 
-        Searches the viewer for fraction layers matching the component name
-        pattern, regardless of which image layer they belong to.
+        Searches the viewer for fraction layers matching the component name,
+        regardless of which image layer they belong to. Component-fit layers
+        are matched first by their ``phasor_component_fraction`` metadata tag
+        (so manually renamed layers are still found), then by name pattern.
 
         Parameters
         ----------
@@ -5329,6 +5362,17 @@ class ComponentsWidget(QWidget):
         for layer in self.viewer.layers:
             if not isinstance(layer, Image):
                 continue
+            tag = layer.metadata.get('phasor_component_fraction')
+            if (
+                isinstance(tag, dict)
+                and tag.get('analysis_type') == 'Component Fit'
+                and self._component_display_name_from_tag(tag)
+                == component_name
+            ):
+                source = tag.get('source_layer')
+                if source:
+                    result[source] = layer
+                    continue
             name = layer.name
             for sep in (" fractions: ", " fraction: "):
                 if name.startswith(component_name + sep):
@@ -5351,6 +5395,18 @@ class ComponentsWidget(QWidget):
         layer_based_names = {}
         for layer in self.viewer.layers:
             if not isinstance(layer, Image):
+                continue
+            # Component-fit layers carry an identifying tag: resolve their
+            # display name from it so a manually renamed layer still surfaces
+            # its component in the combobox.
+            tag = layer.metadata.get('phasor_component_fraction')
+            if (
+                isinstance(tag, dict)
+                and tag.get('analysis_type') == 'Component Fit'
+            ):
+                display = self._component_display_name_from_tag(tag)
+                if display is not None:
+                    layer_based_names[display] = display
                 continue
             for sep in (" fractions: ", " fraction: "):
                 idx = layer.name.find(sep)

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -1638,7 +1638,10 @@ class FretWidget(QWidget):
         if len(per_layer) > 1:
             self.histogram_widget.update_multi_data(per_layer)
         else:
-            self.histogram_widget.update_data(merged)
+            self.histogram_widget.update_data(
+                merged,
+                label=next(iter(per_layer), "Layer"),
+            )
 
     def _on_fret_range_changed(self, min_val, max_val):
         """Handle range slider changes – clip FRET layers and update histogram."""
@@ -1676,7 +1679,10 @@ class FretWidget(QWidget):
             if len(per_layer) > 1:
                 self.histogram_widget.update_multi_data(per_layer)
             else:
-                self.histogram_widget.update_data(merged)
+                self.histogram_widget.update_data(
+                    merged,
+                    label=next(iter(per_layer), "Layer"),
+                )
 
         self.plot_donor_trajectory()
 

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -300,8 +300,8 @@ class PhasorMappingWidget(QWidget):
         self.current_output_type = "Apparent Phase Lifetime"
         self._overlay_imshow = None
         self._mesh_overlay_imshow = None
-        self._phase_colormap_name = "jet"
-        self._modulation_colormap_name = "viridis"
+        self._phase_colormap_name = "cool"
+        self._modulation_colormap_name = "PiYG"
         self._coloring_paused_by_tab = False
         self.min_lifetime = None
         self.max_lifetime = None
@@ -398,7 +398,10 @@ class PhasorMappingWidget(QWidget):
         self.main_layout.addWidget(output_box)
 
         # Coloring section ---------------------------------------------------
+        # Only relevant for Phase/Modulation output; hidden for Lifetime (see
+        # _sync_mode_widgets).
         coloring_box, coloring_box_layout = make_section("Coloring")
+        self.coloring_box = coloring_box
 
         # 2D phasor custom-color controls (visible for Phase/Modulation modes)
         self.colormap_widget = QWidget()
@@ -787,6 +790,9 @@ class PhasorMappingWidget(QWidget):
         pw = self.parent_widget
         self.lifetime_output_widget.setVisible(is_lifetime_mode)
         self.frequency_widget.setVisible(is_lifetime_mode)
+        # Hide the whole Coloring section for Lifetime; show it (and its
+        # controls) for Phase/Modulation.
+        self.coloring_box.setVisible(not is_lifetime_mode)
         self.colormap_widget.setVisible(not is_lifetime_mode)
         self.coloring_checkbox_widget.setVisible(not is_lifetime_mode)
 
@@ -1050,9 +1056,9 @@ class PhasorMappingWidget(QWidget):
     @staticmethod
     def _get_output_colormap_name(output_type: str) -> str:
         if output_type == "Phase":
-            return "jet"
+            return "cool"
         if output_type == "Modulation":
-            return "viridis"
+            return "PiYG"
         return "plasma"
 
     def _configure_histogram_labels_for_output(self, output_type: str):

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -1693,10 +1693,21 @@ class PhasorMappingWidget(QWidget):
         output_type = self._get_selected_output_type()
         if output_type in {"Phase", "Modulation"}:
             self._apply_histogram_coloring(output_type)
-        if self.per_layer_metric_data and len(self.per_layer_metric_data) > 1:
-            self.histogram_widget.update_multi_data(self.per_layer_metric_data)
+        # Name the histogram datasets after the analysis output layers
+        # (e.g. "Lifetime: <image>"), not the intensity image layers, so the
+        # statistics Name column matches the created layers (as in the FRET
+        # tab). The output layers are named ``f"{output_type}: {image_name}"``.
+        named = {
+            f"{output_type}: {name}": data
+            for name, data in (self.per_layer_metric_data or {}).items()
+        }
+        if len(named) > 1:
+            self.histogram_widget.update_multi_data(named)
         else:
-            self.histogram_widget.update_data(self.current_metric_data)
+            self.histogram_widget.update_data(
+                self.current_metric_data,
+                label=next(iter(named), "Layer"),
+            )
 
     def rename_layer(self, old_name: str, new_name: str):
         """Update internal dictionaries and rename derived layers when a layer is renamed."""
@@ -1930,6 +1941,14 @@ class PhasorMappingWidget(QWidget):
                 )
             )
             self._clear_2d_coloring()
+
+        # Refresh the primary button's ready/blocked style. This runs on both
+        # the direct layer-change path and the deferred tab-switch path, so the
+        # button reflects the current validation state (e.g. a selected layer
+        # with the frequency already filled from metadata) instead of keeping a
+        # stale blocked (grey) style.
+        if hasattr(self, '_refresh_calculate_button'):
+            self._refresh_calculate_button()
 
     def _on_calculate_lifetime_clicked(self):
         """Callback when Calculate button is clicked.

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -59,7 +59,6 @@ from ._utils import (
     available_colormap_names,
     build_group_styles_from_layer_metadata,
     build_groups_from_layer_metadata,
-    make_flat_section,
     make_section,
     make_solid_contour_cmap,
     normalize_rgb,
@@ -1982,27 +1981,24 @@ class PlotterWidget(QWidget):
         self.settings_tab.setStyleSheet(analysis_section_stylesheet())
         self.tab_widget.addTab(self.settings_tab, "Plot Settings")
 
-        # Import buttons in a titled section at the top of the Plot Settings
-        # tab. Borderless to save vertical space (it is the first section).
-        import_box, import_box_layout = make_flat_section(
-            "Load and apply settings"
-        )
-        import_buttons_layout = QHBoxLayout()
-        import_buttons_layout.setContentsMargins(0, 0, 0, 0)
-        import_buttons_layout.setSpacing(5)
+        # Import buttons at the top of the Plot Settings tab: a bold label and
+        # both buttons on a single borderless row (no section title).
+        import_box = QWidget()
+        import_box.setLayout(QHBoxLayout())
+        import_box.layout().setContentsMargins(0, 0, 0, 0)
+        import_box.layout().setSpacing(5)
 
         import_label = QLabel("Load and Apply Settings from:")
-        import_label.setWordWrap(True)
-        import_buttons_layout.addWidget(import_label)
+        import_label.setStyleSheet("font-weight: 600;")
+        import_box.layout().addWidget(import_label)
 
         self.import_from_layer_button = QPushButton("Layer")
-        import_buttons_layout.addWidget(self.import_from_layer_button)
+        import_box.layout().addWidget(self.import_from_layer_button)
 
         self.import_from_file_button = QPushButton("OME-TIFF File")
-        import_buttons_layout.addWidget(self.import_from_file_button)
+        import_box.layout().addWidget(self.import_from_file_button)
 
-        import_buttons_layout.addStretch(1)
-        import_box_layout.addLayout(import_buttons_layout)
+        import_box.layout().addStretch(1)
 
         self._import_settings_box = import_box
 

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -59,6 +59,7 @@ from ._utils import (
     available_colormap_names,
     build_group_styles_from_layer_metadata,
     build_groups_from_layer_metadata,
+    make_flat_section,
     make_section,
     make_solid_contour_cmap,
     normalize_rgb,
@@ -1549,6 +1550,13 @@ class PlotterWidget(QWidget):
     }
     PLOT_TYPE_KEYS = {v: k for k, v in PLOT_TYPE_DISPLAY_NAMES.items()}
 
+    # Pixel bands the figure reserves around the axes for the y-label +
+    # colorbar (horizontal) and the x-label (vertical). Used to size the
+    # canvas so the aspect-locked plot fills the container tightly. See
+    # :meth:`_canvas_size_for_ratio`.
+    _CANVAS_H_OVERHEAD = 150
+    _CANVAS_V_OVERHEAD = 55
+
     def __init__(self, napari_viewer):
         """Initialize the PlotterWidget."""
         super().__init__()
@@ -1635,7 +1643,9 @@ class PlotterWidget(QWidget):
         # Create bottom widget for controls
         self.controls_container = QWidget()
         self.controls_container.setLayout(QVBoxLayout())
-        self.controls_container.layout().setContentsMargins(10, 10, 10, 10)
+        # Keep only a small top margin so the controls sit close beneath the
+        # phasor plot (the plot already reserves its own x-label band).
+        self.controls_container.layout().setContentsMargins(10, 2, 10, 10)
         self.controls_container.layout().setSpacing(3)
         self.controls_container.setSizePolicy(
             QSizePolicy.Preferred, QSizePolicy.Maximum
@@ -1972,8 +1982,11 @@ class PlotterWidget(QWidget):
         self.settings_tab.setStyleSheet(analysis_section_stylesheet())
         self.tab_widget.addTab(self.settings_tab, "Plot Settings")
 
-        # Import buttons in a titled section at the top of the Plot Settings tab
-        import_box, import_box_layout = make_section("Load and apply settings")
+        # Import buttons in a titled section at the top of the Plot Settings
+        # tab. Borderless to save vertical space (it is the first section).
+        import_box, import_box_layout = make_flat_section(
+            "Load and apply settings"
+        )
         import_buttons_layout = QHBoxLayout()
         import_buttons_layout.setContentsMargins(0, 0, 0, 0)
         import_buttons_layout.setSpacing(5)
@@ -2428,6 +2441,16 @@ class PlotterWidget(QWidget):
                 [600],
                 Qt.Horizontal,
             )
+            # Give the analysis tabs a taller default height so their controls
+            # are visible without scrolling. The plotter and analysis docks
+            # share the right column's vertical split.
+            plotter_dock = self._find_plotter_dock()
+            if plotter_dock is not None:
+                qt_window.resizeDocks(
+                    [plotter_dock, self._analysis_dock],
+                    [500, 400],
+                    Qt.Vertical,
+                )
             # Height of the bottom (central) histogram/statistics area.
             # Request 1 px so Qt clamps it to the dock's minimum height,
             # keeping the histogram as short as allowed by default.
@@ -2509,16 +2532,12 @@ class PlotterWidget(QWidget):
             return
 
         ratio = self._get_canvas_target_ratio()
-        container_ratio = available_w / available_h
-        if container_ratio >= ratio:
-            target_h = available_h
-            target_w = int(round(target_h * ratio))
-        else:
-            target_w = available_w
-            target_h = int(round(target_w / ratio))
+        target_w, target_h = self._canvas_size_for_ratio(
+            ratio, available_w, available_h
+        )
 
-        target_w = max(int(target_w), 1)
-        target_h = max(int(target_h), 1)
+        target_w = max(int(round(target_w)), 1)
+        target_h = max(int(round(target_h)), 1)
 
         if (
             self.canvas_widget.width() != target_w
@@ -2527,6 +2546,70 @@ class PlotterWidget(QWidget):
             self.canvas_widget.setFixedSize(target_w, target_h)
 
         self._update_text_sizes_for_canvas(min(target_w, target_h))
+
+    def _canvas_size_for_ratio(self, ratio, available_w, available_h):
+        """Return the (width, height) for the canvas widget.
+
+        ``ratio`` is the axes data aspect (width / height). The canvas widget
+        wraps the matplotlib figure - which also carries the axis labels and
+        the colorbar - plus the toolbar. Sizing the canvas to the raw data
+        aspect ignores that the horizontal overhead (y-label + colorbar) is
+        much larger than the vertical overhead (x-label). For the full
+        (square) plot that left wide empty bands above and below the axes.
+
+        Instead, size the canvas so the aspect-locked axes fills the tight
+        dimension and the figure wraps it, accounting for the pixel overhead
+        around the axes. ``h_over`` (y-label + colorbar) is measured live - it
+        is reliable because the plot is horizontally constrained. ``v_over``
+        (x-label band) is estimated from the plot height, avoiding the
+        inflated value measured when the axes is centered in an over-tall
+        figure. Falls back to a plain aspect-fit before the figure is drawn.
+        """
+
+        def _fit(r):
+            if available_w / available_h >= r:
+                th = available_h
+                tw = th * r
+            else:
+                tw = available_w
+                th = tw / r
+            return tw, th
+
+        try:
+            canvas = self.canvas_widget.canvas
+            fig_w = float(canvas.width())
+            fig_h = float(canvas.height())
+            if fig_w <= 0 or fig_h <= 0:
+                return _fit(ratio)
+
+            # Widget chrome (figure border + toolbar), stable and measured live.
+            border_w = max(float(self.canvas_widget.width()) - fig_w, 0)
+            toolbar_h = max(float(self.canvas_widget.height()) - fig_h, 0)
+            # Overhead the figure reserves around the axes for labels and the
+            # colorbar. These are treated as constants rather than measured
+            # from the current draw: an aspect-locked axes that is limited by
+            # one dimension gets *inflated* margins on the other, so feeding
+            # the live margin back into the size would spiral the plot smaller
+            # each pass. Values are the minimal (non-inflated) pixel bands
+            # observed for the y-label + colorbar (horizontal) and the x-label
+            # (vertical).
+            h_over = self._CANVAS_H_OVERHEAD
+            v_over = self._CANVAS_V_OVERHEAD
+
+            # Largest axes height fitting both dims while preserving aspect.
+            axes_h_target = min(
+                (available_w - border_w - h_over) / ratio,
+                available_h - toolbar_h - v_over,
+            )
+            if axes_h_target <= 0:
+                return _fit(ratio)
+
+            axes_w_target = axes_h_target * ratio
+            target_w = min(axes_w_target + h_over + border_w, available_w)
+            target_h = min(axes_h_target + v_over + toolbar_h, available_h)
+            return target_w, target_h
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return _fit(ratio)
 
     @staticmethod
     def _compute_font_size(side):

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -45,7 +45,6 @@ from ._utils import (
     CurrentPageStackedWidget,
     analysis_section_stylesheet,
     colormap_to_dict,
-    make_flat_section,
     make_section,
     setup_primary_button,
 )
@@ -132,11 +131,15 @@ class SelectionWidget(QWidget):
         content_layout = QVBoxLayout(content)
         content_layout.setContentsMargins(0, 0, 0, 0)
 
-        # Selection mode combobox at the top. Borderless to save vertical
-        # space (it is the first section).
-        mode_box, mode_box_layout = make_flat_section("Selection mode")
+        # Selection mode combobox at the top: a bold label + the combobox on a
+        # single borderless row (no section title).
+        mode_box = QWidget()
+        mode_box.setLayout(QVBoxLayout())
+        mode_box.layout().setContentsMargins(0, 0, 0, 0)
         mode_layout = QHBoxLayout()
-        mode_layout.addWidget(QLabel("Selection Mode:"))
+        mode_label = QLabel("Selection Mode:")
+        mode_label.setStyleSheet("font-weight: 600;")
+        mode_layout.addWidget(mode_label)
         self.selection_mode_combobox = QComboBox()
         self.selection_mode_combobox.addItems(
             [
@@ -146,7 +149,7 @@ class SelectionWidget(QWidget):
             ]
         )
         mode_layout.addWidget(self.selection_mode_combobox, 1)
-        mode_box_layout.addLayout(mode_layout)
+        mode_box.layout().addLayout(mode_layout)
         content_layout.addWidget(mode_box)
 
         # Stacked widget to switch between modes

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -45,6 +45,7 @@ from ._utils import (
     CurrentPageStackedWidget,
     analysis_section_stylesheet,
     colormap_to_dict,
+    make_flat_section,
     make_section,
     setup_primary_button,
 )
@@ -131,8 +132,9 @@ class SelectionWidget(QWidget):
         content_layout = QVBoxLayout(content)
         content_layout.setContentsMargins(0, 0, 0, 0)
 
-        # Selection mode combobox at the top
-        mode_box, mode_box_layout = make_section("Selection mode")
+        # Selection mode combobox at the top. Borderless to save vertical
+        # space (it is the first section).
+        mode_box, mode_box_layout = make_flat_section("Selection mode")
         mode_layout = QHBoxLayout()
         mode_layout.addWidget(QLabel("Selection Mode:"))
         self.selection_mode_combobox = QComboBox()


### PR DESCRIPTION
Fixes a batch of UI/layout issues across the analysis tabs and hardens how the
Components and Phasor Mapping tabs track their derived layers.

## Plot layout

- **Taller default analysis dock.** The Phasor Analysis tabs now open with a
  higher default height so their controls are visible without scrolling
  (previously ~254 px → ~400 px), via a vertical `resizeDocks` split.
- **Fixed empty space around the full-circle phasor plot.** Canvas sizing used
  the raw *data* aspect (a square for full-circle), ignoring that the colorbar
  and axis labels make the figure non-square. This left wide empty bands above
  and below the plot. New `_canvas_size_for_ratio` sizes the canvas from the
  aspect-locked plot plus its fixed label/colorbar overhead, so the plot fills
  the space with tight margins in both full- and semi-circle modes.
- **Reduced the gap below the plot** before the layer combobox (trimmed the
  controls container's top margin).

## Borderless top sections

The first section of the **Plot Settings**, **Calibration**, **Selection**, and
**Components** tabs no longer draws a titled `QGroupBox`. The redundant title is
gone and the label preceding the top control is bolded, reclaiming vertical
space. In Plot Settings the "Load and Apply Settings from:" label and its
buttons now sit on a single row. "Analysis **Type**" is renamed to
"Analysis **Method**".

## Components tab

- **Component-fit layers are replaced, not duplicated, across runs.** Running a
  fit, then renaming the components and re-running, previously left the old
  layers behind alongside the newly named ones. Old fraction layers are now
  cleaned up so only the current set remains.
- **Fraction layers are tagged with identifying metadata**
  (`phasor_component_fraction`: source image + component index + harmonic). This
  is used instead of the layer name to detect a component's fraction layer, so:
  - Renaming a fraction layer manually and re-running **updates it in place and
    keeps your custom name** (no duplicate).
  - Renaming the **source image** keeps the tag in sync.
  - A **renamed fraction layer still appears in the histogram/statistics
    component selector** and can be visualized (discovery and resolution are
    now metadata-aware, with a name-based fallback for older layers).
- **Multi-component fit:** in the line/histogram settings dialog, the fraction
  histogram overlay section is disabled (it only applies to two-component
  Linear Projection).

## Statistics "Name" column

The statistics table now labels datasets with the **analysis output layer name**
rather than the intensity image name, consistently across the Components,
Phasor Mapping, and FRET tabs, for both single- and multi-layer selections
(e.g. `Component 2 fraction: <image>`, `Lifetime: <image>`). Single-layer
analyses previously showed a generic `"Layer"`.

## Phasor Mapping tab

- **Fixed the primary button style.** The "Display …" button could stay greyed
  out (but clickable) even when ready, because the deferred tab-switch path
  didn't re-evaluate it. It now shows the green "ready" outline when a layer is
  selected and the frequency is filled, and greys out when requirements are
  missing.
- **Coloring section visibility** now follows the output type: hidden for
  **Lifetime**, shown for **Phase** and **Modulation**.
- **New default colormaps:** Phase → `cool`, Modulation → `PiYG`.

## Statistics "Name" column & multi-image histograms

The statistics table now labels datasets with the **analysis output layer name**
rather than the intensity image name, consistently across the Components,
Phasor Mapping, and FRET tabs (e.g. `Component 2 fraction: <image>`,
`Lifetime: <image>`). Single-layer analyses previously showed a generic
`"Layer"`.

In the Components tab, multi-image analyses previously pooled all layers into
one merged histogram with a single statistics row. Each selected image now
feeds its own dataset (as in the FRET tab), so the statistics table shows one
row per layer and the histogram supports the Merged / Individual layers /
Grouped display modes.