### PR TITLE
Enhance UI usability by adjusting dialog and widget widths

### DIFF
--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -1105,7 +1105,8 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
 
     # Shown as a standalone (non-dockable) window; see ``PopoutWindowMixin``.
     _popout_title = "Batch Analysis"
-    _popout_max_width = 540
+    _popout_max_width = 900
+    _popout_min_width = 760
     _popout_height = 840
 
     # Display labels for the phasor-plot type comboboxes. The canonical key
@@ -1300,7 +1301,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         area.setWidget(widget)
         return area
 
-    def _enable_section(self, title, description=None):
+    def _enable_section(self, title, description=None, stretch_body=False):
         """Return ``(toggle, body, content)`` for an enableable analysis tab.
 
         ``toggle`` is a bold green :class:`superqt.QToggleSwitch` that doubles
@@ -1313,6 +1314,11 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         is the widget the caller should add to the tab layout (it wraps the
         toggle header, the description and the lockable body), so the caller no
         longer needs to add the toggle separately.
+
+        Set ``stretch_body`` for a tab whose body should grow into the tab's
+        spare height (e.g. one holding a scrollable list) rather than staying at
+        its natural height; the caller must also add ``content`` with a stretch
+        factor and omit any trailing stretch.
         """
         toggle = QToggleSwitch(title)
         toggle.onColor = QColor("#27ae60")
@@ -1370,7 +1376,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         content_layout.addWidget(header)
         if description:
             content_layout.addWidget(self._note(description))
-        content_layout.addWidget(section)
+        content_layout.addWidget(section, 1 if stretch_body else 0)
 
         def _on_toggled(checked):
             body.setEnabled(checked)
@@ -2278,6 +2284,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             "Enable masks",
             "Restrict each image to a region of interest using mask image "
             "files matched to inputs by name.",
+            stretch_body=True,
         )
         group_layout = QVBoxLayout(body)
         group_layout.setContentsMargins(0, 0, 0, 0)
@@ -2309,6 +2316,9 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         rows_scroll.setWidgetResizable(True)
         rows_scroll.setFrameShape(QFrame.NoFrame)
         rows_scroll.setWidget(self._mask_rows_container)
+        # The list is the point of this tab: give it a tall floor and let it
+        # take the tab's spare height instead of scrolling within a thin strip.
+        rows_scroll.setMinimumHeight(360)
         group_layout.addWidget(rows_scroll, 1)
 
         note = QLabel(
@@ -2321,8 +2331,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         note.setStyleSheet("color: gray; font-size: 11px;")
         group_layout.addWidget(note)
 
-        outer.addWidget(content)
-        outer.addStretch()
+        outer.addWidget(content, 1)
         return self._scrollable(tab)
 
     def _on_add_mask_folder(self):

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -319,6 +319,11 @@ class PopoutWindowMixin:
     ``_popout_max_width``
         Upper bound on the window width, so wide content (e.g. many tabs) never
         overflows small displays.
+    ``_popout_min_width``
+        Lower bound on the *initial* window width, for content whose natural
+        width hint is narrower than is comfortable to work in. This only sets
+        the size the window opens at; the widget's ``minimumWidth`` still
+        governs how far the user can shrink it afterwards.
     ``_popout_height``
         Fixed window height. Leave ``None`` to use the widget's natural height
         (appropriate for compact, non-scrolling widgets); set a value for tall,
@@ -327,6 +332,7 @@ class PopoutWindowMixin:
 
     _popout_title = None
     _popout_max_width = 540
+    _popout_min_width = 360
     _popout_height = None
 
     def showEvent(self, event):
@@ -376,7 +382,12 @@ class PopoutWindowMixin:
         # never spills off smaller displays.
         screen = QApplication.primaryScreen().availableGeometry()
         max_width = min(self._popout_max_width, screen.width() - 80)
-        width = max(360, min(self.sizeHint().width(), max_width))
+        width = max(
+            self._popout_min_width, min(self.sizeHint().width(), max_width)
+        )
+        # The minimum is a comfort floor, not a guarantee: never let it push the
+        # window past what the screen allows.
+        width = min(width, max_width)
         if self._popout_height:
             height = min(self._popout_height, screen.height() - 120)
         else:
@@ -2040,7 +2051,7 @@ class HistogramSettingsDialog(QDialog):
     ):
         super().__init__(parent)
         self.setWindowTitle("Histogram Settings")
