### PR TITLE
Add histogram dataset key remapping and enhance All/None button UI

### DIFF
--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -3028,6 +3028,39 @@ class HistogramWidget(QWidget):
             self.fig.canvas.draw_idle()
             self.dataChanged.emit()
 
+    def remap_dataset_keys(self, old_to_new: dict) -> None:
+        """Migrate persisted grouping/color state to new dataset labels.
+
+        Group assignments and per-layer colors are keyed by dataset label. When
+        the caller re-feeds the *same* underlying datasets under different
+        labels (e.g. the components tab relabelling fraction data when the
+        selected component changes), those persisted mappings would otherwise
+        no longer match and the datasets would collapse into the default group.
+
+        This copies the existing ``_group_assignments`` and ``_layer_colors``
+        entries from each old label to its new label. It does not re-render;
+        call the appropriate ``update_*_data`` method afterwards.
+
+        Parameters
+        ----------
+        old_to_new : dict
+            ``{old_label: new_label}`` mapping for datasets that persist across
+            the relabel.
+        """
+        new_group_assignments = dict(self._group_assignments)
+        new_layer_colors = dict(self._layer_colors)
+        for old_label, new_label in old_to_new.items():
+            if old_label == new_label:
+                continue
+            if old_label in self._group_assignments:
+                new_group_assignments[new_label] = self._group_assignments[
+                    old_label
+                ]
+            if old_label in self._layer_colors:
+                new_layer_colors[new_label] = self._layer_colors[old_label]
+        self._group_assignments = new_group_assignments
+        self._layer_colors = new_layer_colors
+
     def update_colormap(
         self,
         colormap_colors: np.ndarray = None,

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -341,6 +341,10 @@ class ComponentsWidget(QWidget):
         self.histogram_offset = 0.0
         self.histogram_alpha = 0.75
         self.component_histogram = None
+        # {source_image_name: histogram dataset label} for the component
+        # currently shown, used to carry group/color state across the label
+        # change when a different component is selected.
+        self._histogram_label_by_image = None
 
         # Flag to prevent clearing lifetime when updating from lifetime
         self._updating_from_lifetime = False
@@ -5562,13 +5566,54 @@ class ComponentsWidget(QWidget):
         """
         labeled = {}
         for img_name, data in data_by_image.items():
-            if invert:
-                label = f"{selected_text} fractions: {img_name}"
-            else:
-                fl = fraction_layers_map.get(img_name)
-                label = fl.name if fl is not None else img_name
+            label = self._histogram_label_for_image(
+                img_name, fraction_layers_map, selected_text, invert
+            )
             labeled[label] = np.asarray(data, dtype=float).ravel()
         return labeled
+
+    def _histogram_label_for_image(
+        self, img_name, fraction_layers_map, selected_text, invert
+    ):
+        """Return the histogram dataset label used for ``img_name``.
+
+        Mirrors the labelling in :meth:`_label_fraction_datasets` so callers
+        can build an ``{image: label}`` mapping without the data arrays.
+        """
+        if invert:
+            return f"{selected_text} fractions: {img_name}"
+        fl = fraction_layers_map.get(img_name)
+        return fl.name if fl is not None else img_name
+
+    def _apply_histogram_group_remap(
+        self, fraction_layers_map, selected_text, invert
+    ):
+        """Carry histogram grouping/colors across a component change.
+
+        The histogram widget keys its group assignments and per-layer colors by
+        dataset label. Switching the selected component relabels every dataset
+        (e.g. ``"Component 1 fractions: img"`` -> ``"Component 2 fractions:
+        img"``), which would otherwise orphan those mappings and collapse every
+        dataset into the default group in Grouped mode. Remap the persisted
+        state from the previously displayed labels to the new ones, keyed by the
+        shared source image, before feeding the new data.
+        """
+        image_to_label = {
+            img_name: self._histogram_label_for_image(
+                img_name, fraction_layers_map, selected_text, invert
+            )
+            for img_name in fraction_layers_map
+        }
+        previous = getattr(self, '_histogram_label_by_image', None)
+        if previous:
+            old_to_new = {
+                previous[img_name]: label
+                for img_name, label in image_to_label.items()
+                if img_name in previous
+            }
+            if old_to_new:
+                self.histogram_widget.remap_dataset_keys(old_to_new)
+        self._histogram_label_by_image = image_to_label
 
     def _update_histogram_combobox(self):
         """Populate the component selector comboboxes with fraction layers.
@@ -5696,6 +5741,9 @@ class ComponentsWidget(QWidget):
         # the analysis fraction layer, as in the FRET tab) so the Merged /
         # Individual layers / Grouped display modes and per-row statistics
         # all work.
+        self._apply_histogram_group_remap(
+            fraction_layers_map, selected_text, invert
+        )
         per_layer = self._label_fraction_datasets(
             clipped_data, fraction_layers_map, selected_text, invert
         )
@@ -5804,6 +5852,9 @@ class ComponentsWidget(QWidget):
             )
             for img_name, fl in fraction_layers_map.items()
         }
+        self._apply_histogram_group_remap(
+            fraction_layers_map, selected_text, invert
+        )
         per_layer = self._label_fraction_datasets(
             raw_data, fraction_layers_map, selected_text, invert
         )

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -1680,30 +1680,32 @@ class PlotterWidget(QWidget):
         image_layer_layout.addWidget(self.image_layers_checkable_combobox, 1)
 
         # "All | None" clickable labels for quick bulk selection
