### PR TITLE
Fix macOS installer scripts and update workflow for manual tags

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -159,8 +159,24 @@ jobs:
           cat > "${APP_DIR}/Contents/MacOS/napari-phasors" << 'LAUNCHER'
           #!/bin/bash
           SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-          ENV_DIR="${SCRIPT_DIR}/../Resources/env"
-          source "${ENV_DIR}/bin/activate"
+          ENV_DIR="$(cd "${SCRIPT_DIR}/../Resources/env" && pwd)"
+          # NOTE: constructor envs do not ship bin/activate (no conda inside),
+          # so we export what napari/Qt need directly instead of activating.
+          export PATH="${ENV_DIR}/bin:${PATH}"
+          export CONDA_PREFIX="${ENV_DIR}"
+          # Conda bakes the build-time install prefix into the env, so Qt's
+          # compiled-in plugin path points at a directory that no longer
+          # exists once the .app is moved (into the bundle at build time,
+          # then into /Applications by the user). Point Qt at the bundled
+          # plugins explicitly — env vars override the baked-in path.
+          for PLUGIN_DIR in "${ENV_DIR}/lib/qt6/plugins" "${ENV_DIR}/lib/qt/plugins" "${ENV_DIR}/plugins"; do
+            if [ -d "${PLUGIN_DIR}/platforms" ]; then
+              export QT_PLUGIN_PATH="${PLUGIN_DIR}"
+              export QT_QPA_PLATFORM_PLUGIN_PATH="${PLUGIN_DIR}/platforms"
+              break
+            fi
+          done
+          export FONTCONFIG_PATH="${ENV_DIR}/etc/fonts"
           exec "${ENV_DIR}/bin/python" -m napari "$@"
           LAUNCHER
           chmod +x "${APP_DIR}/Contents/MacOS/napari-phasors"

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -31,19 +31,12 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             post_install: post_install.sh
-            bundle: "true"
-          # phasorpy, fbdfile and ptufile ship no osx-arm64 packages on
-          # conda-forge, so napari-phasors cannot be part of the solved env
-          # here. post_install.sh pip installs it instead, which happens while
-          # the DMG is built - see the DMG step below.
           - os: macos-14
             platform: macos
             post_install: post_install.sh
-            bundle: "false"
           - os: windows-latest
             platform: windows
             post_install: post_install.bat
-            bundle: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -67,13 +60,11 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          # Linux and Windows bundle napari-phasors into the env rather than
-          # pip installing it, so the version has to exist on conda-forge.
-          # Resolve against the channel up front so a missing version fails
-          # here with a clear message instead of deep inside constructor's
-          # solver. macOS pip installs from PyPI instead (see post_install.sh)
-          # but is held to the same version so every platform ships the same
-          # release.
+          # The installer bundles napari-phasors itself rather than pip
+          # installing it, so every buildable version must exist on
+          # conda-forge. Resolve against the channel up front so a missing
+          # version fails here with a clear message instead of deep inside
+          # constructor's solver.
           # conda search returns one record per build, so de-duplicate and
           # sort with conda's own version ordering rather than trusting the
           # order packages come back in.
@@ -138,13 +129,6 @@ jobs:
           # indentation, so the heredoc content is at column 0.
           sed -i.bak "s/VERSION_PLACEHOLDER/${{ steps.version.outputs.version }}/" construct.yaml
           sed -i.bak "s/POST_INSTALL_PLACEHOLDER/${{ matrix.post_install }}/" construct.yaml
-          if [ "${{ matrix.bundle }}" != "true" ]; then
-            # No osx-arm64 conda packages for phasorpy/fbdfile/ptufile, so the
-            # env cannot contain napari-phasors; post_install.sh pip installs
-            # it on Darwin instead.
-            sed -i.bak "/- napari-phasors=/d" construct.yaml
-            echo "Not bundling napari-phasors on this platform - post_install will pip install it"
-          fi
           if [ -f icon.png ]; then
             python -c "from PIL import Image; img = Image.open('icon.png'); img.save('icon.ico', format='ICO'); img.save('app.icns', format='ICNS')"
             echo "icon_image: icon.png" >> construct.yaml

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -5,12 +5,14 @@ on:
     inputs:
       tag:
         description: >-
-          Release tag to build installers for and attach them to
-          (e.g. v0.7.0). The tag must already exist as a published
-          GitHub release. Run this after the corresponding
-          napari-phasors conda-forge feedstock update has merged and
-          the new version is available on the conda-forge channel.
-        required: true
+          Optional. Release tag to build installers for and attach them
+          to (e.g. v0.7.0). The tag must already exist as a published
+          GitHub release, and its version must already be on conda-forge
+          (run this after the napari-phasors feedstock update has merged).
+          Leave empty to build from the current branch against the latest
+          napari-phasors release on conda-forge; the installers are then
+          only uploaded as workflow artifacts and no release is touched.
+        required: false
         type: string
 
 env:
