### PR TITLE
Add smoke test for Linux installer and enhance post-install script

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -149,6 +149,39 @@ jobs:
         shell: bash -el {0}
         run: ls -la installer/napari-phasors-*
 
+      # Install the built .sh and launch napari through the generated
+      # launcher under Xvfb, exactly like a user's desktop entry would
+      # (real xcb platform plugin, no terminal attached). This catches
+      # "installer builds fine but the app never opens" regressions,
+      # which are otherwise invisible until someone tests on real Linux.
+      - name: Smoke test Linux installer
+        if: matrix.platform == 'linux'
+        shell: bash -el {0}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y >/dev/null
+          sudo apt-get install -y xvfb >/dev/null
+          SH_INSTALLER=( installer/napari-phasors-*.sh )
+          if [[ ${#SH_INSTALLER[@]} -ne 1 ]]; then
+            echo "ERROR: Expected exactly one .sh installer, found: ${SH_INSTALLER[*]}"
+            exit 1
+          fi
+          INSTALL_DIR="${RUNNER_TEMP}/smoke-install"
+          echo "=== Installing ==="
+          bash "${SH_INSTALLER[0]}" -b -p "${INSTALL_DIR}"
+          echo "=== Import test ==="
+          QT_QPA_PLATFORM=offscreen "${INSTALL_DIR}/bin/python" \
+            -c "import napari, napari_phasors; print('imports OK')"
+          echo "=== Launcher test (xcb under Xvfb) ==="
+          STATUS=0
+          xvfb-run -a "${INSTALL_DIR}/napari-phasors" --info || STATUS=$?
+          echo "=== Launch log ==="
+          cat "${INSTALL_DIR}/last-launch.log" 2>/dev/null || echo "(no log written)"
+          if [ "${STATUS}" -ne 0 ]; then
+            echo "ERROR: launcher exited with status ${STATUS}"
+            exit "${STATUS}"
+          fi
+
       - name: Create macOS DMG
         if: matrix.platform == 'macos'
         shell: bash -el {0}

--- a/installer/post_install.sh
+++ b/installer/post_install.sh
@@ -13,6 +13,12 @@ cat > "${PREFIX}/napari-phasors" << 'LAUNCHER'
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PATH="${DIR}/bin:${PATH}"
 export CONDA_PREFIX="${DIR}"
+# Shield the bundled python from user-level python config: a stray
+# PYTHONPATH or ~/.local/lib/pythonX.Y/site-packages with incompatible
+# packages (numpy, Qt bindings, ...) would be imported into the app and
+# can crash it on startup.
+unset PYTHONPATH PYTHONHOME
+export PYTHONNOUSERSITE=1
 for PLUGIN_DIR in "${DIR}/lib/qt6/plugins" "${DIR}/lib/qt/plugins" "${DIR}/plugins"; do
     if [ -d "${PLUGIN_DIR}/platforms" ]; then
         export QT_PLUGIN_PATH="${PLUGIN_DIR}"
@@ -22,6 +28,24 @@ for PLUGIN_DIR in "${DIR}/lib/qt6/plugins" "${DIR}/lib/qt/plugins" "${DIR}/plugi
 done
 if [ -d "${DIR}/etc/fonts" ]; then
     export FONTCONFIG_PATH="${DIR}/etc/fonts"
+fi
+if [ "$(uname)" = "Linux" ]; then
+    # Recent Qt may auto-select the Wayland backend on Wayland sessions;
+    # napari is only reliable on xcb, and XWayland covers Wayland desktops.
+    # Respect an explicit user override.
+    export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"
+    # The .desktop entry launches with Terminal=false, so any startup
+    # error would otherwise be invisible. When not attached to a
+    # terminal, keep a log of the last launch attempt.
+    if [ ! -t 1 ]; then
+        LOG_FILE="${DIR}/last-launch.log"
+        if ! : > "${LOG_FILE}" 2>/dev/null; then
+            LOG_FILE="${TMPDIR:-/tmp}/napari-phasors-launch.log"
+            : > "${LOG_FILE}" 2>/dev/null || LOG_FILE=/dev/null
+        fi
+        exec >> "${LOG_FILE}" 2>&1
+        echo "napari-phasors launch: $(date)"
+    fi
 fi
 exec "${DIR}/bin/python" -m napari "$@"
 LAUNCHER
@@ -38,17 +62,31 @@ if [ "$(uname)" = "Linux" ]; then
 Type=Application
 Name=napari-phasors
 Comment=Phasor analysis in napari
-Exec=${PREFIX}/napari-phasors
+Exec="${PREFIX}/napari-phasors"
 Icon=${PREFIX}/icon.png
 Terminal=false
+StartupNotify=true
+StartupWMClass=napari
 Categories=Science;Education;
 DESKTOP
+    update-desktop-database "${APPS_DIR}" >/dev/null 2>&1 || true
 
-    # Also copy to Desktop if it exists
+    # Also copy to Desktop if it exists. GNOME refuses to launch desktop
+    # icons that are not both executable and marked trusted; without the
+    # gio metadata a double-click does nothing (or shows an "untrusted
+    # launcher" warning), which looks like the app never opens.
     if [ -d "${DESKTOP_DIR}" ]; then
         cp "${APPS_DIR}/napari-phasors.desktop" "${DESKTOP_DIR}/"
         chmod +x "${DESKTOP_DIR}/napari-phasors.desktop"
+        gio set "${DESKTOP_DIR}/napari-phasors.desktop" \
+            metadata::trusted true >/dev/null 2>&1 || true
     fi
+
+    echo "napari-phasors installed successfully."
+    echo "Launch it from your applications menu, or run:"
+    echo "    ${PREFIX}/napari-phasors"
+    echo "If the app does not open, check the log at:"
+    echo "    ${PREFIX}/last-launch.log"
 fi
 
 # macOS: no additional launchers needed (handled by .app bundle in DMG)


### PR DESCRIPTION
## Summary

The Linux installer's app never launches, and until now it's been undiagnosable because `Terminal=false` on the desktop entry swallows any error. Root cause: the last built Linux artifact predates the launcher rewrite in #348 — it still sources a `bin/activate` that constructor envs don't ship, so the launcher exits with nothing. This PR fixes the remaining Linux-only launch blockers and, more importantly, makes future launch failures observable instead of silent.

- Log the launcher's stdout/stderr to `last-launch.log` when started without a terminal (i.e. from the desktop entry), so the next failure is actually diagnosable.
- Mark the Desktop copy of the `.desktop` file as trusted (`gio set ... metadata::trusted true`) and refresh the app database — GNOME silently no-ops on untrusted launcher icons, which looks identical to "nothing happens."
- Default `QT_QPA_PLATFORM=xcb` (Qt can auto-pick Wayland on Wayland sessions; napari is only reliable on xcb, and XWayland covers those desktops). Respects an explicit user override.
- Shield the bundled interpreter from the user's environment (`unset PYTHONPATH`, `PYTHONNOUSERSITE=1`) so a stray `~/.local` site-packages can't crash the app on import.
- Quote `Exec=` and add `StartupWMClass=napari` in the `.desktop` file.
- Add a Linux-only CI smoke test: after building the `.sh` installer, install it on the runner and launch it through the generated launcher under Xvfb (real xcb plugin, no terminal attached — the same path a user's desktop icon takes), plus a plain `import napari, napari_phasors` check. The build now fails if the shipped Linux installer can't actually start napari, and `last-launch.log` is dumped to the CI log for debugging.

macOS and Windows installer scripts and workflow steps are untouched; the new logic is gated behind `uname = Linux` in the shared `post_install.sh`, and the new CI step is `if: matrix.platform == 'linux'`.
