### PR TITLE
Update docs for release v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License BSD-3](https://img.shields.io/pypi/l/napari-phasors.svg?color=green)](https://github.com/napari-phasors/napari-phasors/raw/main/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/napari-phasors.svg?color=green)](https://pypi.org/project/napari-phasors)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/napari-phasors.svg)](https://anaconda.org/conda-forge/napari-phasors)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-phasors.svg?color=green)](https://python.org)
 [![tests](https://github.com/napari-phasors/napari-phasors/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/napari-phasors/napari-phasors/actions/workflows/run-tests.yml)
 [![codecov](https://codecov.io/gh/napari-phasors/napari-phasors/branch/main/graph/badge.svg)](https://codecov.io/gh/napari-phasors/napari-phasors)
@@ -34,6 +35,7 @@ available at **[https://napari-phasors.readthedocs.io](https://napari-phasors.re
 - **FRET analysis** with donor trajectory visualization and multi-layer donor/background source selection
 - **Selections** via manual drawing, circular/polar/elliptical cursors, and automatic clustering
 - **Exporting** results as OME-TIF or CSV (multiple layers simultaneously)
+- **Batch Analysis** — apply the same reading and analysis pipeline (calibration, filtering, masking, component analysis, phasor mapping, FRET, selections) to every file in a folder and export the results headlessly
 
 ## Installation
 
@@ -54,10 +56,25 @@ page. Download and run — no Python installation
 needed. Installers are ~350–470 MB and bundle
 everything required.
 
+### Using conda (conda-forge)
+
+napari-phasors is available on the
+[conda-forge](https://anaconda.org/conda-forge/napari-phasors) channel,
+which installs napari, Qt, and every dependency in one step. We recommend
+using [miniforge](https://conda-forge.org/download/). If you use Anaconda or
+Miniconda, replace `mamba` with `conda`.
+
+    mamba create -y -n napari-phasors-env -c conda-forge napari-phasors
+
+Activate the environment:
+
+    conda activate napari-phasors-env
+    napari
+
 ### Using conda + pip
 
-We recommend using [miniforge](https://conda-forge.org/download/). If you
-use Anaconda or Miniconda, replace `mamba` with `conda`.
+Alternatively, create a plain conda environment and install napari-phasors
+from PyPI (useful to get a release before it lands on conda-forge):
 
     mamba create -y -n napari-phasors-env napari pyqt6 python=3.14 # or 3.12, 3.13
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ available at **[https://napari-phasors.readthedocs.io](https://napari-phasors.re
         - `.ome.tif`, `.ome.tiff`, `.r64`, `.ref`, `.ifli`, `.lif`, `.json`
 - **Phasor analysis** on multiple layers simultaneously, including support for stacking multiple raw data files
 - **Calibration** using reference images with known lifetimes
-- **Filtering** with median, wavelet, and automatic thresholding (Otsu, Li, Yen)
+- **Filtering** with median, wavelet (binlet pawFLIM), and automatic thresholding (Otsu, Li, Yen)
 - **Component analysis** for multi-component systems
 - **Phasor Mapping** — colormap apparent/normal lifetime, phasor phase, and phasor modulation per pixel, with interactive 1D histograms, statistics tables, and arc overlay tools
 - **FRET analysis** with donor trajectory visualization and multi-layer donor/background source selection

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -24,6 +24,7 @@ parts:
   - file: guides/fret_analysis
   - file: guides/histogram_statistics
   - file: guides/exporting
+  - file: guides/batch_analysis
 - caption: API Reference
   chapters:
   - file: api/index

--- a/docs/guides/batch_analysis.md
+++ b/docs/guides/batch_analysis.md
@@ -268,7 +268,7 @@ equivalent and for the analysis-type concepts.
 ### Outputs
 
 Formats for exporting the component fraction images, per-file histogram,
-statistics table (CSV), and the phasor plot with the components overlay — see
+statistics table (CSV), and the phasor plot with the components overlay. See
 [Outputs (shared pattern)](#outputs-shared-pattern) below.
 
 
@@ -301,7 +301,7 @@ per file. See {doc}`phasor_mapping` for the interactive-widget equivalent.
 ### Outputs
 
 Formats for exporting the mapped images, per-file histogram, statistics table
-(CSV), and the phasor plot with the mesh/coloring overlay — see
+(CSV), and the phasor plot with the mesh/coloring overlay. See
 [Outputs (shared pattern)](#outputs-shared-pattern) below.
 
 
@@ -332,7 +332,7 @@ interactive-widget equivalent and the underlying concept.
 ### Outputs
 
 Formats for exporting the FRET-efficiency images, per-file histogram,
-statistics table (CSV), and the phasor plot with the FRET overlay — see
+statistics table (CSV), and the phasor plot with the FRET overlay. See
 [Outputs (shared pattern)](#outputs-shared-pattern) below.
 
 
@@ -346,7 +346,7 @@ section layout:
 | **Export \<analysis\> as** | Formats for the colormapped analysis image (one per file): PNG (rendered image) and/or CSV (raw per-pixel values). |
 | **Export histogram as** | Formats for the per-file histogram of the analysis values: PNG and/or CSV. |
 | **Configure groups and display…** | Enabled once a histogram format is selected. Sets the merged/individual/grouped display mode (shared across tabs), assigns files to groups for combined grouped histograms/statistics, and sets histogram display options. |
-| **Export statistics table (CSV)** | Writes per-file (and per-group, if grouped) descriptive statistics — see {doc}`histogram_statistics`. |
+| **Export statistics table (CSV)** | Writes per-file (and per-group, if grouped) descriptive statistics. See {doc}`histogram_statistics`. |
 | **Export Phasor Plot with \<analysis\> Overlay (PNG)** | Exports the phasor plot styled per the **Phasor Plot Settings** tab, with the tab's analysis overlay (components, mesh, or FRET trajectory) drawn on top. |
 
 ## Running the batch

--- a/docs/guides/batch_analysis.md
+++ b/docs/guides/batch_analysis.md
@@ -175,10 +175,10 @@ analysis runs. See {doc}`filtering_thresholding` for the concept.
 
 | Parameter | Description |
 |---|---|
-| **Filter method** | **None**, **Median**, or **Wavelet**. |
+| **Filter method** | **None**, **Median**, or **Wavelet (binlet pawFLIM)**. |
 | **Median kernel size** *(Median)* | Side length (pixels) of the square median-filter window; larger windows smooth more. |
 | **Median repetitions** *(Median)* | Number of times the median filter is applied in succession. |
-| **Wavelet sigma** *(Wavelet)* | Noise standard deviation used by the wavelet filter; higher values remove more noise. Requires harmonics with a double/half counterpart (e.g. 1 and 2). |
+| **Wavelet sigma** *(Wavelet)* | Noise standard deviation used by the wavelet (binlet pawFLIM) filter; higher values remove more noise. Requires harmonics with a double/half counterpart (e.g. 1 and 2). |
 | **Wavelet levels** *(Wavelet)* | Number of wavelet decomposition levels used for denoising. |
 
 ### Threshold

--- a/docs/guides/batch_analysis.md
+++ b/docs/guides/batch_analysis.md
@@ -1,0 +1,359 @@
+# Batch Analysis
+
+The **Batch Analysis** widget applies the same reading and analysis pipeline
+to every supported file in a folder, then exports the results, without
+requiring you to open each file individually in the viewer.
+
+Open it from:
+
+**Plugins -> napari-phasors -> Batch Analysis**
+
+## Overview
+
+The widget is organized into tabs, one per pipeline stage:
+
+- **Setup** — input folder, file format, read parameters, export destination
+- **Signal Export** — export the average signal (decay/spectrum) per file
+- **Phasor Plot Settings** — shared styling/export options for phasor plots
+- **Calibration** — calibrate against a reference of known lifetime
+- **Filter & Threshold** — denoise phasor coordinates and mask dim pixels
+- **Masks** — restrict analysis to a region of interest per file
+- **Selection** — manual cursors or automatic clustering
+- **Components** — multi-component fraction analysis
+- **Phasor Mapping** — lifetime, phase, and modulation images
+- **FRET** — apparent FRET efficiency images
+
+Only **Setup** is mandatory: it requires an **input folder** and an **export
+folder**. Every other analysis tab (Signal Export, Calibration, Filter &
+Threshold, Masks, Selection, Components, Phasor Mapping, FRET) has an
+**Enable** toggle at the top; the rest of the tab's controls are greyed out
+until it is switched on, and clicking a disabled control flashes a reminder
+next to the toggle. Fields marked with a red <span style='color:#e74c3c;'>*</span>
+are required for the tab to run.
+
+Calibration and Filter & Threshold, if enabled, are applied first (in that
+order) since they change the phasor coordinates that every other analysis
+reads. Masks restrict which pixels are analyzed. The remaining analysis tabs
+(Signal Export, Selection, Components, Phasor Mapping, FRET) are independent
+of each other and can be enabled in any combination in a single run.
+
+Once configured, click **Run batch analysis** at the bottom of the widget. A
+progress bar and status label track the run across all files.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/batch%20analysis.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/batch%20analysis.mp4" type="video/mp4">
+</video>
+
+## Setup
+
+Configures which files are processed, how they are read, and where and how
+results are exported.
+
+### Input folder
+
+| Parameter | Description |
+|---|---|
+| **Copy settings from layer / OME-TIFF…** | Populates the analysis tabs (calibration, filter, phasor mapping, FRET, and component positions) from the settings stored in an already-loaded phasor layer, or from an `.ome.tif`/`.ome.tiff` file written by napari-phasors. |
+| **Folder containing the files to process** *(required)* | The folder scanned for input files. |
+| **Include subfolders** | When checked, files are also discovered recursively in subfolders. |
+| **File format** | The file extension to process from the scanned folder (e.g. `.ptu`, `.sdt`, `.ome.tif`). Only one format is processed per run. |
+
+### Read parameters
+
+| Parameter | Description |
+|---|---|
+| **Harmonics** | Comma-separated harmonics to read (e.g. `1, 2`), `all`, or empty for the reader's default. |
+| **Reader keyword arguments** | Format-specific reader parameters (e.g. channel, frame) shown as typed fields for the selected format, plus a **+ Add reader keyword argument** button for any additional key/value pair to pass to the reader. |
+
+### Export
+
+| Parameter | Description |
+|---|---|
+| **Destination folder for the results** *(required)* | Where all exported files are written. |
+| **Export Intensity Image (with phasor data) as** | One or more of **OME-TIFF** (preserves phasor data and settings, re-importable), **CSV**, and **Image (PNG)**. |
+| **Preserve relative subfolder structure** | Mirrors the input folder's subfolder layout inside the export folder instead of flattening all outputs into one folder. |
+| **Include colorbar in exported analysis images (PNG)** | Draws a colorbar next to colormapped analysis images (component fractions, phasor mapping, FRET). |
+| **Image DPI** | Rendering resolution for exported PNG images, phasor plots, and histograms: Low (100), Mid (300), or High (600). Higher DPI gives sharper but larger/slower exports. |
+| **Filename suffix** | Optional text appended to every exported filename. |
+| **Also load results into the viewer** | In addition to exporting to disk, adds the resulting layers to the napari viewer. |
+
+### Performance
+
+| Parameter | Description |
+|---|---|
+| **Bounded memory (streaming aggregation)** | Accumulates fixed-bin histograms instead of holding every pixel in memory for grouped contour/histogram outputs. With this on, median and center-of-mass values become histogram approximations. Useful for very large batches. |
+| **Parallel workers** | Number of files read and computed concurrently (1 = single-threaded). File writing and plot rendering always stay on the main thread. |
+
+## Signal Export
+
+Exports the average signal along the axis the phasor is computed on (time
+bins for FLIM, wavelength for hyperspectral data). For raw files the signal is
+averaged per pixel over the batch mask (see **Masks**); for processed
+OME-TIFF files written by napari-phasors, the stored signal (summed over all
+pixels at import) is used instead and the mask does not apply. This tab is
+locked with an explanation if the selected format cannot provide a signal
+(e.g. processed R64/REF/IFLI files).
+
+| Parameter | Description |
+|---|---|
+| **Export individual signal plots (one per file)** | Exports one signal plot per file, drawn like the signal preview in the Custom Import widget. |
+| **Line color** | Color of the individual signal line. |
+| **Export combined signal plot (mean ± shaded SD)** | Overlays every file's signal as a per-group mean line with a shaded ±1 standard-deviation band. |
+| **Configure Groups…** | Assigns files to groups for the combined plot and sets each group's color/legend. Grouping is shared with the **Phasor Plot Settings** tab. |
+| **Export plots as** | Output formats for the signal plots: PNG (rendered plot) and/or CSV (underlying values). |
+| **Normalization** | Scales each signal before plotting so files of different intensities are comparable: **None** (average per pixel), **Peak** (max = 1), or **Area** (sum = 1). |
+| **Channels** | For multichannel files, draw each channel in its own plot (**Separate**) or overlay all channels in one plot (**Together**). Single-channel files are unaffected. |
+
+## Phasor Plot Settings
+
+Styles and exports the phasor plots shared by every analysis tab. Individual
+(per-file) and combined (all files pooled) plots are configured
+independently, and the chosen styles propagate to the analysis-tab overlay
+plots (Components, Phasor Mapping, FRET, Selection).
+
+### Common appearance
+
+| Parameter | Description |
+|---|---|
+| **Semicircle (FLIM) / Full polar plot (HSI)** | Toggles between drawing the universal semicircle (single-exponential reference, for FLIM data) or the full polar plot (for hyperspectral data). |
+| **White background** | Renders exported plots on a white background instead of the napari theme background. |
+| **Export legends** | Includes a legend in exported phasor plots. |
+| **Frequency (MHz)** | Frequency used to place lifetime tick marks on the semicircle of the exported plot. |
+| **Show phasor centers / color** | Marks each file's phasor center (mean G/S) on the plot, in the chosen color. |
+| **Export phasor centers (CSV, all harmonics)** | Writes a CSV with each file's phasor center for every harmonic. |
+
+### Individual and combined plots
+
+Both the **Individual phasor plots** and **Combined phasor plot** sections
+share the same style controls:
+
+| Parameter | Description |
+|---|---|
+| **Export individual/combined phasor plots** | Master checkbox for exporting this plot mode. |
+| **Plot type** | **Histogram** (2-D density), **Scatter** (dot plot), **Contour** (density contour lines), or **None** (export no phasor data, e.g. only the phasor centers). |
+| **Colormap** | Colormap for the density (Histogram/Contour). |
+| **Histogram bins** | Number of bins per axis for the histogram/contour density. |
+| **Log scale** | Uses a logarithmic color scale for the histogram density (Histogram only). |
+| **Marker size / color / alpha** | Scatter-only: size, color, and opacity of the scatter markers. |
+| **Contour levels / linewidth** | Contour-only: number of contour lines and their line width. |
+
+The combined plot additionally has:
+
+| Parameter | Description |
+|---|---|
+| **Combined contour mode** | **Merged** pools every file into a single contour; **Grouped** draws one contour per file group (Contour plot type only). |
+| **Configure Groups…** | Assigns files to groups and sets group colors/legend for the grouped contour (shared with Signal Export). |
+
+### Zoomed section
+
+| Parameter | Description |
+|---|---|
+| **Export a zoomed section** | In addition to the full plot, saves a `_zoom` PNG cropped to the limits below, for both individual and combined plots and all analysis-tab overlay plots. |
+| **G (x) range / S (y) range** | Zoom limits in phasor coordinates. |
+| **Draw the zoom region as a rectangle on the full plot** | Outlines the zoomed region with a rectangle on the full (un-cropped) plot. |
+
+## Calibration
+
+Calibrates phasor coordinates against a reference of known lifetime before
+the rest of the pipeline runs. See {doc}`calibration` for the concept.
+
+| Parameter | Description |
+|---|---|
+| **Reference source** | Where the calibration reference comes from: **Same reference for all** files, **Different reference per subfolder**, or **Use copied phase/modulation** (from settings copied in the Setup tab). |
+| **Reference layer** *(required, "Same" mode)* | A phasor layer already loaded in the viewer, used as the reference for every file. |
+| **Reference file** *(alternative to Reference layer)* | Path to a reference file read directly instead of using a loaded layer. |
+| **Per-subfolder reference files** *("Different reference per subfolder" mode)* | One reference file picker per subfolder discovered in the input folder. |
+| **Frequency (MHz)** *(required)* | Laser repetition/modulation frequency at which the data and reference were acquired. |
+| **Reference lifetime (ns)** *(required)* | Known fluorescence lifetime of the calibration reference. |
+
+## Filter & Threshold
+
+Smooths phasor coordinates and excludes low-intensity pixels before any
+analysis runs. See {doc}`filtering_thresholding` for the concept.
+
+### Filter
+
+| Parameter | Description |
+|---|---|
+| **Filter method** | **None**, **Median**, or **Wavelet**. |
+| **Median kernel size** *(Median)* | Side length (pixels) of the square median-filter window; larger windows smooth more. |
+| **Median repetitions** *(Median)* | Number of times the median filter is applied in succession. |
+| **Wavelet sigma** *(Wavelet)* | Noise standard deviation used by the wavelet filter; higher values remove more noise. Requires harmonics with a double/half counterpart (e.g. 1 and 2). |
+| **Wavelet levels** *(Wavelet)* | Number of wavelet decomposition levels used for denoising. |
+
+### Threshold
+
+| Parameter | Description |
+|---|---|
+| **Threshold method** | **None**, **Manual**, or automatic (**Otsu**, **Li**, **Yen**). |
+| **Threshold (min)** *(Manual)* | Minimum mean intensity a pixel must have to be kept; dimmer pixels are excluded (set to NaN). |
+| **Threshold (max)** *(Manual)* | Maximum mean intensity a pixel may have to be kept; set to `none` to disable the upper bound. |
+
+## Masks
+
+Restricts each image to a region of interest using mask image files matched
+to inputs by name (e.g. `ABC.ptu` ↔ `ABC_mask.png`). See {doc}`mask` for the
+interactive-widget equivalent.
+
+| Parameter | Description |
+|---|---|
+| **Add mask folder…** | Adds a folder to scan for mask image files (multiple folders can be added). |
+| **Clear** | Removes all added mask folders. |
+| **Include mask subfolders** | Scans mask folders recursively. |
+| **Per-file mask row** | For each matched input file, a dropdown to pick its mask file and an **Invert** checkbox. Pixels outside the mask (or inside it, if inverted) are excluded (set to NaN) before analysis. |
+
+
+## Selection
+
+Labels phasor regions with manual cursors or automatic GMM clustering, and
+exports a selection (labels) image per file. See {doc}`phasor_selection` for
+the interactive-widget equivalent.
+
+| Parameter | Description |
+|---|---|
+| **Harmonic** | Harmonic whose phasor coordinates the cursors/clustering act on. |
+| **Mode** | **Manual cursors** or **Automatic clustering (GMM)**. |
+
+### Manual cursors
+
+Each cursor row (**+ Add cursor**) has:
+
+| Parameter | Description |
+|---|---|
+| **Type** | **Circular**, **Elliptic**, or **Polar**. |
+| **Color** | Display color of the cursor region. |
+| **G, S** *(Circular, Elliptic)* | Center coordinates of the cursor. |
+| **r** *(Circular, Elliptic)* | Radius (major radius for Elliptic). |
+| **rₘ** *(Elliptic)* | Minor radius. |
+| **∠** *(Elliptic)* | Rotation angle, in degrees. |
+| **φ₋, φ₊** *(Polar)* | Minimum/maximum phase bounds, in radians. |
+| **m₋, m₊** *(Polar)* | Minimum/maximum modulation bounds. |
+
+### Automatic clustering (GMM)
+
+| Parameter | Description |
+|---|---|
+| **Number of clusters** | Number of clusters (regions) the GMM fits to the phasor data. |
+| **Sigma** | Size of each cluster's elliptic region, in standard deviations of the fitted Gaussian. |
+
+### Outputs
+
+| Parameter | Description |
+|---|---|
+| **Export cursor selections as** | PNG (rendered image) and/or CSV (label IDs). |
+| **Export selection statistics (CSV)** | Writes one CSV with, per cursor/cluster, the pixel count inside the region and its percentage of the valid pixels. |
+| **Export Phasor Plot with Selection Overlay (PNG)** | Exports the phasor plot with the cursor/cluster regions overlaid. |
+
+## Components
+
+Decomposes each pixel into fractional contributions of known phasor
+components. See {doc}`component_analysis` for the interactive-widget
+equivalent and for the analysis-type concepts.
+
+| Parameter | Description |
+|---|---|
+| **Analysis type** | **Linear Projection** (two components) or **Component Fit** (multi-component fit). |
+| **Frequency (MHz)** | Used to convert a typed lifetime into G/S coordinates. |
+| **Harmonic** | Harmonic whose component G/S locations are currently being edited. Fits with more than 3 components need locations at several harmonics: switch this selector and enter G/S for each required harmonic. |
+| **Component G/S locations** *(required)* | One row per component (**+ Add component**), each with a name, G, S, and an optional lifetime (ns) field that, when a value is entered, converts to G/S automatically. Each component also has its own fraction-image colormap. |
+
+### Fraction images and phasor plot styling
+
+| Parameter | Description |
+|---|---|
+| **Range (image & histogram)** | Fraction range for the colormapped fraction images and histogram. Uncheck **Auto** to set fixed min/max limits; **Auto** pools a single range across every file so outputs are comparable. |
+| **Edit line layout…** | Style of the dots and connecting line drawn between components in the exported phasor plot. |
+| **Edit component name layout…** | Style of the component name labels drawn in the exported phasor plot. |
+
+### Outputs
+
+Formats for exporting the component fraction images, per-file histogram,
+statistics table (CSV), and the phasor plot with the components overlay — see
+[Outputs (shared pattern)](#outputs-shared-pattern) below.
+
+
+## Phasor Mapping
+
+Maps each pixel's phasor to a physical quantity and exports it as an image
+per file. See {doc}`phasor_mapping` for the interactive-widget equivalent.
+
+| Parameter | Description |
+|---|---|
+| **Outputs** *(required)* | One or more of **Apparent Phase Lifetime**, **Apparent Modulation Lifetime**, **Normal Lifetime**, **Phase**, and **Modulation**. One image is exported per file per selected output. |
+| **Frequency (MHz)** | Used to convert phasor coordinates to lifetimes; only enabled when a lifetime output is selected. |
+| **Harmonic** | Harmonic used for the mapping. |
+| **Colormap** | Colormap applied to the exported mapped images. |
+| **Range (image & histogram)** | Value range (e.g. lifetime) for the colormapped image and histogram. Uncheck **Auto** to set fixed min/max limits; **Auto** pools a single range across every file. |
+
+### Phasor plot mesh and coloring
+
+| Parameter | Description |
+|---|---|
+| **Color phasor by** | Colors the exported phasor plot's points by **None**, **Phase**, or **Modulation**. |
+| **Mesh overlay** | Draws a **Phase mesh** and/or **Modulation mesh** grid over the phasor plot. |
+| **Mesh/color colormap** | Colormap used for the mesh and/or point coloring. |
+| **Mesh alpha** | Opacity of the mesh overlay. |
+| **Clip mesh to semicircle** | Only shows the mesh inside the universal semicircle (semicircle plot geometry only). |
+| **Range** | **Auto (range from all files)** computes a single phase/modulation range pooled across every file at export; uncheck to set fixed ranges manually. |
+| **Phase range (rad)** | Manual minimum/maximum phase for the mesh, when Auto is off. |
+| **Modulation range** | Manual minimum/maximum modulation for the mesh, when Auto is off. |
+
+### Outputs
+
+Formats for exporting the mapped images, per-file histogram, statistics table
+(CSV), and the phasor plot with the mesh/coloring overlay — see
+[Outputs (shared pattern)](#outputs-shared-pattern) below.
+
+
+## FRET
+
+Estimates the apparent FRET efficiency of each pixel from a donor trajectory,
+and exports it as an image per file. See {doc}`fret_analysis` for the
+interactive-widget equivalent and the underlying concept.
+
+### Donor trajectory
+
+| Parameter | Description |
+|---|---|
+| **Donor lifetime (ns)** *(required)* | Fluorescence lifetime of the donor in the absence of FRET; anchors the donor trajectory. |
+| **Frequency (MHz)** *(required)* | Laser repetition/modulation frequency at which the data were acquired. |
+| **Harmonic** | Harmonic used to compute the FRET efficiency. |
+| **Donor background** | Fraction of the donor signal coming from background; shifts the trajectory toward the background phasor. |
+| **Donor fretting fraction** | Fraction of donor molecules that undergo FRET (1.0 = all donors participate). |
+| **Background G, Background S** | G/S coordinates of the background phasor. |
+
+### Image styling
+
+| Parameter | Description |
+|---|---|
+| **Colormap** | Colormap applied to the exported FRET-efficiency images. |
+| **Range (image & histogram)** | Efficiency range for the colormapped image and histogram. Uncheck **Auto** to set fixed min/max limits; **Auto** pools a single range across every file. |
+
+### Outputs
+
+Formats for exporting the FRET-efficiency images, per-file histogram,
+statistics table (CSV), and the phasor plot with the FRET overlay — see
+[Outputs (shared pattern)](#outputs-shared-pattern) below.
+
+
+## Outputs (shared pattern)
+
+The Components, Phasor Mapping, and FRET tabs share the same **Outputs**
+section layout:
+
+| Parameter | Description |
+|---|---|
+| **Export \<analysis\> as** | Formats for the colormapped analysis image (one per file): PNG (rendered image) and/or CSV (raw per-pixel values). |
+| **Export histogram as** | Formats for the per-file histogram of the analysis values: PNG and/or CSV. |
+| **Configure groups and display…** | Enabled once a histogram format is selected. Sets the merged/individual/grouped display mode (shared across tabs), assigns files to groups for combined grouped histograms/statistics, and sets histogram display options. |
+| **Export statistics table (CSV)** | Writes per-file (and per-group, if grouped) descriptive statistics — see {doc}`histogram_statistics`. |
+| **Export Phasor Plot with \<analysis\> Overlay (PNG)** | Exports the phasor plot styled per the **Phasor Plot Settings** tab, with the tab's analysis overlay (components, mesh, or FRET trajectory) drawn on top. |
+
+## Running the batch
+
+Click **Run batch analysis** to process every file of the selected format in
+the input folder. A progress bar tracks per-file progress and the status
+label reports completion or the first error encountered. The **Run batch
+analysis** button stays disabled until the required Setup fields are filled
+in and at least one export option (Setup export types, or an enabled
+analysis tab's outputs) is selected.

--- a/docs/guides/component_analysis.md
+++ b/docs/guides/component_analysis.md
@@ -40,7 +40,7 @@ Hovering over this option opens a submenu listing all active cursors (Circular, 
 </video>
 
 ### Select from phasor center (layer selection)
-Selecting **Select from layer(s) phasor center** opens a dialog where you can select one or more image layers with phasor data. The widget will calculate the pooled phasor center of gravity of those layers and use it as the component coordinate.
+Selecting **Select from layer(s) phasor center** opens a dialog where you can select one or more image layers with phasor data. The widget will calculate the pooled phasor G and S centers of those layers and use it as the component coordinate.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20from%20layers.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20from%20layers.mp4" type="video/mp4">

--- a/docs/guides/component_analysis.md
+++ b/docs/guides/component_analysis.md
@@ -9,10 +9,11 @@ The **Components** tab of the **Phasor Plot** widget lets you decompose phasor d
   - **Select on plot**: Click manually on the phasor plot.
   - **Select from layer(s) phasor center**: Calculate the location from the center of selected layer(s).
   - **Select from cursor center**: Use the center of any active cursor.
-  - **Auto intersect semicircle**: Place the component at the intersection of the universal semicircle and the line connecting the previous component to the data center.
+  - **Auto intersect semicircle**: Place the component at the intersection of the universal semicircle and the line connecting the previous component to the phasor center.
 
 **The line and component locations can be fully customized:**
 - Change the width, offset, alpha (transparency), and color of the line joining the components
+- Overlay a histogram of the first component's fraction along the line (two-component Linear Projection only)
 - Style the text labels for each component (size, bold, italic, color)
 
 Two analysis modes are available:
@@ -46,7 +47,7 @@ Selecting **Select from layer(s) phasor center** opens a dialog where you can se
 </video>
 
 ### Auto intersect semicircle
-For Component 2 and subsequent components, selecting **Auto intersect semicircle** automatically positions the component on the universal semicircle. The position is calculated at the intersection point of the universal semicircle and a line drawn from the previous component's coordinates through the center of the active phasor data.
+For Component 2 and subsequent components, selecting **Auto intersect semicircle** automatically positions the component on the universal semicircle. The position is calculated at the intersection point of the universal semicircle and a line drawn from the previous component's coordinates through the phasor center of the active data.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20intersect%20semicircle.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20intersect%20semicircle.mp4" type="video/mp4">
@@ -71,6 +72,16 @@ This mode is fast and intuitive for mixtures dominated by two endmembers.
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20linear%20analysis.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20linear%20analysis.mp4" type="video/mp4">
 </video>
+
+### Fraction histogram overlay
+
+For a two-component Linear Projection, click **Edit Line Layout...** to open
+the line and histogram settings, then enable **Overlay fraction histogram**.
+This draws a histogram of the first component's fraction directly on top of
+the line joining the two components, colored with the line's colormap, so the
+distribution of pixel fractions is visible alongside the line itself in the
+phasor plot. The histogram's height, transparency, and offset from the line
+can all be adjusted in the same dialog.
 
 ## Multi-component fit
 

--- a/docs/guides/component_analysis.md
+++ b/docs/guides/component_analysis.md
@@ -27,6 +27,10 @@ To set or modify a component's coordinates, click the **Select** button next to 
 ### Select on plot
 Allows manual selection by clicking on any position within the phasor plot. You can cancel the selection process at any time by pressing the **Esc** key on your keyboard.
 
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20select%20plot.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20select%20plot.mp4" type="video/mp4">
+</video>
+
 ### Select from cursor center
 Hovering over this option opens a submenu listing all active cursors (Circular, Polar, Elliptical, and GMM Clusters). Selecting a cursor instantly snaps the component to that cursor's center of gravity.
 
@@ -44,8 +48,8 @@ Selecting **Select from layer(s) phasor center** opens a dialog where you can se
 ### Auto intersect semicircle
 For Component 2 and subsequent components, selecting **Auto intersect semicircle** automatically positions the component on the universal semicircle. The position is calculated at the intersection point of the universal semicircle and a line drawn from the previous component's coordinates through the center of the active phasor data.
 
-<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/intersect%20semicircle.gif">
-  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/intersect%20semicircle.mp4" type="video/mp4">
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/component%20intersect%20semicircle.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/component%20intersect%20semicircle.mp4" type="video/mp4">
 </video>
 
 ## Two-component linear projection

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -11,7 +11,7 @@ Multiple layers can be selected and exported simultaneously in a single operatio
 
 ## CSV export
 
-Phasor coordinates and selections can be exported as CSV files using the **Export Phasor** widget. Analysis results — such as lifetime, FRET efficiency, and component fractions — can also be exported to CSV. Similarly, labels layers can be exported to CSV, where the pixel coordinates and corresponding label values/IDs are saved.
+Phasor coordinates and selections can be exported as CSV files using the **Export Phasor** widget. Analysis results, such as lifetime, FRET efficiency, and component fractions, can also be exported to CSV. Similarly, labels layers can be exported to CSV, where the pixel coordinates and corresponding label values/IDs are saved.
 
 ## Image export
 

--- a/docs/guides/filtering_thresholding.md
+++ b/docs/guides/filtering_thresholding.md
@@ -6,16 +6,16 @@ The **Filter** tab provides tools to reduce noise in phasor data and remove low-
 
 ### Median filter
 
-Applies a spatial median filter to the phasor coordinates (G and S channels), reducing salt-and-pepper noise while preserving edges. Generally, filtering 3 times with a
+Applies a spatial median filter to the phasor coordinates (G and S channels), reducing noise while preserving edges. Generally, filtering 3 times with a
 3x3 kernel size is enough.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/median%20filter.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/median%20filter.mp4" type="video/mp4">
 </video>
 
-### Wavelet filter
+### Wavelet (binlet pawFLIM) filter
 
-Applies wavelet denoising to the phasor data. This requires that the selected harmonics are compatible (each must have a double or half counterpart, e.g., harmonics 1 and 2).
+Applies wavelet (binlet pawFLIM) denoising to the phasor data. This requires that the selected harmonics are compatible (each must have a double or half counterpart, e.g., harmonics 1 and 2).
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/wavelet%20filter.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/wavelet%20filter.mp4" type="video/mp4">
@@ -23,13 +23,15 @@ Applies wavelet denoising to the phasor data. This requires that the selected ha
 
 ## Thresholding
 
-Thresholding sets a minimum intensity cutoff. Pixels below the threshold are masked (set to NaN) and excluded from the phasor plot and analysis.
+Thresholding sets a minimum **and** maximum intensity cutoff using a range slider (with paired min/max value fields alongside it). Pixels with intensity below the minimum or above the maximum are masked (set to NaN) and excluded from the phasor plot and analysis.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/threshold.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/threshold.mp4" type="video/mp4">
 </video>
 
 ### Automatic threshold methods
+
+Automatic methods compute the lower cutoff; the upper cutoff can still be adjusted manually with the max value field or the upper slider handle.
 
 | Method | Algorithm | Best for |
 |--------|-----------|----------|
@@ -39,13 +41,13 @@ Thresholding sets a minimum intensity cutoff. Pixels below the threshold are mas
 
 ### Manual threshold
 
-Select **Manual** from the threshold dropdown and drag the slider to set a custom cutoff value.
+Select **Manual** from the threshold dropdown and drag either handle of the range slider (or edit the min/max value fields directly) to set custom lower and upper cutoff values.
 
 ## How it works
 
 1. The intensity histogram of all selected layers is displayed
-2. When an automatic method is selected, the optimal lower threshold is computed and the slider is updated
-3. All phasor coordinates from pixels below the threshold are masked
+2. When an automatic method is selected, the optimal lower threshold is computed and the slider's lower handle is updated
+3. All phasor coordinates from pixels outside the selected [min, max] intensity range are masked
 4. The phasor plot updates in real time
 
-The threshold value is stored in the layer metadata and is preserved across sessions when exporting to OME-TIF.
+The threshold values are stored in the layer metadata and are preserved across sessions when exporting to OME-TIF.

--- a/docs/guides/flim_workflow.md
+++ b/docs/guides/flim_workflow.md
@@ -33,12 +33,12 @@ Use **File → Open File(s)** or drag-and-drop your file into napari.
 
 Alternatively, load the built-in sample data: **File → Open Sample → napari-phasors**.
 
-## 2. Compute phasors
+## 2. Visualize phasors and perform analysis
 
 Once a FLIM file is loaded, the phasor transform is computed automatically and stored in the layer metadata. Open the **Phasor Plot** widget via **Plugins → napari-phasors → Phasor Plot**.
 
-<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/phasor%20plot%202dhist.gif">
-  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/phasor%20plot%202dhist.mp4" type="video/mp4">
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/flim%20workflow.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/flim%20workflow.mp4" type="video/mp4">
 </video>
 
 ## 3. Select layers
@@ -55,12 +55,15 @@ Use the **Filter** tab to apply median or wavelet filters, and set automatic thr
 
 ## 6. Select regions of interest
 
-Use the **Selection** tab to identify regions in phasor space using circular cursors, manual drawing, or automatic clustering. See {doc}`phasor_selection` for details.
+Use the **Selection** tab to identify regions in phasor space using circular, elliptical or polar cursors, manual drawing, or automatic clustering. See {doc}`phasor_selection` for details.
 
 ## 7. Analyze phasor outputs
 
 Run **Component Analysis** when you want to decompose mixtures into two or
 more components and generate fraction maps. See {doc}`component_analysis` for details.
+
+Use the **FRET** tab to perform Förster Resonance Energy Transfer analysis and
+calculate apparent FRET efficiency for each pixel. See {doc}`fret_analysis` for details.
 
 Use the **Phasor Mapping** tab to colormap each pixel by its apparent lifetime,
 phasor phase, or phasor modulation. An interactive 1D histogram and statistics
@@ -72,6 +75,6 @@ For practical visualization examples and plot customization tools, see
 
 ## 8. Export results
 
-Export your phasor coordinates, selections, and analysis results as OME-TIF or
+Export your phasor coordinates, selections, and analysis results as OME-TIF, PNG or
 CSV. Multiple layers can be exported simultaneously. See {doc}`exporting` for
 details.

--- a/docs/guides/flim_workflow.md
+++ b/docs/guides/flim_workflow.md
@@ -51,7 +51,7 @@ If you have a reference image of a known fluorophore, calibrate your data in the
 
 ## 5. Filter and threshold
 
-Use the **Filter** tab to apply median or wavelet filters, and set automatic thresholds (Otsu, Li, Yen) to remove background noise. See {doc}`filtering_thresholding` for details.
+Use the **Filter** tab to apply median or wavelet (binlet pawFLIM) filters, and set automatic thresholds (Otsu, Li, Yen) to remove background noise. See {doc}`filtering_thresholding` for details.
 
 ## 6. Select regions of interest
 

--- a/docs/guides/fret_analysis.md
+++ b/docs/guides/fret_analysis.md
@@ -19,6 +19,19 @@ FRET analysis in phasor space uses the donor fluorophore's position on the phaso
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/fret.mp4" type="video/mp4">
 </video>
 
+## Model parameters
+
+The donor trajectory is a model of the donor channel signal, and its shape
+depends on the following parameters, in addition to the donor lifetime and
+frequency described above:
+
+| Parameter | Description |
+|---|---|
+| **Donor Background** | The weight of the background signal in the donor channel, relative to the signal of the donor without FRET, in range 0–1. A value of 1 means the background and the FRET-free donor signal contribute equally; 0 means there is no background contribution. Increasing it pulls the whole trajectory toward the background phasor position. |
+| **Background position** | The phasor coordinate (G, S) of the pure background signal, entered manually or averaged from one or more selected background layers (see step 2 above). Combined with **Donor Background**, it anchors where the trajectory is pulled toward. |
+| **Proportion fretting** | The fraction of donor molecules that actually participate in FRET, in range 0–1. A value of 1.0 means every donor molecule has a nearby acceptor and undergoes energy transfer; lower values model a mixed population where some donors have no acceptor and never leave their unquenched (0 % efficiency) position. This shortens the trajectory but does not change its path. |
+| **Overlay colormap on donor trajectory** | When enabled, colors the trajectory line by FRET efficiency (0–100 %) instead of drawing it as a single flat color, making it easier to read off the efficiency at a glance. |
+
 ## Donor lifetime types
 
 | Type | Description |

--- a/docs/guides/histogram_statistics.md
+++ b/docs/guides/histogram_statistics.md
@@ -1,6 +1,6 @@
 # Histogram and Statistics Table
 
-The **1D Histogram** and **Statistics Table** panels in napari-phasors provide quantitative analysis for a variety of workflows, including:
+The **Histogram** and **Statistics Table** panels in napari-phasors provide quantitative analysis for a variety of workflows, including:
 
 - **Component analysis**
 - **Phasor mapping** (lifetime, phase, modulation)
@@ -10,19 +10,38 @@ For component-analysis-specific setup and interpretation, see {doc}`component_an
 
 The statistics table can also display phasor center data for each layer or group.
 
-## 1D Histogram
+## Histogram
 
-After running an analysis (component, mapping, or FRET), a **1D Histogram** dock panel opens automatically below the Phasor Plot widget. It shows the distribution of the computed metric values (e.g., lifetime, phase, modulation, or component fraction) across all valid pixels of all selected layers.
+After running an analysis (component, mapping, or FRET), a **Histogram** dock panel opens automatically below the Phasor Plot widget. It shows the distribution of the computed metric values (e.g., lifetime, phase, modulation, or component fraction) across all valid pixels of all selected layers.
 
 ### Histogram display modes
 
-The histogram can be shown in three modes:
+The histogram can be shown in three modes, switched in the **Histogram
+Settings** dialog:
 
-- **Merged**: All selected layers' data are pooled and shown as a single curve.
-- **Individual layers**: Each selected layer is shown as a separate curve, allowing direct comparison.
-- **Grouped**: Layers can be assigned to custom groups, and each group's data is pooled and shown as a separate curve.
+#### Merged
 
-You can switch between these modes in the **Histogram Settings** dialog.
+All selected layers' data are pooled and shown as a single curve.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/histogram%20merged.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/histogram%20merged.mp4" type="video/mp4">
+</video>
+
+#### Individual layers
+
+Each selected layer is shown as a separate curve, allowing direct comparison.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/histogram%20individual.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/histogram%20individual.mp4" type="video/mp4">
+</video>
+
+#### Grouped
+
+Layers can be assigned to custom groups, and each group's data is pooled and shown as a separate curve.
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/histogram%20grouped.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/histogram%20grouped.mp4" type="video/mp4">
+</video>
 
 ### Histogram features
 
@@ -33,7 +52,7 @@ You can switch between these modes in the **Histogram Settings** dialog.
 - **White background**: Switches to a white plot background for figures.
 - **Smooth curves**: Applies Gaussian smoothing to improve curve readability.
 - **Layer/group colours**: Picker for per-layer or per-group histogram colours.
-- **Save Histogram as PNG**: Exports the histogram at 300 DPI.
+- **Save Histogram**: Exports the histogram, either as a PNG image (at 300 DPI) or as a CSV of the underlying bin centers and counts (per layer or per group, depending on the current display mode).
 
 ## Statistics Table
 
@@ -43,6 +62,10 @@ The **Statistics** dock panel, linked to the histogram, displays per-layer (and 
 - Component fractions (component analysis)
 - FRET efficiency or related metrics (FRET analysis)
 - Phasor center coordinates (if enabled)
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/table.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/table.mp4" type="video/mp4">
+</video>
 
 ### Table columns
 
@@ -63,7 +86,3 @@ Right-clicking on the table provides **Copy**, **Copy with Headers**, and **Sele
 2. View the histogram and statistics table for all selected layers.
 3. Switch between merged, individual, or grouped display modes as needed.
 4. Export the histogram or statistics for publication or further analysis.
-
-<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/histogram%20table.gif">
-  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/histogram%20table.mp4" type="video/mp4">
-</video>

--- a/docs/guides/hyperspectral_workflow.md
+++ b/docs/guides/hyperspectral_workflow.md
@@ -22,11 +22,11 @@ Alternatively, load the built-in sample data: **File → Open Sample → napari-
 For advanced import options and stack building with the custom widget, see
 {doc}`open_files`.
 
-## 2. Compute phasors
+## 2. Visualize phasors and perform analysis
 
 Once a hyperspectral file is loaded, the phasor transform is computed automatically and stored in the layer metadata. Open the **Phasor Plot** widget via **Plugins → napari-phasors → Phasor Plot**.
 
-To visualize hyperspectral data in the full universal circle, uncheck **Universal Semi-Circle/Full Polar Plot** in the **Plot Settings** tab.
+To visualize hyperspectral data in the full universal circle, toggle **Full Polar Plot (Spectral Phasor)** in the **Plot Settings** tab.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/hsi%20plot.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/hsi%20plot.mp4" type="video/mp4">
@@ -43,7 +43,7 @@ Use the **Filter** tab to apply median or wavelet filters, and set automatic thr
 
 ## 5. Select regions of interest
 
-Use the **Selection** tab to identify regions in phasor space using circular cursors, manual drawing, or automatic clustering. See {doc}`phasor_selection` for details.
+Use the **Selection** tab to identify regions in phasor space using circular, elliptical or polar cursors, manual drawing, or automatic clustering. See {doc}`phasor_selection` for details.
 
 In hyperspectral analysis, positions in the phasor plot relate to **spectral composition** rather than fluorescence lifetimes.
 
@@ -58,4 +58,4 @@ For practical visualization examples and plot customization tools, see
 
 ## 7. Export results
 
-Export your phasor coordinates, selections, and analysis results as OME-TIF or CSV. Multiple layers can be exported simultaneously. See {doc}`exporting` for details.
+Export your phasor coordinates, selections, and analysis results as OME-TIF, PNG or CSV. Multiple layers can be exported simultaneously. See {doc}`exporting` for details.

--- a/docs/guides/hyperspectral_workflow.md
+++ b/docs/guides/hyperspectral_workflow.md
@@ -39,7 +39,7 @@ Multiple image layers can be selected simultaneously from the layer dropdown. Us
 
 ## 4. Filter and threshold
 
-Use the **Filter** tab to apply median or wavelet filters, and set automatic thresholds (Otsu, Li, Yen) to remove background noise. See {doc}`filtering_thresholding` for details.
+Use the **Filter** tab to apply median or wavelet (binlet pawFLIM) filters, and set automatic thresholds (Otsu, Li, Yen) to remove background noise. See {doc}`filtering_thresholding` for details.
 
 ## 5. Select regions of interest
 

--- a/docs/guides/mask.md
+++ b/docs/guides/mask.md
@@ -56,12 +56,16 @@ You can invert a mask so that pixels **outside** the drawn region are included i
 
 When using the **Assign Masks** dialog (for multiple image layers), each layer has its own **Invert** checkbox, allowing independent inversion per layer.
 
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/invert%20mask.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/invert%20mask.mp4" type="video/mp4">
+</video>
+
 ## Assigning masks to image layers
 
 - You can assign a mask to a single image layer, restricting phasor analysis to that region only.
 - Different image layers can have different masks assigned, allowing for independent region-of-interest analysis across multiple images.
 - To do this, select the desired image layer, then choose the appropriate mask layer in the **Phasor Plot** widget.
 
-<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/mask%20multiple.gif">
-  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/mask%20multiple.mp4" type="video/mp4">
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/assign%20masks.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/assign%20masks.mp4" type="video/mp4">
 </video>

--- a/docs/guides/multi_layer_analysis.md
+++ b/docs/guides/multi_layer_analysis.md
@@ -32,6 +32,10 @@ significantly streamlines the workflow for experimental series.
 > You can quickly select or deselect all layers using the **All** and **None**
 > links next to the layer selection dropdown.
 
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/multi-layer.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/multi-layer.mp4" type="video/mp4">
+</video>
+
 ## Copying and Importing Settings
 
 You can reuse analysis parameters and plot configurations from existing layers
@@ -49,12 +53,14 @@ To copy settings from one layer to another:
 2. Click the **Layer** button.
 3. Select the source layer from the dialog.
 4. Choose the categories of settings you wish to copy:
-    - **Frequency & Harmonic**
+    - **Frequency**
     - **Plot Settings** (background, type, colormap, log scale, etc.)
     - **Calibration Parameters**
     - **Filter & Threshold Settings**
+    - **Region Selection (Cursors)**
+    - **Component Positions, Names and Display Settings**
     - **Phasor Mapping Parameters**
-    - **FRET & Component Analysis Positions**
+    - **FRET**
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/copy%20from%20layer.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/copy%20from%20layer.mp4" type="video/mp4">

--- a/docs/guides/open_files.md
+++ b/docs/guides/open_files.md
@@ -16,11 +16,11 @@ By default, standard opening reads the first 1<sup>st</sup> and second 2<sup>nd<
 
 Use the **Phasor Custom Import** widget when you need to override those defaults (for example, choose a specific channel/frame, set LIF image/dimension, select the phasor axis, or build a custom 3D stack with z spacing and axis order).
 
-The **Phasor Custom Import** widget (**PhasorTransformWidget**) provides format-aware import options for FLIM and hyperspectral files.
+The **Phasor Custom Import** widget provides format-aware import options for FLIM and hyperspectral files.
 
 Open it from:
 
-**Plugins -> napari-phasors -> Phasor Transform**
+**Plugins -> napari-phasors -> Phasor Custom Import**
 
 ### Default reader parameters by format
 

--- a/docs/guides/phasor_mapping.md
+++ b/docs/guides/phasor_mapping.md
@@ -18,7 +18,7 @@ of three output modes:
 | **Phase** | Computes the polar angle of the phasor (radians or degrees) |
 | **Modulation** | Computes the polar modulus of the phasor (0 – 1) |
 
-### Lifetime mode
+## Lifetime mode
 
 When **Lifetime** is selected, a secondary drop-down lets you choose between:
 
@@ -36,7 +36,7 @@ from the calibration tab when calibration is applied).
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/lifetime.mp4" type="video/mp4">
 </video>
 
-### Phase and Modulation modes
+## Phase and Modulation modes
 
 These modes derive the polar coordinates of the phasor directly with no
 frequency input required.  A **Colormap** drop-down lets you choose the
@@ -52,17 +52,6 @@ phasor plot and the image.
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/phase%20modulation.mp4" type="video/mp4">
 </video>
 
-## Calculating the output
-
-Click **Calculate Output** to compute the selected metric for all currently
-selected layers. A new napari image layer is created (or updated if it already
-exists) with the selected colormap applied. The colormapped image can be
-exported as a PNG or OME-TIF file. For histogram and statistics options, see
-{doc}`histogram_statistics`.
-
-For practical FLIM examples and visualization/customization tools (contours,
-and phasor centers), see {doc}`plot_customization`.
-
 ## Arc Overlay Tool
 
 The **Phase & Modulation Arcs** tool helps visualize analysis boundaries by
@@ -77,3 +66,18 @@ component or reflects mixed lifetimes.
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/phase%20arc.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/phase%20arc.mp4" type="video/mp4">
 </video>
+
+## Calculating the output
+
+Click **Calculate Output** to compute the selected metric for all currently
+selected layers. A new napari image layer is created (or updated if it
+already exists) with the selected colormap applied.
+
+- View value distributions as histograms and summary statistics in the **Histogram and Statistics Table** widget
+- Compare layers as merged, individual, or grouped data
+- Export the colormapped image as a PNG or OME-TIF file
+- Export summary statistics to CSV
+
+For full histogram/table options, see {doc}`histogram_statistics`. For
+practical FLIM examples and visualization/customization tools (contours and
+phasor centers), see {doc}`plot_customization`.

--- a/docs/guides/phasor_mapping.md
+++ b/docs/guides/phasor_mapping.md
@@ -15,7 +15,7 @@ of three output modes:
 | Mode | Description |
 |------|-------------|
 | **Lifetime** | Computes apparent phase lifetime, apparent modulation lifetime, or normal lifetime (ns) |
-| **Phase** | Computes the polar angle of the phasor (radians or degrees) |
+| **Phase** | Computes the polar angle of the phasor (radians) |
 | **Modulation** | Computes the polar modulus of the phasor (0 – 1) |
 
 ## Lifetime mode

--- a/docs/guides/phasor_selection.md
+++ b/docs/guides/phasor_selection.md
@@ -15,7 +15,7 @@ Below, each mode is described in detail.
 
 Define one or more cursors on the phasor plot to select regions of interest. Each cursor can be:
 
-- Positioned and reshaped directly on the plot: circular and elliptical cursors are repositioned by clicking and dragging their body; polar cursors have no single body to drag — instead, click near any of its four edges (the two phase bounds or the two modulation bounds) and drag to move that edge independently
+- Positioned and reshaped directly on the plot: circular and elliptical cursors are repositioned by clicking and dragging their body; polar cursors have no single body to drag; instead, click near any of its four edges (the two phase bounds or the two modulation bounds) and drag to move that edge independently
 - Switched between **Circular**, **Polar (Sector)**, and **Elliptical** modes
 - Configured with specific coordinates and other parameters in the table
 
@@ -70,7 +70,7 @@ Each of these four bounds is one edge of the wedge, and can be dragged directly 
 
 Cluster phasors automatically using a Gaussian Mixture Model (GMM). The number of clusters can be specified, and the results are mapped back to the image as a labels layer, one ellipse per cluster.
 
-Each ellipse is centered on the fitted Gaussian's mean, with its major/minor radii scaled from the eigenvalues of the fitted covariance by a fixed scaling factor (sigma = 2, not user-adjustable in this tab). At that default scaling, each ellipse is a **~98.2% confidence ellipse** of its cluster's distribution — i.e., about 98.2% of the pixels belonging to that Gaussian component are expected to fall inside the drawn ellipse.
+Each ellipse is centered on the fitted Gaussian's mean, with its major/minor radii scaled from the eigenvalues of the fitted covariance by a fixed scaling factor (sigma = 2, not user-adjustable in this tab). At that default scaling, each ellipse is a **~98.2% confidence ellipse** of its cluster's distribution  (i.e., about 98.2% of the pixels belonging to that Gaussian component are expected to fall inside the drawn ellipse).
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/automatic%20clustering.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/automatic%20clustering.mp4" type="video/mp4">

--- a/docs/guides/phasor_selection.md
+++ b/docs/guides/phasor_selection.md
@@ -4,7 +4,7 @@
 The **Selection** tab provides several modes for identifying regions of interest (ROIs) in the phasor plot and mapping the corresponding pixels back to the intensity image. The main selection modes are:
 
 - **Cursor selection** (circular, polar, elliptical)
-- **Automatic clustering** (k-means, GMM)
+- **Automatic clustering** (GMM)
 - **Manual selection** (freeform shapes)
 
 Below, each mode is described in detail.
@@ -15,7 +15,7 @@ Below, each mode is described in detail.
 
 Define one or more cursors on the phasor plot to select regions of interest. Each cursor can be:
 
-- Positioned by clicking and dragging on the plot (only circular and elliptical cursors)
+- Positioned and reshaped directly on the plot: circular and elliptical cursors are repositioned by clicking and dragging their body; polar cursors have no single body to drag — instead, click near any of its four edges (the two phase bounds or the two modulation bounds) and drag to move that edge independently
 - Switched between **Circular**, **Polar (Sector)**, and **Elliptical** modes
 - Configured with specific coordinates and other parameters in the table
 
@@ -24,7 +24,10 @@ A separate labels layer is created for each cursor, color-coded for easy identif
 
 ### Circular cursors
 
-**Circular cursors** select a circular region in phasor space.
+**Circular cursors** select a circular region in phasor space, defined by:
+
+- **Center G, S** — the coordinate of the circle's center, set by dragging the cursor on the plot or typed directly
+- **Radius** — the circle's radius, set with the **Radius** field in the table
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/circular%20cursor.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/circular%20cursor.mp4" type="video/mp4">
@@ -32,7 +35,12 @@ A separate labels layer is created for each cursor, color-coded for easy identif
 
 ### Polar cursors
 
-**Polar cursors** allow selecting phasors within a range of phases and modulations.
+**Polar cursors** select an annular wedge of phasor space, bounded by:
+
+- **Phase (min / max)** — the lower and upper angular bounds, in degrees
+- **Modulation (min / max)** — the lower and upper radial bounds (0 to 1)
+
+Each of these four bounds is one edge of the wedge, and can be dragged directly in the phasor plot: click closest to the edge you want to move (whichever phase or modulation bound is nearest to the click) and drag it to a new position. The bounds can also be set numerically in the table.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/polar%20cursor.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/polar%20cursor.mp4" type="video/mp4">
@@ -40,7 +48,12 @@ A separate labels layer is created for each cursor, color-coded for easy identif
 
 ### Elliptical cursors
 
-**Elliptical cursors** allow defining arbitrary stretching and rotation for specific phasor component analysis.
+**Elliptical cursors** allow defining arbitrary stretching and rotation for specific phasor component analysis, defined by:
+
+- **Center G, S** — the coordinate of the ellipse's center, set by dragging the cursor on the plot or typed directly
+- **Radius** — the major-axis radius
+- **rₘ** — the minor-axis radius
+- **Angle** — the rotation of the major axis, in degrees
 
 > [!TIP]
 > To rotate (shift the angle of) an elliptical cursor, hold the **Shift** key and click-and-drag on the cursor.
@@ -53,7 +66,9 @@ A separate labels layer is created for each cursor, color-coded for easy identif
 
 ## Automatic clustering
 
-Cluster phasors automatically using k-means or Gaussian Mixture Models (GMM). The number of clusters can be specified, and the results are mapped back to the image as a labels layer.
+Cluster phasors automatically using a Gaussian Mixture Model (GMM). The number of clusters can be specified, and the results are mapped back to the image as a labels layer, one ellipse per cluster.
+
+Each ellipse is centered on the fitted Gaussian's mean, with its major/minor radii scaled from the eigenvalues of the fitted covariance by a fixed scaling factor (sigma = 2, not user-adjustable in this tab). At that default scaling, each ellipse is a **~98.2% confidence ellipse** of its cluster's distribution — i.e., about 98.2% of the pixels belonging to that Gaussian component are expected to fall inside the drawn ellipse.
 
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/automatic%20clustering.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/automatic%20clustering.mp4" type="video/mp4">

--- a/docs/guides/phasor_selection.md
+++ b/docs/guides/phasor_selection.md
@@ -21,6 +21,8 @@ Define one or more cursors on the phasor plot to select regions of interest. Eac
 
 A separate labels layer is created for each cursor, color-coded for easy identification. Statistics for each cursor region are displayed in the table.
 
+> [!TIP]
+> Enable the **Autoupdate** toggle to automatically recompute the selection (and any dependent analysis) whenever a cursor changes, instead of clicking **Calculate Selection** each time.
 
 ### Circular cursors
 

--- a/docs/guides/plot_customization.md
+++ b/docs/guides/plot_customization.md
@@ -48,8 +48,16 @@ Customizable parameters include:
 
 When multiple layers are selected, you can choose between **Merged**, **Individual**, or **Group** modes, each with customizable colors.
 
+**Merged** pools every selected layer into a single contour:
+
 <video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/phasor%20plot%20contour.gif">
   <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/phasor%20plot%20contour.mp4" type="video/mp4">
+</video>
+
+**Group** draws one contour per configured group of layers, each with its own color:
+
+<video width="100%" autoplay loop muted playsinline poster="https://github.com/napari-phasors/napari-phasors-data/raw/main/gifs/phasor%20plot%20contour%20group.gif">
+  <source src="https://github.com/napari-phasors/napari-phasors-data/raw/main/videos/phasor%20plot%20contour%20group.mp4" type="video/mp4">
 </video>
 
 ## Phasor Centers

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,6 +53,18 @@ If you already have Anaconda or Miniconda, you can use `conda` instead of
 mamba create -y -n napari-phasors-env napari pyqt6 python=3.14 # or 3.12, 3.13
 ```
 
+```{tip}
+napari-phasors is also published on the
+[conda-forge](https://anaconda.org/conda-forge/napari-phasors) channel. That
+recipe pulls in napari, PyQt6, and every other dependency, so you can
+replace Steps 2 and 4 with a single command and skip `pip` entirely:
+
+    mamba create -y -n napari-phasors-env -c conda-forge napari-phasors
+
+The conda-forge release can lag a little behind the version on PyPI; use
+the pip steps below if you need the very latest release right away.
+```
+
 ### Step 3: Activate the environment
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ If you already have [napari](https://napari.org) installed, this is the simplest
 4. Click **Install**
 5. Restart napari
 
-That's it — no terminal or command line needed.
+That's it, no terminal or command line needed.
 
 ```{note}
 If you don't have napari yet, see [Option 2](#option-2-using-conda--pip-recommended) to install both napari and napari-phasors together.
@@ -98,7 +98,7 @@ Pre-built installers for Windows, macOS, and Linux are
 available on the
 [latest release](https://github.com/napari-phasors/napari-phasors/releases/latest)
 page. Download the installer for your platform, run it,
-and you're ready to go — no Python installation needed.
+and you're ready to go, no Python installation needed.
 
 | Platform  | File type | How to install                             |
 |-----------|-----------|--------------------------------------------|
@@ -108,7 +108,7 @@ and you're ready to go — no Python installation needed.
 
 ```{tip}
 Installers are ~350–470 MB because they bundle
-Python, napari, and all dependencies — nothing else
+Python, napari, and all dependencies, nothing else
 to install.
 ```
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,7 +14,7 @@ napari-phasors is a comprehensive plugin, based on the [phasorpy](https://www.ph
 - **Component analysis** for multi-component systems
 - **Phasor Mapping** — colormap apparent/normal lifetime, phasor phase, and phasor modulation per pixel, with interactive 1D histograms, statistics tables, and arc overlay tools
 - **FRET analysis** with donor trajectory visualization and multi-layer donor/background source selection
-- **Filtering** with median, wavelet, and automatic thresholding (Otsu, Li, Yen)
+- **Filtering** with median, wavelet (binlet pawFLIM), and automatic thresholding (Otsu, Li, Yen)
 - **Selections** via manual drawing, circular/polar/elliptical cursors, and automatic clustering
 - **Exporting** results as OME-TIF or CSV (multiple layers simultaneously)
 - **Batch Analysis** — apply the same reading and analysis pipeline to every file in a folder and export the results headlessly

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,6 +17,7 @@ napari-phasors is a comprehensive plugin, based on the [phasorpy](https://www.ph
 - **Filtering** with median, wavelet, and automatic thresholding (Otsu, Li, Yen)
 - **Selections** via manual drawing, circular/polar/elliptical cursors, and automatic clustering
 - **Exporting** results as OME-TIF or CSV (multiple layers simultaneously)
+- **Batch Analysis** — apply the same reading and analysis pipeline to every file in a folder and export the results headlessly
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "napari-phasors"
 dynamic = ["version"]
-description = "A simple plugin to use phasor analysis"
+description = "A plugin for performing phasor analysis of fluorescence microscopy data"
 readme = "README.md"
 requires-python = ">=3.12"
 license = { file = "LICENSE" }

--- a/src/napari_phasors/_batch_analysis.py
+++ b/src/napari_phasors/_batch_analysis.py
@@ -2162,10 +2162,12 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
         method_row = QHBoxLayout()
         method_row.addWidget(QLabel("Filter method:"))
         self.filter_method_combo = QComboBox()
-        self.filter_method_combo.addItems(["None", "Median", "Wavelet"])
+        self.filter_method_combo.addItems(
+            ["None", "Median", "Wavelet (binlet pawFLIM)"]
+        )
         self.filter_method_combo.setToolTip(
             "Smoothing applied to the phasor coordinates before analysis: "
-            "none, a median filter, or a wavelet filter."
+            "none, a median filter, or a wavelet (binlet pawFLIM) filter."
         )
         self.filter_method_combo.currentTextChanged.connect(
             self._on_filter_method_changed
@@ -2265,7 +2267,9 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
 
     def _on_filter_method_changed(self, method):
         self.median_filter_widget.setVisible(method == "Median")
-        self.wavelet_filter_widget.setVisible(method == "Wavelet")
+        self.wavelet_filter_widget.setVisible(
+            method == "Wavelet (binlet pawFLIM)"
+        )
 
     def _on_threshold_method_changed(self, method):
         self.threshold_manual_widget.setVisible(method == "Manual")
@@ -4790,7 +4794,9 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
                         int(filter_settings["repeat"])
                     )
             elif method == "wavelet":
-                self.filter_method_combo.setCurrentText("Wavelet")
+                self.filter_method_combo.setCurrentText(
+                    "Wavelet (binlet pawFLIM)"
+                )
                 if filter_settings.get("sigma") is not None:
                     self.wavelet_sigma_spin.setValue(
                         float(filter_settings["sigma"])
@@ -5033,7 +5039,7 @@ class BatchAnalysisWidget(PopoutWindowMixin, QWidget):
             kwargs["filter_method"] = "median"
             kwargs["size"] = self.median_size_spin.value()
             kwargs["repeat"] = self.median_repeat_spin.value()
-        elif method == "Wavelet":
+        elif method == "Wavelet (binlet pawFLIM)":
             kwargs["filter_method"] = "wavelet"
             kwargs["sigma"] = self.wavelet_sigma_spin.value()
             kwargs["levels"] = self.wavelet_levels_spin.value()

--- a/src/napari_phasors/_tests/test_batch_analysis.py
+++ b/src/napari_phasors/_tests/test_batch_analysis.py
@@ -836,7 +836,7 @@ def test_filter_param_visibility(qtbot, make_viewer_model):
     widget.filter_method_combo.setCurrentText("Median")
     assert not widget.median_filter_widget.isHidden()
     assert widget.wavelet_filter_widget.isHidden()
-    widget.filter_method_combo.setCurrentText("Wavelet")
+    widget.filter_method_combo.setCurrentText("Wavelet (binlet pawFLIM)")
     assert widget.median_filter_widget.isHidden()
     assert not widget.wavelet_filter_widget.isHidden()
     widget.threshold_method_combo.setCurrentText("Manual")
@@ -3683,7 +3683,9 @@ def test_apply_settings_to_ui_populates_all_tabs(qtbot, make_viewer_model):
     assert widget.calibration_group.isChecked()
     assert widget._copied_calibration is not None
     assert widget.filter_group.isChecked()
-    assert widget.filter_method_combo.currentText() == "Wavelet"
+    assert (
+        widget.filter_method_combo.currentText() == "Wavelet (binlet pawFLIM)"
+    )
     assert widget.wavelet_sigma_spin.value() == 2.5
     assert widget.wavelet_levels_spin.value() == 3
     assert widget.threshold_max_spin.value() == 9.0
@@ -3815,7 +3817,7 @@ def test_collect_filter_kwargs_wavelet_and_manual(qtbot, make_viewer_model):
     widget = BatchAnalysisWidget(make_viewer_model())
     qtbot.addWidget(widget)
 
-    widget.filter_method_combo.setCurrentText("Wavelet")
+    widget.filter_method_combo.setCurrentText("Wavelet (binlet pawFLIM)")
     widget.wavelet_sigma_spin.setValue(1.5)
     widget.wavelet_levels_spin.setValue(4)
     widget.threshold_method_combo.setCurrentText("Manual")

--- a/src/napari_phasors/_tests/test_filter_tab.py
+++ b/src/napari_phasors/_tests/test_filter_tab.py
@@ -51,7 +51,10 @@ def test_filter_widget_initialization_values(make_viewer_model, qtbot):
     assert filter_widget.filter_method_combobox.count() == 3
     assert filter_widget.filter_method_combobox.itemText(0) == "None"
     assert filter_widget.filter_method_combobox.itemText(1) == "Median"
-    assert filter_widget.filter_method_combobox.itemText(2) == "Wavelet"
+    assert (
+        filter_widget.filter_method_combobox.itemText(2)
+        == "Wavelet (binlet pawFLIM)"
+    )
     assert filter_widget.filter_method_combobox.currentText() == "None"
 
     # Test threshold method combobox
@@ -156,7 +159,9 @@ def test_filter_method_switching(make_viewer_model, qtbot):
     assert not filter_widget.median_filter_widget.isHidden()
     assert filter_widget.wavelet_filter_widget.isHidden()
 
-    filter_widget.filter_method_combobox.setCurrentText("Wavelet")
+    filter_widget.filter_method_combobox.setCurrentText(
+        "Wavelet (binlet pawFLIM)"
+    )
     filter_widget.on_filter_method_changed()
 
     assert filter_widget.median_filter_widget.isHidden()
@@ -277,7 +282,9 @@ def test_wavelet_harmonics_validation_compatible(make_viewer_model, qtbot):
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
 
-    filter_widget.filter_method_combobox.setCurrentText("Wavelet")
+    filter_widget.filter_method_combobox.setCurrentText(
+        "Wavelet (binlet pawFLIM)"
+    )
     filter_widget.on_filter_method_changed()
 
     assert filter_widget.harmonic_warning_label.isHidden()
@@ -292,7 +299,9 @@ def test_wavelet_harmonics_validation_incompatible(make_viewer_model, qtbot):
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
 
-    filter_widget.filter_method_combobox.setCurrentText("Wavelet")
+    filter_widget.filter_method_combobox.setCurrentText(
+        "Wavelet (binlet pawFLIM)"
+    )
     filter_widget.on_filter_method_changed()
 
     assert not filter_widget.harmonic_warning_label.isHidden()
@@ -315,7 +324,9 @@ def test_apply_button_with_wavelet_filter(make_viewer_model, qtbot):
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
 
-    filter_widget.filter_method_combobox.setCurrentText("Wavelet")
+    filter_widget.filter_method_combobox.setCurrentText(
+        "Wavelet (binlet pawFLIM)"
+    )
     filter_widget.on_filter_method_changed()
     filter_widget.wavelet_sigma_spinbox.setValue(1.5)
     filter_widget.wavelet_levels_spinbox.setValue(2)
@@ -449,8 +460,14 @@ def test_settings_restoration_with_wavelet(make_viewer_model, qtbot):
     parent = PlotterWidget(viewer)
     filter_widget = parent.filter_tab
 
-    assert filter_widget.filter_method_combobox.currentText() == "Wavelet"
-    assert filter_widget.filter_method_combobox.currentText() == "Wavelet"
+    assert (
+        filter_widget.filter_method_combobox.currentText()
+        == "Wavelet (binlet pawFLIM)"
+    )
+    assert (
+        filter_widget.filter_method_combobox.currentText()
+        == "Wavelet (binlet pawFLIM)"
+    )
     assert filter_widget.wavelet_sigma_spinbox.value() == 3.5
     assert filter_widget.wavelet_levels_spinbox.value() == 4
     assert filter_widget.threshold_method_combobox.currentText() == "Li"

--- a/src/napari_phasors/filter_tab.py
+++ b/src/napari_phasors/filter_tab.py
@@ -159,7 +159,9 @@ class FilterWidget(QWidget):
         filter_method_layout = QHBoxLayout()
         filter_method_layout.addWidget(QLabel("Filter Method:"))
         self.filter_method_combobox = QComboBox()
-        self.filter_method_combobox.addItems(["None", "Median", "Wavelet"])
+        self.filter_method_combobox.addItems(
+            ["None", "Median", "Wavelet (binlet pawFLIM)"]
+        )
         self.filter_method_combobox.setCurrentText("None")
         filter_method_layout.addWidget(self.filter_method_combobox)
         filter_box_layout.addLayout(filter_method_layout)
@@ -341,7 +343,7 @@ class FilterWidget(QWidget):
         elif method == "Median":
             self.median_filter_widget.setVisible(True)
             self.wavelet_filter_widget.setVisible(False)
-        elif method == "Wavelet":
+        elif method == "Wavelet (binlet pawFLIM)":
             self.median_filter_widget.setVisible(False)
             self.wavelet_filter_widget.setVisible(True)
 
@@ -594,7 +596,7 @@ class FilterWidget(QWidget):
                             and validate_harmonics_for_wavelet(harmonics)
                         ):
                             self.filter_method_combobox.setCurrentText(
-                                "Wavelet"
+                                "Wavelet (binlet pawFLIM)"
                             )
                         else:
                             self.filter_method_combobox.setCurrentText(
@@ -996,9 +998,11 @@ class FilterWidget(QWidget):
             if upper_val < self.threshold_slider.maximum():
                 threshold_upper = upper_val / self.threshold_factor
 
-        current_filter_method = (
-            self.filter_method_combobox.currentText().lower()
-        )
+        current_filter_method_text = self.filter_method_combobox.currentText()
+        if current_filter_method_text == "Wavelet (binlet pawFLIM)":
+            current_filter_method = "wavelet"
+        else:
+            current_filter_method = current_filter_method_text.lower()
 
         # Apply filter and threshold to each selected layer
         for layer in selected_layers:


### PR DESCRIPTION
## Summary

Documentation refresh covering the v0.7.0 feature set, plus a small terminology fix for the wavelet filter and a README/install update for the new conda-forge package.

## Changes

### New documentation
- Add a full **Batch Analysis** guide (`docs/guides/batch_analysis.md`), covering every tab of the widget (Setup, Signal Export, Calibration, Filter & Threshold, Masks, Selection, Components, Phasor Mapping, FRET) and wired into the docs TOC.
- Document new FRET model parameters (Donor Background, Background position, Proportion fretting, trajectory colormap overlay) in `fret_analysis.md`.
- Document the fraction histogram overlay for two-component Linear Projection in `component_analysis.md`.
- Add videos/GIFs and expand the histogram display-mode docs (Merged/Individual/Grouped) and CSV export option in `histogram_statistics.md`.

### Terminology / clarity fixes
- Rename the "Wavelet" filter option to **"Wavelet (binlet pawFLIM)"** throughout the UI and docs, to make the underlying method explicit (`filter_tab.py`, `_batch_analysis.py`, tests updated accordingly).
- Replace references to "data center" with **"phasor center"** for consistency across component analysis docs.
- Clarify phase units (radians only) in `phasor_mapping.md` and trim a stale "Calculating the output" section duplicated elsewhere.
- Various small wording/formatting consistency passes across batch analysis, exporting, phasor selection, and installation guides.

### README / installation
- Add a conda-forge badge and a dedicated **"Using conda (conda-forge)"** install path in `README.md` and `installation.md`, alongside the existing conda + pip instructions.
- Update the package description in `pyproject.toml` to be more descriptive.
- Add **Batch Analysis** to the feature bullet lists in README and `intro.md`.