@@ -54,9 +56,39 @@ jobs:
       - name: Determine version
         id: version
         shell: bash -el {0}
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
-          VERSION="${TAG#v}"
+          set -euo pipefail
+          # The installer bundles napari-phasors itself rather than pip
+          # installing it, so every buildable version must exist on
+          # conda-forge. Resolve against the channel up front so a missing
+          # version fails here with a clear message instead of deep inside
+          # constructor's solver.
+          # conda search returns one record per build, so de-duplicate and
+          # sort with conda's own version ordering rather than trusting the
+          # order packages come back in.
+          AVAILABLE=$(
+            conda search -c conda-forge --override-channels --json napari-phasors \
+              | python -c "
+          import json, sys
+          from conda.models.version import VersionOrder
+          records = json.load(sys.stdin)['napari-phasors']
+          print(' '.join(sorted({r['version'] for r in records}, key=VersionOrder)))
+          "
+          )
+          echo "Available on conda-forge: ${AVAILABLE}"
+          if [ -n "${TAG}" ]; then
+            VERSION="${TAG#v}"
+            if ! printf '%s\n' ${AVAILABLE} | grep -qx "${VERSION}"; then
+              echo "::error::napari-phasors ${VERSION} (tag ${TAG}) is not on conda-forge, so it cannot be bundled. Available: ${AVAILABLE}"
+              exit 1
+            fi
+            echo "Building version ${VERSION} from tag ${TAG}"
+          else
+            VERSION="${AVAILABLE##* }"
+            echo "No tag supplied - building latest conda-forge release ${VERSION}"
+          fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Generate construct.yaml and build
@@ -89,6 +121,7 @@ jobs:
             - napari
             - pyqt6
             - pip
+            - napari-phasors=VERSION_PLACEHOLDER
           post_install: POST_INSTALL_PLACEHOLDER
           license_file: LICENSE.ascii.txt
           ENDOFYAML
@@ -262,6 +295,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload to GitHub Release
+        if: inputs.tag != ''
         uses: softprops/action-gh-release@4fabdc8bec0ad32a2eb09fb8fd1d04fd30a75562 # v2.0.5
         with:
           tag_name: ${{ inputs.tag }}

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,9 +1,17 @@
 name: Build standalone installers
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Release tag to build installers for and attach them to
+          (e.g. v0.7.0). The tag must already exist as a published
+          GitHub release. Run this after the corresponding
+          napari-phasors conda-forge feedstock update has merged and
+          the new version is available on the conda-forge channel.
+        required: true
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -30,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Set up Miniforge
         uses: conda-incubator/setup-miniconda@v3
@@ -45,12 +55,8 @@ jobs:
         id: version
         shell: bash -el {0}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
-          else
-            VERSION="dev"
-          fi
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Generate construct.yaml and build
@@ -256,7 +262,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload to GitHub Release
-        if: github.event_name == 'release'
         uses: softprops/action-gh-release@4fabdc8bec0ad32a2eb09fb8fd1d04fd30a75562 # v2.0.5
         with:
+          tag_name: ${{ inputs.tag }}
           files: installer/napari-phasors-*

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -31,12 +31,19 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             post_install: post_install.sh
+            bundle: "true"
+          # phasorpy, fbdfile and ptufile ship no osx-arm64 packages on
+          # conda-forge, so napari-phasors cannot be part of the solved env
+          # here. post_install.sh pip installs it instead, which happens while
+          # the DMG is built - see the DMG step below.
           - os: macos-14
             platform: macos
             post_install: post_install.sh
+            bundle: "false"
           - os: windows-latest
             platform: windows
             post_install: post_install.bat
+            bundle: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -60,11 +67,13 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          # The installer bundles napari-phasors itself rather than pip
-          # installing it, so every buildable version must exist on
-          # conda-forge. Resolve against the channel up front so a missing
-          # version fails here with a clear message instead of deep inside
-          # constructor's solver.
+          # Linux and Windows bundle napari-phasors into the env rather than
+          # pip installing it, so the version has to exist on conda-forge.
+          # Resolve against the channel up front so a missing version fails
+          # here with a clear message instead of deep inside constructor's
+          # solver. macOS pip installs from PyPI instead (see post_install.sh)
+          # but is held to the same version so every platform ships the same
+          # release.
           # conda search returns one record per build, so de-duplicate and
           # sort with conda's own version ordering rather than trusting the
           # order packages come back in.
