### PR TITLE
Pass frequency and lifetime as keyword arguments

### DIFF
--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -236,8 +236,8 @@ def test_calibrate_layer_success(make_viewer_model, qtbot):
         mean_original,
         g_reshaped,
         s_reshaped,
-        frequency,
-        lifetime,
+        frequency=frequency,
+        lifetime=lifetime,
     )
     _, real_center, imag_center = phasor_center(
         mean_original, g_reshaped, s_reshaped


### PR DESCRIPTION
The `frequency` and `lifetime` parameters of `phasor_calibrate` are about to become keyword-only: https://github.com/phasorpy/phasorpy/pull/368