### PR TITLE
Refactor aspect ratio handling in HistogramWidget and add tests

### DIFF
--- a/src/napari_phasors/_tests/test_utils_widgets.py
+++ b/src/napari_phasors/_tests/test_utils_widgets.py
@@ -1808,6 +1808,48 @@ def test_histogram_widget_save_png(qtbot, tmp_path, monkeypatch):
     w._save_histogram_png()
 
 
+def test_histogram_widget_square_aspect_keeps_data(
+    qtbot, tmp_path, monkeypatch
+):
+    """The square option squares the axes box without squashing the data.
+
+    The x axis is in data units and y is in counts, so a 1:1 *data* aspect
+    collapses the x range. Only the box aspect may be constrained, and it
+    must survive an export so the viewer plot stays square.
+    """
+    from qtpy.QtWidgets import QFileDialog
+
+    w = HistogramWidget(bins=50)
+    qtbot.addWidget(w)
+    # Counts far larger than the x range: the regime a data aspect ruins.
+    w.update_data(np.repeat(np.linspace(0.0, 10.0, 50), 400))
+
+    w._aspect_ratio = "equal"
+    w._render()
+    expected_xlim = w.ax.get_xlim()
+
+    assert w.ax.get_box_aspect() == 1
+    assert w.ax.get_aspect() == "auto"
+
+    out = tmp_path / "square.png"
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", lambda *a, **k: (str(out), "")
+    )
+    w._save_histogram_png()
+    assert out.exists()
+
+    # The exported figure keeps the full x range, and the on-screen plot is
+    # still square once the export has finished.
+    assert w.ax.get_xlim() == expected_xlim
+    assert w.ax.get_box_aspect() == 1
+    assert w.ax.get_aspect() == "auto"
+
+    # Switching back to auto releases the box constraint.
+    w._aspect_ratio = "auto"
+    w._render()
+    assert w.ax.get_box_aspect() is None
+
+
 def test_checkable_combobox_event_filter(qtbot):
     """Drive the CheckableComboBox event filter: line-edit clicks, hover,
     header All/None clicks, item toggle and leave."""

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2097,7 +2097,7 @@ class HistogramSettingsDialog(QDialog):
 
         # --- Aspect ratio ---
         aspect_layout = QHBoxLayout()
-        aspect_layout.addWidget(QLabel("Export aspect ratio:"))
+        aspect_layout.addWidget(QLabel("Aspect ratio:"))
         self.aspect_ratio_combo = QComboBox()
         self.aspect_ratio_combo.addItem("Auto (Rectangle)", "auto")
         self.aspect_ratio_combo.addItem("Equal (Square)", "equal")
@@ -2736,10 +2736,6 @@ class HistogramWidget(QWidget):
             file_path += '.png'
 
         self._style_axes(export_mode=True)
-        if self._aspect_ratio == "equal":
-            self.ax.set_aspect(1, adjustable='box')
-        else:
-            self.ax.set_aspect("auto")
         self.fig.canvas.draw_idle()
 
         use_transparent = not self._white_background
@@ -3198,6 +3194,17 @@ class HistogramWidget(QWidget):
             self.ax.tick_params(
                 axis="y", which=which, labelsize=7, colors=color
             )
+
+        self._apply_aspect_ratio()
+
+    def _apply_aspect_ratio(self) -> None:
+        """Make the axes box square or let it fill the canvas.
+
+        ``set_box_aspect`` constrains the shape of the axes box only. The
+        data aspect must stay "auto": x is in data units and y is in counts,
+        so tying them together would collapse one of the axes.
+        """
+        self.ax.set_box_aspect(1 if self._aspect_ratio == "equal" else None)
 
     def _get_cmap_and_norm(self):
         """Return (cmap, norm) from current colormap state."""


### PR DESCRIPTION
## Fix square aspect ratio in HistogramWidget

### Problem

Selecting **Equal (Square)** and saving the histogram as PNG produced an
unusable image: the plot was collapsed to a hairline instead of showing the
histogram. The broken aspect ratio also leaked into the live plot in the
napari viewer and stayed there after the save finished.

### Cause

`_save_histogram_png` called `ax.set_aspect(1, adjustable='box')`, which sets
the **data** aspect — it forces one x-data-unit to equal one y-data-unit on
screen. In this histogram the x axis is in data units (lifetime, phase,
modulation) while y is in pixel counts, so the two are orders of magnitude
apart and matplotlib squeezed x down to nothing to satisfy the 1:1 ratio.

The same call is correct in `plotter.py` and `phasor_mapping_tab.py`, where
both axes are phasor coordinates in [0, 1] — a 1:1 data aspect is exactly
what those plots want. Only the histogram mixes units, so only it broke.

The viewer side effect had the same root: the save path applied the aspect
but only ever restored the *colors* afterwards (via
`_style_axes(export_mode=False)`), leaving the broken aspect on the live axes.

### Fix

Use `set_box_aspect(1)`, which constrains the shape of the axes **box** while
leaving the data aspect `auto`, so the x range is untouched. This is moved
into an `_apply_aspect_ratio()` helper called from `_style_axes()`, which
every draw path already goes through (`__init__`, `_render`, and export), so
the setting is applied consistently in one place. The save path no longer
touches the aspect at all.

This also delivers the requested behaviour change: because the settings
dialog already calls `_render()` on accept, choosing **Equal (Square)** now
squares the histogram in the napari viewer immediately, not just on export.
Since the setting is no longer export-only, the dialog field is relabelled
from "Export aspect ratio:" to "Aspect ratio:".

### Verification

- Drove the real widget headless and exported both modes. The square export
  renders the full gradient histogram in a 321×321 axes box with the x range
  intact (-0.48 to 10.64); `auto` is unchanged.
- Added `test_histogram_widget_square_aspect_keeps_data`, asserting the box is
  square, the data aspect stays `auto`, xlim survives the export, and the
  square box persists afterwards. Confirmed it **fails** against the old
  `set_aspect` code before restoring the fix.
- All 91 tests in `test_utils_widgets.py` pass, plus 122 in
  `test_phasor_mapping_tab.py` and `test_plotter_features.py`.