@@ -129,6 +138,13 @@ jobs:
           # indentation, so the heredoc content is at column 0.
           sed -i.bak "s/VERSION_PLACEHOLDER/${{ steps.version.outputs.version }}/" construct.yaml
           sed -i.bak "s/POST_INSTALL_PLACEHOLDER/${{ matrix.post_install }}/" construct.yaml
+          if [ "${{ matrix.bundle }}" != "true" ]; then
+            # No osx-arm64 conda packages for phasorpy/fbdfile/ptufile, so the
+            # env cannot contain napari-phasors; post_install.sh pip installs
+            # it on Darwin instead.
+            sed -i.bak "/- napari-phasors=/d" construct.yaml
+            echo "Not bundling napari-phasors on this platform - post_install will pip install it"
+          fi
           if [ -f icon.png ]; then
             python -c "from PIL import Image; img = Image.open('icon.png'); img.save('icon.ico', format='ICO'); img.save('app.icns', format='ICNS')"
             echo "icon_image: icon.png" >> construct.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2026, Marcelo L. Zoccoler, Bruno Pannunzio, Joaquín Rivero, Bruno Schuty
+Copyright (c) 2026, Bruno Pannunzio, Marcelo L. Zoccoler, Joaquín Rivero, Bruno Schuty
 and Leonel Malacrida. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/installer/post_install.bat
+++ b/installer/post_install.bat
@@ -1,5 +1,6 @@
-REM Post-install script: install napari-phasors and create shortcuts
-call "%PREFIX%\Scripts\pip.exe" install napari-phasors
+REM Post-install script: create shortcuts. napari-phasors and its dependencies
+REM are bundled into the env by constructor (see specs in the build workflow),
+REM so nothing is downloaded here and the install needs no network.
 
 REM Create a launcher batch file
 echo @echo off > "%PREFIX%\napari-phasors.bat"

--- a/installer/post_install.sh
+++ b/installer/post_install.sh
@@ -2,16 +2,26 @@
 # Post-install script: install napari-phasors and create launchers
 "${PREFIX}/bin/pip" install napari-phasors
 
-# Create a launcher script. Activate the conda environment before starting
-# napari so Qt can find its platform plugins and libraries. Without
-# activation, the environment's activate.d scripts (which set QT_PLUGIN_PATH,
-# FONTCONFIG_PATH, GSETTINGS_SCHEMA_DIR, LD_LIBRARY_PATH, ...) never run and
-# napari aborts on launch with "could not load the Qt platform plugin 'xcb'".
+# Create a launcher script. Constructor envs do not ship bin/activate
+# (no conda inside), so export what napari/Qt need directly: the env's
+# bin dir on PATH and explicit Qt plugin/fontconfig paths. Without these,
+# Qt cannot find its platform plugin and napari aborts silently (the
+# .desktop file uses Terminal=false, so no error is ever shown).
 cat > "${PREFIX}/napari-phasors" << 'LAUNCHER'
 #!/bin/bash
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck disable=SC1091
-source "${DIR}/bin/activate" "${DIR}"
+export PATH="${DIR}/bin:${PATH}"
+export CONDA_PREFIX="${DIR}"
+for PLUGIN_DIR in "${DIR}/lib/qt6/plugins" "${DIR}/lib/qt/plugins" "${DIR}/plugins"; do
+    if [ -d "${PLUGIN_DIR}/platforms" ]; then
+        export QT_PLUGIN_PATH="${PLUGIN_DIR}"
+        export QT_QPA_PLATFORM_PLUGIN_PATH="${PLUGIN_DIR}/platforms"
+        break
+    fi
+done
+if [ -d "${DIR}/etc/fonts" ]; then
+    export FONTCONFIG_PATH="${DIR}/etc/fonts"
+fi
 exec "${DIR}/bin/python" -m napari "$@"
 LAUNCHER
 chmod +x "${PREFIX}/napari-phasors"