-        select_all_label = QLabel('<a href="all" style="color: gray;">All</a>')
-        select_all_label.setTextFormat(Qt.RichText)
-        select_all_label.setCursor(Qt.PointingHandCursor)
-        select_all_label.setToolTip("Select all layers")
-        image_layer_layout.addWidget(select_all_label)
+        self._select_all_label = QLabel(
+            '<a href="all" style="color: gray;">All</a>'
+        )
+        self._select_all_label.setTextFormat(Qt.RichText)
+        self._select_all_label.setCursor(Qt.PointingHandCursor)
+        self._select_all_label.setToolTip("Select all layers")
+        image_layer_layout.addWidget(self._select_all_label)
 
         separator_label = QLabel("|")
         separator_label.setStyleSheet("color: gray;")
         image_layer_layout.addWidget(separator_label)
 
-        deselect_all_label = QLabel(
+        self._deselect_all_label = QLabel(
             '<a href="none" style="color: gray;">None</a>'
         )
-        deselect_all_label.setTextFormat(Qt.RichText)
-        deselect_all_label.setCursor(Qt.PointingHandCursor)
-        deselect_all_label.setToolTip("Deselect all layers")
-        image_layer_layout.addWidget(deselect_all_label)
+        self._deselect_all_label.setTextFormat(Qt.RichText)
+        self._deselect_all_label.setCursor(Qt.PointingHandCursor)
+        self._deselect_all_label.setToolTip("Deselect all layers")
+        image_layer_layout.addWidget(self._deselect_all_label)
 
         # Connect All/None labels (use lambdas to consume the href argument)
-        select_all_label.linkActivated.connect(
-            lambda _: self.image_layers_checkable_combobox.selectAll()
+        self._select_all_label.linkActivated.connect(
+            lambda _: self._on_select_all_clicked()
         )
-        deselect_all_label.linkActivated.connect(
-            lambda _: self.image_layers_checkable_combobox.deselectAll()
+        self._deselect_all_label.linkActivated.connect(
+            lambda _: self._on_deselect_all_clicked()
         )
 
         image_layer_widget = QWidget()
@@ -2659,6 +2661,40 @@ class PlotterWidget(QWidget):
                 tick_label.set_fontsize(fs)
 
         self.canvas_widget.figure.canvas.draw_idle()
+
+    def _on_select_all_clicked(self):
+        """Select all layers, briefly flashing the "All" label bold green."""
+        # Highlight (and force an immediate repaint) before the selection work
+        # runs so the feedback is instant rather than lagging behind the
+        # synchronous plot update triggered by ``selectAll``.
+        self._select_all_label.setText(
+            '<a href="all" style="color: green; font-weight: bold;">All</a>'
+        )
+        self._select_all_label.repaint()
+        self.image_layers_checkable_combobox.selectAll()
+        QTimer.singleShot(
+            200,
+            lambda: self._select_all_label.setText(
+                '<a href="all" style="color: gray;">All</a>'
+            ),
+        )
+
+    def _on_deselect_all_clicked(self):
+        """Deselect all layers, briefly flashing the "None" label bold red."""
+        # Highlight (and force an immediate repaint) before the selection work
+        # runs so the feedback is instant rather than lagging behind the
+        # synchronous plot update triggered by ``deselectAll``.
+        self._deselect_all_label.setText(
+            '<a href="none" style="color: red; font-weight: bold;">None</a>'
+        )
+        self._deselect_all_label.repaint()
+        self.image_layers_checkable_combobox.deselectAll()
+        QTimer.singleShot(
+            200,
+            lambda: self._deselect_all_label.setText(
+                '<a href="none" style="color: gray;">None</a>'
+            ),
+        )
 
     def get_selected_layer_names(self):
         """Get the names of all selected (checked) layers.


### PR DESCRIPTION
## Summary

- Fix a bug in the components tab histogram where **Grouped** display mode only showed one group outline when "Component 2" was selected (instead of both), while Component 1 and Merged/Individual modes worked correctly.
- Add instant visual feedback to the "All" / "None" quick-selection labels next to the image layer combobox in the main plotter: clicking briefly flashes the text bold green ("All") or bold red ("None").

## Details

### Histogram grouped-mode bug

`HistogramWidget` keys its `_group_assignments` and `_layer_colors` by dataset **label**. Switching the selected component in the Components tab relabels every dataset (e.g. `"Component 1 fractions: img"` → `"Component 2 fractions: img"`), so the previously configured group assignments no longer matched any label — every dataset silently fell back to the default group, collapsing Grouped mode down to a single outline. Merged mode averages across all datasets and Individual mode ignores groups entirely, which is why the bug was isolated to Grouped mode with Component 2 (or any component other than the first shown).

Fix:
- Added `HistogramWidget.remap_dataset_keys(old_to_new)` in [_utils.py](src/napari_phasors/_utils.py), which migrates persisted group/color state from old labels to new labels.
- Added `_apply_histogram_group_remap()` in [components_tab.py](src/napari_phasors/components_tab.py), called before each histogram data feed. It tracks a stable `{source_image: label}` mapping and remaps the widget's group/color state through the shared source image whenever the displayed component (and thus the labels) changes.

### All / None button feedback

In [plotter.py](src/napari_phasors/plotter.py), clicking "All" or "None" now immediately (before the selection/plot update runs) sets the clicked label to bold green/red and forces a repaint, then resets it to gray after 200 ms via `QTimer.singleShot`. Highlighting before triggering `selectAll()`/`deselectAll()` (rather than after) avoids the visible lag caused by the synchronous plot redraw.