-        self.setMinimumWidth(340)
+        self.setMinimumWidth(520)
 
         layout = QVBoxLayout(self)
 
@@ -4049,7 +4060,7 @@ class FileOrderDialog(QDialog):
     ):
         super().__init__(parent)
         self.setWindowTitle("Reorder Files for 3D Stack")
-        self.setMinimumWidth(500)
+        self.setMinimumWidth(680)
         self.setMinimumHeight(400)
 
         self._paths = list(file_paths)

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -223,8 +223,8 @@ class PhasorCenterSelectionDialog(QDialog):
     def __init__(self, layers, parent=None, preselected=None):
         super().__init__(parent)
         self.setWindowTitle("Select Phasor Center Layers")
-        self.setMinimumWidth(360)
-        self.resize(360, 150)
+        self.setMinimumWidth(520)
+        self.resize(520, 150)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(15, 15, 15, 15)

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -297,7 +297,7 @@ class MaskAssignmentDialog(QDialog):
     ):
         super().__init__(parent)
         self.setWindowTitle("Assign Mask Layers")
-        self.setMinimumWidth(400)
+        self.setMinimumWidth(560)
 
         if current_assignments is None:
             current_assignments = {}
@@ -613,7 +613,7 @@ class ContourLayerSettingsDialog(QDialog):
         self.setWindowTitle(
             "Configure Groups" if groups_only else "Contour Layer Settings"
         )
-        self.setMinimumWidth(550)
+        self.setMinimumWidth(720)
 
         self._layer_labels = list(layer_labels or [])
         self._group_row_data = []
@@ -1118,7 +1118,7 @@ class PhasorCenterLayerSettingsDialog(QDialog):
             self.setWindowTitle("Phasor Center Settings")
         else:
             self.setWindowTitle("Phasor Center Settings (Multi-Layer)")
-        self.setMinimumWidth(500)
+        self.setMinimumWidth(680)
 
         self._group_row_data = []
 


### PR DESCRIPTION
## Summary

Several dialogs and the Batch Analysis window opened too narrow for their content, forcing unnecessary scrolling/wrapping; the Masks tab's file list was also squeezed into a short scrollable strip despite plenty of free space below it.

- Widen the group/settings/selection dialogs so their content isn't cramped:
  - Contour groups (`ContourLayerSettingsDialog`, incl. batch analysis' "Configure Groups"): 550 → 720
  - Phasor center groups (`PhasorCenterLayerSettingsDialog`): 500 → 680
  - Histogram settings / configure groups (`HistogramSettingsDialog`): 340 → 520
  - Assign Mask Layers (`MaskAssignmentDialog`): 400 → 560
  - Select Phasor Center Layers (`PhasorCenterSelectionDialog`): 360 → 520
  - Reorder Files for 3D Stack (`FileOrderDialog`): 500 → 680
- Batch Analysis window: opens at 760px instead of being capped at 540px.
  - Added `_popout_min_width` to `PopoutWindowMixin` — a floor on the *initial* pop-out width, separate from `minimumWidth`, so the window still opens comfortably wide but users on small displays can still shrink it back down. Only `BatchAnalysisWidget` opts into a higher floor (760); every other pop-out widget keeps the previous default (360), so this is a no-op elsewhere.
- Masks tab: the file/mask list now grows to fill the tab's available height instead of sitting in a short (~90px) scroll area with a large empty area below it.
  - Added an opt-in `stretch_body` flag to `_enable_section` (default off, so the other eight analysis tabs are unaffected) and gave the mask list a 360px minimum height.

## Verification

Measured actual rendered widths/heights via Qt (`dialog.show(); dialog.width()`, etc.) rather than relying on the constants alone, since Qt's layout system can override a `setMinimumWidth` with a larger size hint:

| Element | Before | After |
|---|---|---|
| Contour groups dialog | 550 | 720 |
| Phasor center groups dialog | 500 | 680 |
| Histogram settings dialog | 340 | 520 |
| Mask assignment dialog | 400 | 560 |
| Phasor center selection dialog | 360 | 520 |
| File order dialog | 500 | 680 |
| Batch Analysis window | 540 | 760 |
| Masks tab list height (@ 760×840 window) | 88px (14% of tab) | 430px (67% of tab) |