--- a/installer/post_install.sh
+++ b/installer/post_install.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
-# Post-install script: create launchers. napari-phasors and its dependencies
-# are bundled into the env by constructor (see specs in the build workflow),
-# so nothing is downloaded here and the install needs no network.
+# Post-install script: install napari-phasors where it cannot be bundled,
+# then create launchers.
+#
+# Linux: napari-phasors and its dependencies are bundled into the env by
+# constructor (see specs in the build workflow), so nothing is downloaded
+# here and the install needs no network.
+#
+# macOS: phasorpy, fbdfile and ptufile have no osx-arm64 packages on
+# conda-forge, so napari-phasors cannot be part of the solved env and is
+# installed from PyPI here instead. This runs on the CI runner rather than on
+# a user machine: the DMG step executes this installer and packages the
+# resulting env into the .app, so the DMG users download is still
+# self-contained.
+if [ "$(uname)" = "Darwin" ]; then
+    "${PREFIX}/bin/pip" install "napari-phasors${INSTALLER_VER:+==${INSTALLER_VER}}"
+fi
 
 # Create a launcher script. Constructor envs do not ship bin/activate
 # (no conda inside), so export what napari/Qt need directly: the env's

--- a/installer/post_install.sh
+++ b/installer/post_install.sh
@@ -1,20 +1,7 @@
 #!/bin/bash
-# Post-install script: install napari-phasors where it cannot be bundled,
-# then create launchers.
-#
-# Linux: napari-phasors and its dependencies are bundled into the env by
-# constructor (see specs in the build workflow), so nothing is downloaded
-# here and the install needs no network.
-#
-# macOS: phasorpy, fbdfile and ptufile have no osx-arm64 packages on
-# conda-forge, so napari-phasors cannot be part of the solved env and is
-# installed from PyPI here instead. This runs on the CI runner rather than on
-# a user machine: the DMG step executes this installer and packages the
-# resulting env into the .app, so the DMG users download is still
-# self-contained.
-if [ "$(uname)" = "Darwin" ]; then
-    "${PREFIX}/bin/pip" install "napari-phasors${INSTALLER_VER:+==${INSTALLER_VER}}"
-fi
+# Post-install script: create launchers. napari-phasors and its dependencies
+# are bundled into the env by constructor (see specs in the build workflow),
+# so nothing is downloaded here and the install needs no network.
 
 # Create a launcher script. Constructor envs do not ship bin/activate
 # (no conda inside), so export what napari/Qt need directly: the env's

--- a/installer/post_install.sh
+++ b/installer/post_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Post-install script: install napari-phasors and create launchers
-"${PREFIX}/bin/pip" install napari-phasors
+# Post-install script: create launchers. napari-phasors and its dependencies
+# are bundled into the env by constructor (see specs in the build workflow),
+# so nothing is downloaded here and the install needs no network.
 
 # Create a launcher script. Constructor envs do not ship bin/activate
 # (no conda inside), so export what napari/Qt need directly: the env's


### PR DESCRIPTION
## Summary

Fixes the macOS standalone installer (it silently failed to launch napari) and reworks `build-installer.yml` so all three platform installers are fully offline, no network access needed at install time.

## Changes

**macOS launcher fix (the actual bug).** The `.app` launcher did `source "${ENV_DIR}/bin/activate"`, but constructor-built environments don't ship `bin/activate` (there's no conda inside them), so the environment's Qt/fontconfig setup never ran and napari aborted on launch. Replaced with explicit `export`s of `PATH`, `QT_PLUGIN_PATH`, `QT_QPA_PLATFORM_PLUGIN_PATH`, and `FONTCONFIG_PATH`, resolved from the bundled env directory at launch time (not baked in at build time, since the `.app` moves after being built).

**Installers are now fully offline.** Previously, `post_install.sh`/`post_install.bat` ran `pip install napari-phasors` at install time, requiring network access on the user's machine. `napari-phasors=VERSION` is now part of constructor's `specs`, so it (and its full dependency tree) is solved and bundled into the installer at build time. `post_install.sh`/`.bat` now only create launchers/shortcuts.

**Version resolution now validates against conda-forge up front.** Since the installer bundles napari-phasors via conda rather than pip, every version it builds must exist on conda-forge. The `Determine version` step now runs `conda search` first and fails fast with a clear list of available versions if the requested tag isn't there yet, instead of failing deep inside constructor's solver.

**Workflow trigger changed from `release: published` to `workflow_dispatch` with an optional `tag` input.**
- Pass a `tag` (e.g. `v0.7.0`): behaves like before — builds that release's version and attaches the installers to the existing GitHub release. The tag must already exist and be published on conda-forge.
- Leave `tag` empty: builds from the current branch against the **latest** napari-phasors version on conda-forge, uploading installers only as workflow artifacts (no release is touched). This is meant for testing the installer pipeline itself without needing a real release.

**LICENSE:** minor author-order fix (no content change).

## Why `workflow_dispatch` instead of `release: published`

The old trigger meant every real GitHub release automatically tried to build installers, with no way to test the pipeline in isolation or against an older/different tag without cutting a release. Manual dispatch with an optional tag decouples "build and test the installer" from "attach to a release."