### PR TITLE
Enhance time-lapse functionality and data handling across components

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ available at **[https://napari-phasors.readthedocs.io](https://napari-phasors.re
 - **Phasor Mapping** — colormap apparent/normal lifetime, phasor phase, and phasor modulation per pixel, with interactive 1D histograms, statistics tables, and arc overlay tools
 - **FRET analysis** with donor trajectory visualization and multi-layer donor/background source selection
 - **Selections** via manual drawing, circular/polar/elliptical cursors, and automatic clustering
+- **Time-lapse analysis** — the phasor plot, histogram and statistics follow napari's own dimension slider (including its play button), with a per-frame statistics table, GIF animation export, and statistics exported pooled or per timepoint
 - **Exporting** results as OME-TIF or CSV (multiple layers simultaneously)
 - **Batch Analysis** — apply the same reading and analysis pipeline (calibration, filtering, masking, component analysis, phasor mapping, FRET, selections) to every file in a folder and export the results headlessly
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -23,6 +23,7 @@ parts:
   - file: guides/phasor_mapping
   - file: guides/fret_analysis
   - file: guides/histogram_statistics
+  - file: guides/timelapse
   - file: guides/exporting
   - file: guides/batch_analysis
 - caption: API Reference

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,6 +26,14 @@ This section documents the public Python API of napari-phasors.
    :undoc-members:
 ```
 
+## Time-lapse
+
+```{eval-rst}
+.. automodule:: napari_phasors._timelapse
+   :members:
+   :undoc-members:
+```
+
 ## Synthetic Data Generator
 
 ```{eval-rst}

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -13,6 +13,12 @@ Multiple layers can be selected and exported simultaneously in a single operatio
 
 Phasor coordinates and selections can be exported as CSV files using the **Export Phasor** widget. Analysis results, such as lifetime, FRET efficiency, and component fractions, can also be exported to CSV. Similarly, labels layers can be exported to CSV, where the pixel coordinates and corresponding label values/IDs are saved.
 
+## Animation and per-timepoint export
+
+For time-lapse acquisitions, the phasor plot and the histogram can be exported
+as an animated GIF, and both statistics tables can be exported with one row per
+timepoint. See {doc}`timelapse`.
+
 ## Image export
 
 The colormapped image layer can be exported with or without its associated colorbar. Labels layers can also be exported as images using their colored representation.

--- a/docs/guides/histogram_statistics.md
+++ b/docs/guides/histogram_statistics.md
@@ -80,6 +80,11 @@ The **Statistics** dock panel, linked to the histogram, displays per-layer (and 
 
 Right-clicking on the table provides **Copy**, **Copy with Headers**, and **Select All** options. The entire table can also be exported to CSV via the **Export Table as CSV** button.
 
+For time-lapse data the histogram follows the timepoint shown in the viewer,
+and the table switches to one row per timepoint with the displayed frame
+highlighted. The export button additionally offers *All timepoints pooled* and
+*Per timepoint*. See {doc}`timelapse`.
+
 ## Example usage
 
 1. Run any supported analysis (component, mapping, or FRET).

--- a/docs/guides/timelapse.md
+++ b/docs/guides/timelapse.md
@@ -1,0 +1,146 @@
+# Time-lapse Analysis
+
+Many acquisitions have one or more dimensions beyond the image plane — a time
+series, a Z stack, or a spectral series read from a `.czi`, `.lsm` or `.ptu`
+file. napari-phasors analyses every one of those planes, so the derived layers
+(lifetime, component fractions, FRET efficiency) already play as a movie in the
+napari viewer.
+
+The **Frames** controls, shown beneath the phasor plot, extend that to the plot
+itself: instead of pooling every timepoint into one cloud, the phasor plot, the
+1-D histogram and the statistics table follow the timepoint napari is
+displaying — including while napari plays the stack — and the result can be
+exported as an animation.
+
+The controls only appear when the selected layers actually have a non-spatial
+axis. For plain 2-D data nothing changes.
+
+## Frames controls
+
+| Control | Description |
+|---------|-------------|
+| **Frames** | `All timepoints` pools the whole acquisition into one phasor plot (the default, and how earlier versions always behaved). `Current timepoint` shows only the frame displayed in the viewer. |
+| **Axis** | Which dimension to step through. Only shown when the data has more than one non-spatial axis (e.g. a Z stack acquired over time). |
+| **Export Animation…** | Render the time-lapse to an animated GIF. Enabled in `Current timepoint` mode. |
+
+### Navigation is napari's slider
+
+There is deliberately no frame slider, play button or frame counter in the
+plugin: **napari's own dimension slider is the control**. Drag it, use its play
+button, or type a frame number, and the phasor plot, the histogram and the
+statistics table follow. The plugin also pushes changes back the other way, so
+the image and the plot can never disagree about which timepoint you are
+looking at.
+
+The display mode and the chosen axis are stored in the layer's settings
+alongside every other plot setting, so they are restored when you switch back
+to a layer or reload an exported OME-TIF. The frame index itself is not stored
+— it always comes from the viewer.
+
+## What follows the frame
+
+In `Current timepoint` mode:
+
+- the **phasor plot** (density, scatter and contour) shows only that frame's
+  pixels;
+- the **phasor centers** and their statistics summarise only that frame;
+- the **1-D histogram** of the analysis tabs (phasor mapping, component
+  analysis, FRET) summarises only that frame;
+- the **statistics table** switches to one row per timepoint (see below).
+
+## Statistics table
+
+In `All timepoints` mode the table keeps its usual layout: one row per layer,
+pooled over the whole acquisition.
+
+In `Current timepoint` mode it gains a **Frame** column and lists every
+timepoint at once, so you can read the trend down the column instead of
+scrubbing. The row for the frame on screen is **bold and highlighted**, and it
+follows along as you move the slider or play the acquisition — the table also
+scrolls to keep it in view. With several layers selected there is one row per
+frame per layer, grouped by frame.
+
+The centre-of-mass column is binned over the whole acquisition (using the
+histogram's bin count and range), so the value is comparable from frame to
+frame rather than being rebinned on each frame's own extent.
+
+Group statistics stay a pooled, per-layer concept and are hidden while the
+per-frame rows are shown.
+
+Range sliders keep using the whole acquisition's extent, so the colormap
+contrast limits do not jump around while playing. If a frame has no valid
+pixels — because a threshold or a mask removed them all — the plot is blanked
+rather than left showing the previous frame.
+
+### A colour scale that means the same thing on every frame
+
+The 2-D phasor histogram would otherwise re-bin and re-normalise on each
+frame, so a given colour — and the colorbar beside it — would stand for a
+different number of pixels at every timepoint. Instead, both the bin grid and
+the colour range are computed once over the **whole acquisition**, across
+**every selected layer**, and then applied unchanged to each frame:
+
+- the bin grid is the one the `All timepoints` plot would draw, so the
+  histogram does not shift under you while stepping;
+- the colour scale runs from 1 count up to the highest bin count reached by
+  any single frame, so the busiest frame uses the full colormap and quieter
+  frames read as genuinely quieter.
+
+Both are cached and only recomputed when the selected layers, the harmonic or
+the bin count change.
+
+### Selections
+
+Selections are regions in phasor space, so they always apply to the whole
+acquisition. Drawing a lasso, rectangle or ellipse while a single frame is
+displayed labels the matching pixels in *every* timepoint, exactly as the
+cursor and clustering selections do. This keeps a selection meaningful as a
+population of molecular species rather than as a per-frame annotation.
+
+## Exporting an animation
+
+With `Current timepoint` active, click **Export Animation…** to choose:
+
+- whether to render the **phasor plot**, the **histogram**, or both side by
+  side;
+- the **first** and **last** frame;
+- the **frame rate**.
+
+The result is written as an animated GIF. Exporting leaves the viewer on the
+frame you started from.
+
+```{note}
+GIF export uses the `imageio` package, which ships with napari. If it is
+missing from your environment, install it with `pip install imageio`.
+```
+
+## Exporting statistics
+
+Both statistics tables offer a pooled and a per-timepoint export for stacks.
+
+**Analysis statistics** — click **Export Table as CSV** in the Statistics dock
+and choose:
+
+- *Current view* — the table exactly as displayed;
+- *All timepoints pooled* — one row per layer over the whole acquisition;
+- *Per timepoint* — one row per layer per frame.
+
+The per-timepoint file has the columns `Frame, Name, Center of Mass, Mean,
+Median, Std Dev`.
+
+**Phasor centers** — with phasor centers enabled in the Plot Settings tab,
+click **Export Centers as CSV** and choose *All timepoints pooled* or *Per
+timepoint*. The file has the columns `Frame, Name, G (center), S (center),
+Phase (deg), Modulation`, which makes it straightforward to plot how the
+phasor centroid moves over the acquisition.
+
+## Example workflow
+
+1. Open a time-lapse file and run the analysis you are interested in
+   (see {doc}`phasor_mapping`, {doc}`component_analysis` or
+   {doc}`fret_analysis`).
+2. Inspect the pooled phasor plot to set thresholds, filters and selections.
+3. Switch **Frames** to `Current timepoint`, then scrub or play napari's
+   dimension slider to see how the distribution evolves.
+4. Export the animation for a presentation, and the per-timepoint CSV for
+   quantification.

--- a/src/napari_phasors/_tests/test_plotter_tabs_toolbar.py
+++ b/src/napari_phasors/_tests/test_plotter_tabs_toolbar.py
@@ -700,3 +700,49 @@ def test_phasor_plotter_visibility_methods_integration_with_tab_changes(
             assert not call[0][0]
         # The last FRET call should be True (show FRET)
         assert calls_fret[-1][0][0]
+
+
+def test_deferred_tab_update_after_primary_layer_removed(make_viewer_model):
+    """Deferred tab updates must survive the primary layer being removed.
+
+    The FRET and Phasor Mapping tabs resolve their layer by name. Once the
+    plotter is closed its viewer connections are gone, so removing a layer
+    leaves the combobox reporting a stale name while the layer is no longer
+    in ``viewer.layers``. A pending update for a non-visible tab then runs
+    against that stale name and used to raise ``KeyError``.
+    """
+    viewer = make_viewer_model()
+    intensity_image_layer = create_image_layer_with_phasors()
+    viewer.add_layer(intensity_image_layer)
+    plotter = PlotterWidget(viewer)
+
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [intensity_image_layer.name]
+    )
+    plotter._process_layer_selection_change()
+
+    # Keep the analysis tabs non-visible so their updates stay deferred.
+    plotter.tab_widget.setCurrentWidget(plotter.settings_tab)
+    plotter.close()
+    viewer.layers.remove(intensity_image_layer)
+
+    # The stale name is what makes this a regression test: the guards, not
+    # an empty selection, are what keep the lookups from raising.
+    stale_name = plotter.get_primary_layer_name()
+    assert stale_name == intensity_image_layer.name
+    assert stale_name not in viewer.layers
+    assert plotter.fret_tab._needs_update
+    assert plotter.phasor_mapping_tab._needs_update
+
+    plotter.tab_widget.setCurrentWidget(plotter.fret_tab)
+    plotter.tab_widget.setCurrentWidget(plotter.phasor_mapping_tab)
+
+    # The individual guarded lookups, exercised directly.
+    plotter.fret_tab._update_fret_setting_in_metadata('donor_lifetime', 1.0)
+    plotter.fret_tab._restore_fret_settings_from_metadata()
+
+    mapping_tab = plotter.phasor_mapping_tab
+    assert mapping_tab._get_current_layer_mapping_settings() is None
+    assert mapping_tab._get_current_layer_mapping_settings(create=True) is None
+    mapping_tab._restore_lifetime_settings_from_metadata()
+    mapping_tab._restore_lifetime_range_from_metadata()

--- a/src/napari_phasors/_tests/test_timelapse.py
+++ b/src/napari_phasors/_tests/test_timelapse.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from qtpy.QtWidgets import QDialog
 
 from napari_phasors._synthetic_generator import (
     make_intensity_layer_with_phasors,
@@ -1219,3 +1220,596 @@ def test_combine_frames_pads_to_a_common_height():
     assert combine_frames([]) is None
     assert combine_frames([left]).shape == (10, 4, 3)
     assert combine_frames([left, right]).shape == (10, 9, 3)
+
+
+# ---------------------------------------------------------------------------
+# Export handlers (the dialog-driven entry points)
+# ---------------------------------------------------------------------------
+
+
+class _DialogStub:
+    """Stand in for a modal dialog, returning a fixed result and options."""
+
+    def __init__(self, accepted, options=None):
+        self._accepted = accepted
+        self._options = options or {}
+        self.constructed_with = None
+
+    def __call__(self, *args, **kwargs):
+        self.constructed_with = (args, kwargs)
+        return self
+
+    def exec_(self):
+        return self._accepted
+
+    def exec(self):
+        return self._accepted
+
+    def get_options(self):
+        return self._options
+
+
+def _accept_save_dialog(monkeypatch, path):
+    """Make QFileDialog.getSaveFileName return *path* without a UI."""
+    monkeypatch.setattr(
+        "napari_phasors.plotter.QFileDialog.getSaveFileName",
+        staticmethod(lambda *a, **k: (str(path), "")),
+    )
+
+
+def test_export_animation_click_writes_a_gif(
+    make_viewer_model, monkeypatch, tmp_path
+):
+    """The Export Animation button renders and saves without a dialog."""
+    pytest.importorskip("imageio.v3")
+
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+
+        target = tmp_path / "movie"  # no extension: handler must add .gif
+        stub = _DialogStub(
+            QDialog.Accepted,
+            {
+                "include_phasor": True,
+                "include_histogram": False,
+                "frames": list(range(N_FRAMES)),
+                "fps": 5,
+            },
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.AnimationExportDialog", stub
+        )
+        _accept_save_dialog(monkeypatch, target)
+
+        plotter._on_export_animation_clicked()
+
+        assert (tmp_path / "movie.gif").exists()
+    finally:
+        plotter.close()
+
+
+def test_export_animation_click_needs_per_frame_mode(
+    make_viewer_model, monkeypatch
+):
+    """In pooled mode the handler explains itself instead of exporting."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        messages = []
+        monkeypatch.setattr(
+            "napari_phasors.plotter.notifications.show_info", messages.append
+        )
+        # A dialog must never be constructed on this path.
+        monkeypatch.setattr(
+            "napari_phasors.plotter.AnimationExportDialog",
+            lambda *a, **k: pytest.fail("dialog opened in pooled mode"),
+        )
+
+        plotter._on_export_animation_clicked()
+
+        assert messages and "Current timepoint" in messages[0]
+    finally:
+        plotter.close()
+
+
+def test_export_animation_click_cancelled(make_viewer_model, monkeypatch):
+    """Rejecting the options dialog exports nothing."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        monkeypatch.setattr(
+            "napari_phasors.plotter.AnimationExportDialog",
+            _DialogStub(QDialog.Rejected),
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QFileDialog.getSaveFileName",
+            staticmethod(
+                lambda *a, **k: pytest.fail("save dialog opened after cancel")
+            ),
+        )
+
+        plotter._on_export_animation_clicked()
+    finally:
+        plotter.close()
+
+
+def test_export_animation_click_requires_a_figure(
+    make_viewer_model, monkeypatch
+):
+    """Deselecting both figures warns rather than writing an empty GIF."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        warnings_seen = []
+        monkeypatch.setattr(
+            "napari_phasors.plotter.notifications.show_warning",
+            warnings_seen.append,
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.AnimationExportDialog",
+            _DialogStub(
+                QDialog.Accepted,
+                {
+                    "include_phasor": False,
+                    "include_histogram": False,
+                    "frames": [0],
+                    "fps": 5,
+                },
+            ),
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QFileDialog.getSaveFileName",
+            staticmethod(lambda *a, **k: pytest.fail("save dialog opened")),
+        )
+
+        plotter._on_export_animation_clicked()
+
+        assert warnings_seen
+    finally:
+        plotter.close()
+
+
+def test_export_animation_click_no_path_chosen(make_viewer_model, monkeypatch):
+    """Dismissing the file dialog exports nothing."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        monkeypatch.setattr(
+            "napari_phasors.plotter.AnimationExportDialog",
+            _DialogStub(
+                QDialog.Accepted,
+                {
+                    "include_phasor": True,
+                    "include_histogram": False,
+                    "frames": [0],
+                    "fps": 5,
+                },
+            ),
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QFileDialog.getSaveFileName",
+            staticmethod(lambda *a, **k: ("", "")),
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.export_animation",
+            lambda *a, **k: pytest.fail("exported without a path"),
+        )
+
+        plotter._on_export_animation_clicked()
+    finally:
+        plotter.close()
+
+
+def test_render_animation_frames_skips_out_of_range(make_viewer_model):
+    """Frame indices outside the stack are ignored, not clamped."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        frames = plotter._render_animation_frames(
+            {
+                "include_phasor": True,
+                "include_histogram": False,
+                "frames": [-1, 0, N_FRAMES, N_FRAMES + 5],
+                "fps": 5,
+            },
+            histogram=None,
+        )
+        assert len(frames) == 1
+    finally:
+        plotter.close()
+
+
+def test_render_animation_frames_redraws_the_starting_frame(
+    make_viewer_model,
+):
+    """The frame already displayed still gets rendered."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 2
+        frames = plotter._render_animation_frames(
+            {
+                "include_phasor": True,
+                "include_histogram": False,
+                "frames": [2],
+                "fps": 5,
+            },
+            histogram=None,
+        )
+        assert len(frames) == 1
+    finally:
+        plotter.close()
+
+
+def _choose_menu_action(monkeypatch, index):
+    """Pick the *index*-th action of the next QMenu shown, or None to cancel."""
+
+    def fake_exec(self, *args, **kwargs):
+        actions = self.actions()
+        return None if index is None else actions[index]
+
+    monkeypatch.setattr(
+        "napari_phasors.plotter.QMenu.exec_", fake_exec, raising=False
+    )
+
+
+def test_phasor_center_export_per_timepoint(
+    make_viewer_model, monkeypatch, tmp_path
+):
+    """Choosing 'Per timepoint' writes one row per frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        target = tmp_path / "centers"  # no extension: handler must add .csv
+        _choose_menu_action(monkeypatch, 1)  # "Per timepoint"
+        _accept_save_dialog(monkeypatch, target)
+
+        plotter._export_phasor_center_statistics()
+
+        lines = (tmp_path / "centers.csv").read_text().strip().splitlines()
+        assert len(lines) == N_FRAMES + 1
+        assert lines[0].startswith("Frame,Name,G (center)")
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_export_pooled(make_viewer_model, monkeypatch, tmp_path):
+    """Choosing 'All timepoints pooled' writes a single row."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        target = tmp_path / "pooled.csv"
+        _choose_menu_action(monkeypatch, 0)  # "All timepoints pooled"
+        _accept_save_dialog(monkeypatch, target)
+
+        plotter._export_phasor_center_statistics()
+
+        lines = target.read_text().strip().splitlines()
+        assert len(lines) == 2
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_export_menu_cancelled(make_viewer_model, monkeypatch):
+    """Dismissing the menu exports nothing."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        _choose_menu_action(monkeypatch, None)
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QFileDialog.getSaveFileName",
+            staticmethod(lambda *a, **k: pytest.fail("save dialog opened")),
+        )
+
+        plotter._export_phasor_center_statistics()
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_export_no_path_chosen(make_viewer_model, monkeypatch):
+    """Dismissing the file dialog writes nothing."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        _choose_menu_action(monkeypatch, 0)
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QFileDialog.getSaveFileName",
+            staticmethod(lambda *a, **k: ("", "")),
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.write_rows_to_csv",
+            lambda *a, **k: pytest.fail("wrote without a path"),
+        )
+
+        plotter._export_phasor_center_statistics()
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_export_for_2d_data_skips_the_menu(
+    make_viewer_model, monkeypatch, tmp_path
+):
+    """Without a stack axis there is nothing to choose, so no menu appears."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_flat_layer())
+    try:
+        target = tmp_path / "flat.csv"
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QMenu.exec_",
+            lambda self, *a, **k: pytest.fail("menu opened for 2D data"),
+            raising=False,
+        )
+        _accept_save_dialog(monkeypatch, target)
+
+        plotter._export_phasor_center_statistics()
+
+        assert len(target.read_text().strip().splitlines()) == 2
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_export_without_centers_warns(
+    make_viewer_model, monkeypatch
+):
+    """A selection with no computable centers warns instead of writing."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        warnings_seen = []
+        monkeypatch.setattr(
+            "napari_phasors.plotter.notifications.show_warning",
+            warnings_seen.append,
+        )
+        monkeypatch.setattr(
+            plotter, "_phasor_center_statistics_rows", lambda per_frame: []
+        )
+        monkeypatch.setattr(
+            "napari_phasors.plotter.QFileDialog.getSaveFileName",
+            staticmethod(lambda *a, **k: pytest.fail("save dialog opened")),
+        )
+        _choose_menu_action(monkeypatch, 0)
+
+        plotter._export_phasor_center_statistics()
+
+        assert warnings_seen
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Guard branches
+# ---------------------------------------------------------------------------
+
+
+def test_frame_callbacks_are_inert_while_closing(make_viewer_model):
+    """Queued frame callbacks must not touch a widget that is tearing down."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter._is_closing = True
+
+        replots = []
+        plotter._replot_for_frame_state = lambda: replots.append(True)
+
+        plotter._on_frame_changed(1)
+        plotter._on_frame_mode_changed(POOLED)
+        plotter._on_frame_axis_changed(0)
+
+        assert replots == []
+    finally:
+        plotter._is_closing = False
+        plotter.close()
+
+
+def test_frame_changed_is_inert_in_pooled_mode(make_viewer_model):
+    """A frame change while pooled changes nothing on screen."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        replots = []
+        plotter._replot_for_frame_state = lambda: replots.append(True)
+
+        plotter._on_frame_changed(2)
+
+        assert replots == []
+    finally:
+        plotter.close()
+
+
+def test_frame_axis_change_replots_only_per_frame(make_viewer_model):
+    """Switching axis matters only when a single frame is displayed."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(
+        viewer, create_stack_layer(shape=(2, 3, 5, 6))
+    )
+    try:
+        replots = []
+        plotter._replot_for_frame_state = lambda: replots.append(True)
+
+        plotter._on_frame_axis_changed(1)
+        assert replots == []
+
+        plotter.frame_context.mode = CURRENT
+        plotter._on_frame_axis_changed(0)
+        assert replots
+    finally:
+        plotter.close()
+
+
+def test_refresh_timelapse_controls_without_a_bar(make_viewer_model):
+    """The refresh helper tolerates being called before the bar exists."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        bar = plotter.timelapse_bar
+        del plotter.timelapse_bar
+        plotter._refresh_timelapse_controls()  # must not raise
+        plotter.timelapse_bar = bar
+    finally:
+        plotter.close()
+
+
+def test_refresh_frame_dependent_tabs_skips_missing_tabs(make_viewer_model):
+    """Tabs that are absent or lack the hook are stepped over."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        original = (
+            plotter.phasor_mapping_tab,
+            plotter.components_tab,
+            plotter.fret_tab,
+        )
+        plotter.phasor_mapping_tab = None
+        # An object that simply has no ``refresh_for_frame_change`` hook.
+        plotter.components_tab = object()
+
+        plotter._refresh_frame_dependent_tabs()  # must not raise
+
+        (
+            plotter.phasor_mapping_tab,
+            plotter.components_tab,
+            plotter.fret_tab,
+        ) = original
+    finally:
+        plotter.close()
+
+
+def test_active_histogram_widget_without_data(make_viewer_model):
+    """No analysis run means no histogram to offer the animation export."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.tab_widget.setCurrentWidget(plotter.settings_tab)
+        assert plotter._active_histogram_widget() is None
+    finally:
+        plotter.close()
+
+
+def test_deferred_tab_update_skipped_for_a_removed_layer(make_viewer_model):
+    """A pending tab update must not look up a layer that is already gone.
+
+    The tab-change event can arrive after the layer was removed; the restore
+    paths index the viewer by name, so the update is skipped wholesale.
+    """
+    viewer = make_viewer_model()
+    layer = create_stack_layer()
+    plotter = make_plotter_with_layer(viewer, layer)
+    try:
+        mapping_tab = plotter.phasor_mapping_tab
+        mapping_tab._needs_update = True
+        restores = []
+        mapping_tab._restore_on_layer_change = lambda: restores.append(True)
+
+        # The combobox still reports a layer the viewer no longer holds,
+        # which is exactly the state a late tab-change event arrives in.
+        plotter.get_primary_layer_name = lambda: "Gone Intensity Image"
+        plotter._run_deferred_tab_update(mapping_tab)
+        assert restores == []
+
+        # Tearing down short-circuits the same way.
+        plotter.get_primary_layer_name = lambda: layer.name
+        plotter._is_closing = True
+        plotter._run_deferred_tab_update(mapping_tab)
+        assert restores == []
+        plotter._is_closing = False
+
+        # With a live layer the deferred update still runs.
+        plotter._run_deferred_tab_update(mapping_tab)
+        assert restores == [True]
+    finally:
+        plotter.close()
+
+
+def test_layer_phasor_arrays_without_phasor_data(make_viewer_model):
+    """A layer with no G/S contributes nothing rather than raising."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        layer = plotter.get_selected_layers()[0]
+        layer.metadata.pop("G")
+
+        assert plotter._get_layer_phasor_arrays(layer) is None
+        assert list(plotter._iter_layer_gs_arrays()) == []
+        assert plotter._phasor_center_statistics_rows(per_frame=True) == []
+
+        plotter.frame_context.mode = CURRENT
+        assert plotter._frame_histogram_reference() is None
+    finally:
+        plotter.close()
+
+
+def test_frame_histogram_reference_without_a_selection(make_viewer_model):
+    """No selected layers means no shared range to compute."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.image_layers_checkable_combobox.setCheckedItems([])
+
+        assert plotter._frame_histogram_reference() is None
+    finally:
+        plotter.close()
+
+
+def test_frame_histogram_reference_with_all_nan_phasors(make_viewer_model):
+    """A fully masked stack yields no usable range."""
+    viewer = make_viewer_model()
+    layer = create_stack_layer()
+    layer.metadata["G"][:] = np.nan
+    layer.metadata["S"][:] = np.nan
+    plotter = make_plotter_with_layer(viewer, layer)
+    try:
+        plotter.frame_context.mode = CURRENT
+        assert plotter._frame_histogram_reference() is None
+    finally:
+        plotter.close()
+
+
+def test_frame_histogram_reference_includes_a_2d_layer(make_viewer_model):
+    """A plain 2D layer beside a stack contributes to every frame."""
+    viewer = make_viewer_model()
+    stack = create_stack_layer(name="Stack")
+    flat = create_flat_layer(name="Flat")
+    viewer.add_layer(stack)
+    viewer.add_layer(flat)
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [stack.name, flat.name]
+    )
+    plotter._process_layer_selection_change()
+    try:
+        plotter.frame_context.mode = CURRENT
+        reference = plotter._frame_histogram_reference()
+
+        assert reference is not None
+        # One stack frame (30 px) plus the whole 2D layer (30 px).
+        assert plotter.get_merged_features()[0].size == 2 * 5 * 6
+    finally:
+        plotter.close()
+
+
+def test_plot_blanks_when_features_are_unavailable(make_viewer_model):
+    """``plot`` blanks the canvas when a frame yields no features at all."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.plot()
+        assert plotter.canvas_widget.artists['HISTOGRAM2D'].visible is True
+
+        plotter.get_features = lambda: None
+        plotter.plot()
+
+        assert plotter.canvas_widget.artists['HISTOGRAM2D'].visible is False
+        assert plotter._frame_plot_blanked is True
+    finally:
+        plotter.close()

--- a/src/napari_phasors/_tests/test_timelapse.py
+++ b/src/napari_phasors/_tests/test_timelapse.py
@@ -1,0 +1,1221 @@
+"""Tests for time-lapse (stack) support in the phasor plot and histogram."""
+
+import numpy as np
+import pytest
+
+from napari_phasors._synthetic_generator import (
+    make_intensity_layer_with_phasors,
+    make_raw_flim_data,
+)
+from napari_phasors._timelapse import (
+    CURRENT,
+    POOLED,
+    AnimationExportDialog,
+    FrameContext,
+    TimelapseControlBar,
+    build_frame_statistics_rows,
+    combine_frames,
+    stack_axes,
+)
+from napari_phasors.plotter import PlotterWidget
+
+N_FRAMES = 4
+STACK_SHAPE = (N_FRAMES, 5, 6)
+
+
+def create_stack_layer(shape=STACK_SHAPE, name="Stack"):
+    """Create an intensity layer with phasors whose data has a stack axis.
+
+    Seven time constants over 30 pixels per frame means the decay pattern
+    does not repeat frame to frame, so each frame has distinct phasor
+    coordinates.
+    """
+    raw_flim_data = make_raw_flim_data(
+        shape=shape, time_constants=[0.1, 0.5, 1, 2, 3, 4, 5]
+    )
+    return make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=[1, 2], name=name
+    )
+
+
+def create_flat_layer(name="Flat"):
+    """Create a plain 2D intensity layer with phasors."""
+    raw_flim_data = make_raw_flim_data(
+        shape=(5, 6), time_constants=[0.1, 1, 2, 3, 4, 5]
+    )
+    return make_intensity_layer_with_phasors(
+        raw_flim_data, harmonic=[1, 2], name=name
+    )
+
+
+def make_plotter_with_layer(viewer, layer):
+    """Add *layer* to *viewer*, select it in a fresh plotter and return it."""
+    viewer.add_layer(layer)
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems([layer.name])
+    plotter._process_layer_selection_change()
+    return plotter
+
+
+def _run_linear_projection(components_tab):
+    """Configure two components and run a Linear Projection analysis."""
+    components_tab.analysis_type_combo.setCurrentText("Linear Projection")
+    components_tab.components[0].g_edit.setText("0.2")
+    components_tab.components[0].s_edit.setText("0.1")
+    components_tab._on_component_coords_changed(0)
+    components_tab.components[1].g_edit.setText("0.8")
+    components_tab.components[1].s_edit.setText("0.5")
+    components_tab._on_component_coords_changed(1)
+    components_tab._run_analysis()
+
+
+def _histogram_mean(histogram):
+    """Mean of the values the histogram is currently displaying."""
+    return float(np.mean(histogram._raw_valid_data))
+
+
+def _expected_frame_mean(histogram, frame):
+    """Mean of *frame* computed straight from the un-sliced source data."""
+    values = []
+    for data in histogram._frame_source_datasets.values():
+        array = np.asarray(data, dtype=float)[frame].ravel()
+        values.append(array[np.isfinite(array)])
+    return float(np.mean(np.concatenate(values)))
+
+
+def _assert_frame_source_keeps_layer_shape(histogram):
+    """The recorded source arrays must keep their stack axis.
+
+    Flattening them before the frame slice is applied silently pools every
+    timepoint, which is exactly the bug this guards against.
+    """
+    assert histogram._frame_source_datasets
+    for name, data in histogram._frame_source_datasets.items():
+        assert (
+            np.asarray(data).shape == STACK_SHAPE
+        ), f"{name} lost its stack axis: {np.asarray(data).shape}"
+
+
+# ---------------------------------------------------------------------------
+# FrameContext basics
+# ---------------------------------------------------------------------------
+
+
+def test_stack_axes_only_counts_non_spatial_axes():
+    """The last two axes are spatial; anything before them is a stack axis."""
+
+    class _Layer:
+        def __init__(self, data):
+            self.data = data
+
+    assert stack_axes(_Layer(np.zeros((5, 6)))) == []
+    assert stack_axes(_Layer(np.zeros((4, 5, 6)))) == [0]
+    assert stack_axes(_Layer(np.zeros((3, 4, 5, 6)))) == [0, 1]
+    assert stack_axes(_Layer(None)) == []
+
+
+def test_frame_context_reports_no_axes_for_2d_data(make_viewer_model):
+    """2D data must not offer a frame axis, keeping the bar hidden."""
+    viewer = make_viewer_model()
+    layer = create_flat_layer()
+    viewer.add_layer(layer)
+
+    context = FrameContext(viewer, lambda: [layer])
+
+    assert context.available_axes() == []
+    assert context.refresh_bounds() is False
+    assert context.frame_mask(layer.data.shape) is None
+    assert context.state_key() == (POOLED,)
+
+
+def test_frame_context_masks_and_slices_the_current_frame(make_viewer_model):
+    """The frame mask and slice must select exactly one frame."""
+    viewer = make_viewer_model()
+    layer = create_stack_layer()
+    viewer.add_layer(layer)
+
+    context = FrameContext(viewer, lambda: [layer])
+    context.mode = CURRENT
+    context.index = 2
+
+    assert context.available_axes() == [0]
+    assert context.n_frames == N_FRAMES
+    assert context.state_key() == (CURRENT, 0, 2)
+
+    flat_mask = context.flat_frame_mask(STACK_SHAPE)
+    assert flat_mask.sum() == 5 * 6
+    assert np.array_equal(
+        flat_mask.reshape(STACK_SHAPE)[2], np.ones((5, 6), dtype=bool)
+    )
+
+    data = np.arange(np.prod(STACK_SHAPE)).reshape(STACK_SHAPE)
+    assert np.array_equal(context.slice_array(data), data[2])
+
+    valid = np.ones(STACK_SHAPE, dtype=bool)
+    assert context.filter_valid(valid, STACK_SHAPE).sum() == 5 * 6
+    assert context.filter_valid(valid.ravel(), STACK_SHAPE).sum() == 5 * 6
+
+
+def test_frame_context_pooled_mode_is_a_no_op(make_viewer_model):
+    """Pooled mode must leave every array untouched."""
+    viewer = make_viewer_model()
+    layer = create_stack_layer()
+    viewer.add_layer(layer)
+
+    context = FrameContext(viewer, lambda: [layer])
+    data = np.arange(np.prod(STACK_SHAPE)).reshape(STACK_SHAPE)
+
+    assert context.frame_mask(STACK_SHAPE) is None
+    assert context.flat_frame_mask(STACK_SHAPE) is None
+    assert np.array_equal(context.slice_array(data), data)
+
+
+def test_frame_context_second_axis_of_a_4d_stack(make_viewer_model):
+    """A 4D stack exposes two axes and can be stepped along either."""
+    viewer = make_viewer_model()
+    layer = create_stack_layer(shape=(2, 3, 5, 6))
+    viewer.add_layer(layer)
+
+    context = FrameContext(viewer, lambda: [layer])
+    assert context.available_axes() == [0, 1]
+
+    context.mode = CURRENT
+    context.axis = 1
+    context.index = 2
+    assert context.n_frames == 3
+
+    mask = context.flat_frame_mask((2, 3, 5, 6)).reshape((2, 3, 5, 6))
+    assert mask[:, 2].all()
+    assert not mask[:, 0].any()
+
+
+# ---------------------------------------------------------------------------
+# napari dims synchronisation
+# ---------------------------------------------------------------------------
+
+
+def test_dims_slider_drives_the_frame(make_viewer_model):
+    """Moving napari's slider must move the plotter's frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 3)
+        assert plotter.frame_context.index == 3
+    finally:
+        plotter.close()
+
+
+def test_frame_change_drives_the_dims_slider(make_viewer_model):
+    """Setting the frame must move napari's slider."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 2
+        assert viewer.dims.current_step[0] == 2
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Phasor plot features
+# ---------------------------------------------------------------------------
+
+
+def test_merged_features_are_restricted_to_the_current_frame(
+    make_viewer_model,
+):
+    """Per-frame mode must plot only one frame's worth of samples."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        pooled_g, pooled_s = plotter.get_merged_features()
+
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 1
+        frame_g, frame_s = plotter.get_merged_features()
+
+        assert frame_g.size == pooled_g.size // N_FRAMES
+        assert frame_s.size == pooled_s.size // N_FRAMES
+
+        layer = plotter.get_selected_layers()[0]
+        harmonic_g = layer.metadata["G"][0]
+        expected = harmonic_g[1].ravel()
+        expected = expected[~np.isnan(expected)]
+        assert np.allclose(np.sort(frame_g), np.sort(expected))
+
+        plotter.frame_context.mode = POOLED
+        assert plotter.get_merged_features()[0].size == pooled_g.size
+    finally:
+        plotter.close()
+
+
+def test_features_cache_is_keyed_on_the_frame(make_viewer_model):
+    """Switching frames must not serve a stale cached feature set."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 0
+        first = plotter.get_merged_features()[0].copy()
+
+        plotter.frame_context.index = 3
+        second = plotter.get_merged_features()[0]
+
+        assert not np.array_equal(first, second)
+        assert plotter._features_cache_key[-1] == (CURRENT, 0, 3)
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_samples_follow_the_frame(make_viewer_model):
+    """Phasor-center statistics must summarise only the visible frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        layer = plotter.get_selected_layers()[0]
+        pooled = plotter._get_layer_phasor_samples(layer)
+        assert pooled[0].size == np.prod(STACK_SHAPE)
+
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 2
+        per_frame = plotter._get_layer_phasor_samples(layer)
+
+        assert per_frame[0].size == np.prod(STACK_SHAPE) // N_FRAMES
+        assert np.allclose(per_frame[0], layer.data[2].ravel())
+        assert plotter._compute_single_center(layer) is not None
+    finally:
+        plotter.close()
+
+
+def test_per_layer_feature_map_follows_the_frame(make_viewer_model):
+    """Contour data (one entry per layer) must follow the frame too."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        pooled = plotter._get_selected_layer_feature_map()
+        pooled_size = next(iter(pooled.values()))[0].size
+
+        plotter.frame_context.mode = CURRENT
+        per_frame = plotter._get_selected_layer_feature_map()
+        assert next(iter(per_frame.values()))[0].size == (
+            pooled_size // N_FRAMES
+        )
+    finally:
+        plotter.close()
+
+
+def _histogram_norm(plotter):
+    """Return the ``(vmin, vmax)`` the 2D histogram is coloured with."""
+    artist = plotter.canvas_widget.artists['HISTOGRAM2D']
+    norm = artist._get_normalization(artist.histogram[0], is_overlay=False)
+    return float(norm.vmin), float(norm.vmax)
+
+
+def _histogram_grid(plotter):
+    """Return a hashable description of the 2D histogram's bin grid."""
+    artist = plotter.canvas_widget.artists['HISTOGRAM2D']
+    _counts, x_edges, y_edges = artist.histogram
+    return (
+        len(x_edges),
+        len(y_edges),
+        float(x_edges[0]),
+        float(x_edges[-1]),
+        float(y_edges[0]),
+        float(y_edges[-1]),
+    )
+
+
+def test_histogram_colour_scale_is_fixed_across_frames(make_viewer_model):
+    """The 2D histogram must not rescale its colours frame by frame.
+
+    Both the colour normalisation and the bin grid come from the whole
+    acquisition, so a colour means the same pixel count at every timepoint
+    and the colorbar stops jumping around while stepping.
+    """
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+
+        norms = set()
+        grids = set()
+        for frame in range(N_FRAMES):
+            viewer.dims.set_current_step(0, frame)
+            norms.add(_histogram_norm(plotter))
+            grids.add(_histogram_grid(plotter))
+
+        assert len(norms) == 1, f"colour scale changed between frames: {norms}"
+        assert len(grids) == 1, f"bin grid changed between frames: {grids}"
+
+        # The scale must span the busiest frame, not one frame's own max.
+        reference = plotter._frame_histogram_reference()
+        assert norms.pop() == (reference["vmin"], reference["vmax"])
+    finally:
+        plotter.close()
+
+
+def test_histogram_grid_matches_pooled_mode(make_viewer_model):
+    """Per-frame bins reuse the grid the pooled plot would have drawn."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        pooled_grid = _histogram_grid(plotter)
+
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 1)
+
+        assert _histogram_grid(plotter) == pooled_grid
+    finally:
+        plotter.close()
+
+
+def test_histogram_colour_scale_fixed_with_log_scale(make_viewer_model):
+    """Log colouring must be pinned across frames as well."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.plotter_inputs_widget.log_scale_checkbox.setChecked(True)
+        plotter.frame_context.mode = CURRENT
+
+        norms = set()
+        for frame in range(N_FRAMES):
+            viewer.dims.set_current_step(0, frame)
+            norms.add(_histogram_norm(plotter))
+
+        assert len(norms) == 1
+        vmin, _vmax = norms.pop()
+        # LogNorm cannot start at a non-positive value.
+        assert vmin > 0
+    finally:
+        plotter.close()
+
+
+def test_histogram_colour_scale_spans_every_selected_layer(make_viewer_model):
+    """With several stacks selected the range covers all of them."""
+    viewer = make_viewer_model()
+    first = create_stack_layer(name="First")
+    second = create_stack_layer(name="Second")
+    viewer.add_layer(first)
+    viewer.add_layer(second)
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [first.name, second.name]
+    )
+    plotter._process_layer_selection_change()
+    try:
+        plotter.frame_context.mode = CURRENT
+
+        norms = set()
+        grids = set()
+        for frame in range(N_FRAMES):
+            viewer.dims.set_current_step(0, frame)
+            norms.add(_histogram_norm(plotter))
+            grids.add(_histogram_grid(plotter))
+            # Both layers contribute to every frame.
+            assert plotter.get_merged_features()[0].size == 2 * 5 * 6
+
+        assert len(norms) == 1
+        assert len(grids) == 1
+    finally:
+        plotter.close()
+
+
+def test_pooled_mode_keeps_biaplotter_colour_scale(make_viewer_model):
+    """Pooled plots are untouched: no fixed range is imposed on them."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        artist = plotter.canvas_widget.artists['HISTOGRAM2D']
+        assert (
+            getattr(artist, '_napari_phasors_fixed_counts_range', None) is None
+        )
+        assert plotter._frame_histogram_reference() is None
+
+        plotter.frame_context.mode = CURRENT
+        assert artist._napari_phasors_fixed_counts_range is not None
+
+        plotter.frame_context.mode = POOLED
+        assert artist._napari_phasors_fixed_counts_range is None
+    finally:
+        plotter.close()
+
+
+def test_frame_histogram_reference_is_cached(make_viewer_model):
+    """Stepping frames must not recompute the whole-stack range each time."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        reference = plotter._frame_histogram_reference()
+
+        viewer.dims.set_current_step(0, 2)
+        assert plotter._frame_histogram_reference() is reference
+
+        # Changing the bin count invalidates it through the cache key.
+        plotter.histogram_bins = plotter.histogram_bins + 10
+        assert plotter._frame_histogram_reference() is not reference
+    finally:
+        plotter.close()
+
+
+def test_plot_runs_in_per_frame_mode(make_viewer_model):
+    """Every plot type must render without error from a single frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        for plot_type in ("HISTOGRAM2D", "SCATTER", "CONTOUR"):
+            plotter.switch_plot_type(plot_type)
+            plotter.frame_context.index = 1
+            plotter.plot()
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Control bar
+# ---------------------------------------------------------------------------
+
+
+def test_empty_frame_blanks_the_plot(make_viewer_model):
+    """A fully masked frame must not keep showing the previous frame."""
+    viewer = make_viewer_model()
+    layer = create_stack_layer()
+    # Mask out the whole second frame, as a threshold would.
+    layer.metadata["G"][:, 1] = np.nan
+    layer.metadata["S"][:, 1] = np.nan
+    plotter = make_plotter_with_layer(viewer, layer)
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 0
+        plotter.plot()
+        assert plotter.canvas_widget.artists['HISTOGRAM2D'].visible is True
+
+        plotter.frame_context.index = 1
+        assert plotter.get_merged_features() is None
+        assert plotter.canvas_widget.artists['HISTOGRAM2D'].visible is False
+
+        plotter.frame_context.index = 2
+        assert plotter.canvas_widget.artists['HISTOGRAM2D'].visible is True
+    finally:
+        plotter.close()
+
+
+def test_control_bar_is_hidden_for_2d_data(make_viewer_model):
+    """Plain 2D workflows must not see the time-lapse controls at all."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_flat_layer())
+    try:
+        # ``isHidden`` (not ``isVisible``) is the right check here: the
+        # widget tree is never shown in tests, so ``isVisible`` is False
+        # for every widget regardless of our own setVisible calls.
+        assert plotter.timelapse_bar.isHidden() is True
+        assert plotter.frame_context.available_axes() == []
+    finally:
+        plotter.close()
+
+
+def test_control_bar_configures_itself_for_a_stack(make_viewer_model):
+    """The bar offers the mode and export, and hides the axis picker for 3D."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        bar = plotter.timelapse_bar
+        # A single stack axis needs no picker.
+        assert bar.axis_combobox.isVisibleTo(bar) is False
+
+        # Animations can only be exported frame by frame.
+        assert bar.export_button.isEnabled() is False
+        bar.mode_combobox.setCurrentIndex(bar.mode_combobox.findData(CURRENT))
+        assert plotter.frame_context.is_per_frame
+        assert bar.export_button.isEnabled() is True
+    finally:
+        plotter.close()
+
+
+def test_control_bar_has_no_playback_controls(make_viewer_model):
+    """Stepping and playback belong to napari's own dimension slider.
+
+    Duplicating them here would give two sets of controls for one piece of
+    state, so the bar deliberately exposes none.
+    """
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        bar = plotter.timelapse_bar
+        for removed in (
+            "play_button",
+            "frame_slider",
+            "frame_label",
+            "fps_spinbox",
+        ):
+            assert not hasattr(bar, removed), f"{removed} is back"
+
+        # The napari slider remains the way to change frames.
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 2)
+        assert plotter.frame_context.index == 2
+    finally:
+        plotter.close()
+
+
+def test_control_bar_axis_picker_shown_for_4d(make_viewer_model):
+    """More than one stack axis means the user gets to choose."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(
+        viewer, create_stack_layer(shape=(2, 3, 5, 6))
+    )
+    try:
+        bar = plotter.timelapse_bar
+        assert bar.axis_combobox.isVisibleTo(bar) is True
+        assert bar.axis_combobox.count() == 2
+    finally:
+        plotter.close()
+
+
+def test_napari_playback_drives_every_frame(make_viewer_model):
+    """Stepping the viewer through the stack keeps the plot in step.
+
+    This is what napari's own play button does, one step at a time.
+    """
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        for frame in range(N_FRAMES):
+            viewer.dims.set_current_step(0, frame)
+            assert plotter.frame_context.index == frame
+            assert plotter.get_merged_features()[0].size == 5 * 6
+    finally:
+        plotter.close()
+
+
+def test_control_bar_survives_a_context_without_layers(make_viewer_model):
+    """A bar built on an empty selection must simply hide itself."""
+    viewer = make_viewer_model()
+    context = FrameContext(viewer, list)
+    bar = TimelapseControlBar(context)
+    try:
+        assert bar.isHidden() is True
+        assert context.refresh_bounds() is False
+    finally:
+        bar.close()
+
+
+# ---------------------------------------------------------------------------
+# Settings persistence
+# ---------------------------------------------------------------------------
+
+
+def test_frame_settings_round_trip_through_layer_metadata(make_viewer_model):
+    """Mode and axis persist on the layer like every other plot setting."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(
+        viewer, create_stack_layer(shape=(2, 3, 5, 6))
+    )
+    try:
+        layer = plotter.get_selected_layers()[0]
+        plotter.frame_context.axis = 1
+        plotter.frame_context.mode = CURRENT
+
+        settings = layer.metadata["settings"]
+        assert settings["timelapse_mode"] == CURRENT
+        assert settings["timelapse_axis"] == 1
+
+        # Reset the in-memory state without writing it back to the layer, so
+        # the restore below has something different to restore.
+        plotter._updating_settings = True
+        try:
+            plotter.frame_context.mode = POOLED
+            plotter.frame_context.axis = 0
+        finally:
+            plotter._updating_settings = False
+
+        plotter._restore_plot_settings_from_metadata()
+
+        assert plotter.frame_context.mode == CURRENT
+        assert plotter.frame_context.axis == 1
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Statistics and animation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_frame_statistics_rows_covers_every_frame(make_viewer_model):
+    """One row per frame and dataset, in frame order."""
+    viewer = make_viewer_model()
+    layer = create_stack_layer()
+    viewer.add_layer(layer)
+    context = FrameContext(viewer, lambda: [layer])
+
+    data = np.arange(np.prod(STACK_SHAPE), dtype=float).reshape(STACK_SHAPE)
+    rows = build_frame_statistics_rows({"A": data, "B": data * 2}, context)
+
+    assert len(rows) == 2 * N_FRAMES
+    assert [row["Frame"] for row in rows] == sorted(
+        row["Frame"] for row in rows
+    )
+    first = next(
+        row for row in rows if row["Frame"] == 0 and row["Name"] == "A"
+    )
+    assert first["Mean"] == pytest.approx(np.mean(data[0]))
+
+
+def test_build_frame_statistics_rows_handles_2d_data(make_viewer_model):
+    """2D datasets collapse to a single frame-0 row."""
+    viewer = make_viewer_model()
+    layer = create_flat_layer()
+    viewer.add_layer(layer)
+    context = FrameContext(viewer, lambda: [layer])
+
+    rows = build_frame_statistics_rows({"A": np.ones((5, 6))}, context)
+    assert len(rows) == 1
+    assert rows[0]["Frame"] == 0
+    assert rows[0]["Mean"] == pytest.approx(1.0)
+
+
+def test_phasor_center_rows_pooled_and_per_frame(make_viewer_model):
+    """Phasor-center export offers one pooled row or one row per frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        pooled_rows = plotter._phasor_center_statistics_rows(per_frame=False)
+        assert len(pooled_rows) == 1
+        assert pooled_rows[0]["Frame"] == 0
+
+        frame_rows = plotter._phasor_center_statistics_rows(per_frame=True)
+        assert len(frame_rows) == N_FRAMES
+        assert [row["Frame"] for row in frame_rows] == list(range(N_FRAMES))
+        assert set(frame_rows[0]) == {
+            "Frame",
+            "Name",
+            "G (center)",
+            "S (center)",
+            "Phase (deg)",
+            "Modulation",
+        }
+    finally:
+        plotter.close()
+
+
+def test_phasor_center_export_writes_csv(make_viewer_model, tmp_path, qtbot):
+    """The phasor-center CSV has a header plus one row per frame."""
+    from napari_phasors._utils import write_rows_to_csv
+
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        rows = plotter._phasor_center_statistics_rows(per_frame=True)
+        target = tmp_path / "centers.csv"
+        write_rows_to_csv(str(target), rows)
+
+        lines = target.read_text().strip().splitlines()
+        assert len(lines) == N_FRAMES + 1
+        assert lines[0].startswith("Frame,Name,G (center)")
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Histogram / statistics dock
+# ---------------------------------------------------------------------------
+
+
+def test_histogram_follows_the_frame(make_viewer_model):
+    """The 1-D histogram and its statistics summarise one frame at a time."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        mapping_tab = plotter.phasor_mapping_tab
+        mapping_tab.frequency_input.setText("80")
+        mapping_tab.calculate_output_data()
+        mapping_tab.plot_lifetime_histogram()
+
+        histogram = mapping_tab.histogram_widget
+        pooled_size = len(histogram._raw_valid_data)
+        assert histogram.has_frame_source() is True
+
+        # Drive it the way the user does — through the viewer slider — so a
+        # broken signal chain fails here rather than being masked by an
+        # explicit refresh call.
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 1)
+
+        assert plotter.frame_context.index == 1
+        assert len(histogram._raw_valid_data) == pooled_size // N_FRAMES
+        assert _histogram_mean(histogram) == pytest.approx(
+            _expected_frame_mean(histogram, 1)
+        )
+
+        viewer.dims.set_current_step(0, 3)
+        assert _histogram_mean(histogram) == pytest.approx(
+            _expected_frame_mean(histogram, 3)
+        )
+    finally:
+        plotter.close()
+
+
+def test_components_histogram_follows_the_frame(make_viewer_model):
+    """Component fractions must be summarised one frame at a time.
+
+    Regression test: the component datasets used to be flattened before the
+    frame slice could be applied, so the histogram (and therefore the
+    statistics table and the per-timepoint export) stayed pooled.
+    """
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        components_tab = plotter.components_tab
+        _run_linear_projection(components_tab)
+
+        histogram = components_tab.histogram_widget
+        pooled_size = len(histogram._raw_valid_data)
+        assert histogram.has_frame_source() is True
+        _assert_frame_source_keeps_layer_shape(histogram)
+
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 1)
+
+        assert len(histogram._raw_valid_data) == pooled_size // N_FRAMES
+        assert _histogram_mean(histogram) == pytest.approx(
+            _expected_frame_mean(histogram, 1)
+        )
+
+        viewer.dims.set_current_step(0, 3)
+        assert _histogram_mean(histogram) == pytest.approx(
+            _expected_frame_mean(histogram, 3)
+        )
+    finally:
+        plotter.close()
+
+
+def test_fret_histogram_follows_the_frame(make_viewer_model):
+    """FRET efficiency must be summarised one frame at a time."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        fret_tab = plotter.fret_tab
+        fret_tab.frequency_input.setText("80")
+        fret_tab.donor_line_edit.setText("4.0")
+        assert fret_tab._fret_validation() is None
+        fret_tab.calculate_fret_efficiency()
+
+        histogram = fret_tab.histogram_widget
+        pooled_size = len(histogram._raw_valid_data)
+        assert histogram.has_frame_source() is True
+        _assert_frame_source_keeps_layer_shape(histogram)
+
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 2)
+
+        assert len(histogram._raw_valid_data) == pooled_size // N_FRAMES
+        assert _histogram_mean(histogram) == pytest.approx(
+            _expected_frame_mean(histogram, 2)
+        )
+    finally:
+        plotter.close()
+
+
+def test_components_export_per_timepoint(make_viewer_model, tmp_path):
+    """Per-timepoint export of component fractions has one row per frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        components_tab = plotter.components_tab
+        _run_linear_projection(components_tab)
+
+        stats_dock = plotter._statistics_stack.widget(
+            plotter._components_stats_page_idx
+        )
+        target = tmp_path / "components_per_frame.csv"
+        stats_dock._write_frame_statistics_to_csv(str(target), "per_frame")
+
+        lines = target.read_text().strip().splitlines()
+        assert len(lines) == N_FRAMES + 1
+        assert [line.split(",")[0] for line in lines[1:]] == [
+            str(frame) for frame in range(N_FRAMES)
+        ]
+    finally:
+        plotter.close()
+
+
+def _run_mapping_analysis(plotter, frequency="80"):
+    """Run the phasor mapping analysis the way the Calculate button does."""
+    mapping_tab = plotter.phasor_mapping_tab
+    mapping_tab.frequency_input.setText(frequency)
+    mapping_tab._on_calculate_lifetime_clicked()
+    return mapping_tab
+
+
+def _mapping_stats_dock(plotter):
+    """Return the statistics dock page linked to the phasor mapping tab."""
+    return plotter._statistics_stack.widget(plotter._phasor_map_stats_page_idx)
+
+
+def _table_column_names(table):
+    """Return the table's current header labels."""
+    return [
+        table.horizontalHeaderItem(index).text()
+        for index in range(table.columnCount())
+    ]
+
+
+def _table_rows(table):
+    """Return the table contents as a list of row-value lists."""
+    return [
+        [
+            table.item(row, col).text() if table.item(row, col) else ""
+            for col in range(table.columnCount())
+        ]
+        for row in range(table.rowCount())
+    ]
+
+
+def _highlighted_frames(table):
+    """Return the Frame values of the rows rendered as 'current'."""
+    frames = []
+    for row in range(table.rowCount()):
+        item = table.item(row, 0)
+        if item is not None and item.font().bold():
+            frames.append(item.text())
+    return frames
+
+
+def test_statistics_table_lists_every_frame(make_viewer_model):
+    """In per-frame mode the table shows one row per timepoint."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        _run_mapping_analysis(plotter)
+        table = _mapping_stats_dock(plotter).layer_stats_table
+
+        # Pooled mode keeps the historic one-row-per-layer layout.
+        assert table.rowCount() == 1
+        assert _table_column_names(table)[0] == "Name"
+
+        plotter.frame_context.mode = CURRENT
+
+        assert table.rowCount() == N_FRAMES
+        assert _table_column_names(table) == [
+            "Frame",
+            "Name",
+            "Center of Mass",
+            "Mean",
+            "Median",
+            "Std Dev",
+        ]
+        assert [row[0] for row in _table_rows(table)] == [
+            str(frame) for frame in range(N_FRAMES)
+        ]
+
+        # Each row must report that frame's own mean, not a pooled one.
+        histogram = plotter.phasor_mapping_tab.histogram_widget
+        for row in _table_rows(table):
+            frame = int(row[0])
+            assert float(row[3]) == pytest.approx(
+                _expected_frame_mean(histogram, frame), abs=5e-5
+            )
+    finally:
+        plotter.close()
+
+
+def test_statistics_table_highlights_the_current_frame(make_viewer_model):
+    """Exactly the displayed frame's row is highlighted, and it follows."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        _run_mapping_analysis(plotter)
+        table = _mapping_stats_dock(plotter).layer_stats_table
+
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 2)
+        assert _highlighted_frames(table) == ["2"]
+
+        viewer.dims.set_current_step(0, 0)
+        assert _highlighted_frames(table) == ["0"]
+    finally:
+        plotter.close()
+
+
+def test_statistics_table_restores_pooled_layout(make_viewer_model):
+    """Leaving per-frame mode brings back the per-layer table."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        _run_mapping_analysis(plotter)
+        table = _mapping_stats_dock(plotter).layer_stats_table
+
+        plotter.frame_context.mode = CURRENT
+        assert table.rowCount() == N_FRAMES
+
+        plotter.frame_context.mode = POOLED
+        assert table.rowCount() == 1
+        assert _table_column_names(table)[0] == "Name"
+        assert _highlighted_frames(table) == []
+    finally:
+        plotter.close()
+
+
+def test_statistics_table_frame_rows_for_multiple_layers(make_viewer_model):
+    """With several layers the table has one row per frame per layer."""
+    viewer = make_viewer_model()
+    first = create_stack_layer(name="First")
+    second = create_stack_layer(name="Second")
+    viewer.add_layer(first)
+    viewer.add_layer(second)
+
+    plotter = PlotterWidget(viewer)
+    plotter.image_layers_checkable_combobox.setCheckedItems(
+        [first.name, second.name]
+    )
+    plotter._process_layer_selection_change()
+    try:
+        _run_mapping_analysis(plotter)
+        table = _mapping_stats_dock(plotter).layer_stats_table
+
+        plotter.frame_context.mode = CURRENT
+        viewer.dims.set_current_step(0, 1)
+
+        assert table.rowCount() == 2 * N_FRAMES
+        # Rows are grouped by frame, so a frame's layers sit side by side.
+        assert [row[0] for row in _table_rows(table)] == [
+            str(frame) for frame in range(N_FRAMES) for _ in range(2)
+        ]
+        assert _highlighted_frames(table) == ["1", "1"]
+    finally:
+        plotter.close()
+
+
+def test_statistics_dock_exports_per_timepoint(make_viewer_model, tmp_path):
+    """Per-timepoint export writes one row per frame per dataset."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        mapping_tab = plotter.phasor_mapping_tab
+        mapping_tab.frequency_input.setText("80")
+        mapping_tab.calculate_output_data()
+        mapping_tab.plot_lifetime_histogram()
+
+        stats_dock = plotter._statistics_stack.widget(
+            plotter._phasor_map_stats_page_idx
+        )
+
+        per_frame_path = tmp_path / "per_frame.csv"
+        stats_dock._write_frame_statistics_to_csv(
+            str(per_frame_path), "per_frame"
+        )
+        lines = per_frame_path.read_text().strip().splitlines()
+        assert lines[0].startswith("Frame,Name,Center of Mass")
+        assert len(lines) == N_FRAMES + 1
+
+        pooled_path = tmp_path / "pooled.csv"
+        stats_dock._write_frame_statistics_to_csv(str(pooled_path), "pooled")
+        pooled_lines = pooled_path.read_text().strip().splitlines()
+        assert len(pooled_lines) == 2
+        assert pooled_lines[1].startswith("all,")
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Selections
+# ---------------------------------------------------------------------------
+
+
+def test_selection_data_stays_aligned_with_the_plot(make_viewer_model):
+    """The per-point selection array must match the plotted sample count."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        selection_tab = plotter.selection_tab
+        selection_tab.selection_mode_combobox.setCurrentText(
+            "Manual Selection"
+        )
+
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 2
+
+        layer = plotter.get_selected_layers()[0]
+        g = layer.metadata["G"][0]
+        s = layer.metadata["S"][0]
+
+        n_plotted = plotter.get_merged_features()[0].size
+        assert selection_tab._frame_valid_mask(g, s).sum() == n_plotted
+    finally:
+        plotter.close()
+
+
+def test_manual_selection_applies_to_every_frame(make_viewer_model):
+    """A region drawn on one frame labels matching pixels in all frames."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        selection_tab = plotter.selection_tab
+        selection_tab.selection_mode_combobox.setCurrentText(
+            "Manual Selection"
+        )
+
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 0
+
+        # Draw a rectangle covering the whole phasor space so every pixel
+        # falls inside it, using biaplotter's own rectangle selector.
+        canvas = plotter.canvas_widget
+        canvas.active_selector = "RECTANGLE"
+        selector = canvas.active_selector
+
+        class _MouseEvent:
+            def __init__(self, x, y):
+                self.xdata = x
+                self.ydata = y
+
+        frame_g, frame_s = plotter.get_merged_features()
+        selector.data = np.column_stack((frame_g, frame_s))
+        selector.on_select(_MouseEvent(-2.0, -2.0), _MouseEvent(2.0, 2.0))
+
+        # biaplotter hands back one class value per *plotted* point.
+        selection_tab.manual_selection_changed(
+            np.ones(frame_g.size, dtype=np.uint32)
+        )
+
+        layer = plotter.get_selected_layers()[0]
+        selection_map = layer.metadata["settings"]["selections"][
+            "manual_selections"
+        ][selection_tab.selection_id]
+
+        assert selection_map.shape == STACK_SHAPE
+        for frame in range(N_FRAMES):
+            assert selection_map[frame].any(), f"frame {frame} not labelled"
+    finally:
+        plotter.close()
+
+
+# ---------------------------------------------------------------------------
+# Animation export
+# ---------------------------------------------------------------------------
+
+
+def test_animation_export_writes_a_gif(make_viewer_model, tmp_path):
+    """Rendering and writing a GIF produces one image per requested frame."""
+    iio = pytest.importorskip("imageio.v3")
+
+    from napari_phasors._timelapse import export_animation
+
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        options = {
+            "include_phasor": True,
+            "include_histogram": False,
+            "frames": list(range(N_FRAMES)),
+            "fps": 5,
+        }
+        frames = plotter._render_animation_frames(options, histogram=None)
+        assert len(frames) == N_FRAMES
+        assert frames[0].ndim == 3 and frames[0].shape[2] == 3
+
+        target = tmp_path / "animation.gif"
+        assert export_animation(str(target), frames, options["fps"]) is True
+        assert target.exists()
+        assert len(iio.imread(str(target))) == N_FRAMES
+    finally:
+        plotter.close()
+
+
+def test_animation_export_restores_the_starting_frame(make_viewer_model):
+    """Exporting must leave the viewer on the frame it started from."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        plotter.frame_context.mode = CURRENT
+        plotter.frame_context.index = 2
+        plotter._render_animation_frames(
+            {
+                "include_phasor": True,
+                "include_histogram": False,
+                "frames": [0, 1, 2, 3],
+                "fps": 5,
+            },
+            histogram=None,
+        )
+        assert plotter.frame_context.index == 2
+    finally:
+        plotter.close()
+
+
+def test_animation_can_include_the_histogram(make_viewer_model):
+    """Rendering both figures stacks them side by side in each frame."""
+    viewer = make_viewer_model()
+    plotter = make_plotter_with_layer(viewer, create_stack_layer())
+    try:
+        mapping_tab = plotter.phasor_mapping_tab
+        plotter.tab_widget.setCurrentWidget(mapping_tab)
+        mapping_tab.frequency_input.setText("80")
+        mapping_tab.calculate_output_data()
+        mapping_tab.plot_lifetime_histogram()
+
+        histogram = plotter._active_histogram_widget()
+        assert histogram is mapping_tab.histogram_widget
+
+        plotter.frame_context.mode = CURRENT
+        options = {
+            "include_phasor": True,
+            "include_histogram": True,
+            "frames": [0, 1],
+            "fps": 5,
+        }
+        both = plotter._render_animation_frames(options, histogram)
+        options["include_histogram"] = False
+        phasor_only = plotter._render_animation_frames(options, histogram)
+
+        assert len(both) == 2
+        assert both[0].shape[1] > phasor_only[0].shape[1]
+    finally:
+        plotter.close()
+
+
+def test_animation_export_dialog_options(make_viewer_model, qtbot):
+    """The dialog reports a normalised, inclusive frame range."""
+    dialog = AnimationExportDialog(
+        n_frames=N_FRAMES, histogram_available=False, fps=8
+    )
+    qtbot.addWidget(dialog)
+    try:
+        # Histogram cannot be selected when no histogram is displayed.
+        assert dialog.histogram_checkbox.isEnabled() is False
+
+        options = dialog.get_options()
+        assert options["include_phasor"] is True
+        assert options["frames"] == list(range(N_FRAMES))
+        assert options["fps"] == pytest.approx(8.0)
+
+        # A reversed range is normalised rather than producing no frames.
+        dialog.first_spinbox.setValue(3)
+        dialog.last_spinbox.setValue(2)
+        assert dialog.get_options()["frames"] == [1, 2]
+    finally:
+        dialog.close()
+
+
+def test_export_animation_reports_no_frames(tmp_path):
+    """Exporting nothing fails cleanly rather than raising."""
+    from napari_phasors._timelapse import export_animation
+
+    assert export_animation(str(tmp_path / "empty.gif"), [], 5) is False
+
+
+def test_combine_frames_pads_to_a_common_height():
+    """Side-by-side figures are padded, never scaled."""
+    left = np.zeros((10, 4, 3), dtype=np.uint8)
+    right = np.zeros((6, 5, 3), dtype=np.uint8)
+
+    assert combine_frames([]) is None
+    assert combine_frames([left]).shape == (10, 4, 3)
+    assert combine_frames([left, right]).shape == (10, 9, 3)

--- a/src/napari_phasors/_timelapse.py
+++ b/src/napari_phasors/_timelapse.py
@@ -1,0 +1,869 @@
+"""Time-lapse (stack) support for the phasor plot and its histogram.
+
+Phasor data is stored per layer as ``G``/``S`` arrays shaped
+``(harmonic, *layer.data.shape)``.  For a time-lapse acquisition
+``layer.data`` has one or more leading non-spatial axes (e.g. ``(T, Y, X)``),
+and every plot consumer in the plugin historically flattened *all* of them,
+pooling every timepoint into a single phasor cloud.
+
+This module adds the notion of a *current frame*:
+
+* :class:`FrameContext` is the single source of truth for which frame is
+  displayed.  It stays in sync with the napari dims sliders in both
+  directions, so dragging (or playing) the viewer slider moves the phasor
+  plot and vice versa.
+* :class:`TimelapseControlBar` is the compact row of controls shown beneath
+  the phasor plot.  It is hidden entirely when the selected layers have no
+  non-spatial axis, so 2-D workflows are unaffected.
+* :class:`AnimationExportDialog` and :func:`export_animation` render the
+  phasor plot and/or the 1-D histogram frame by frame into an animated GIF.
+* :func:`build_frame_statistics_rows` produces the per-frame statistics rows
+  used by the CSV exporters.
+
+"""
+
+import contextlib
+
+import numpy as np
+from napari.utils import notifications
+from qtpy.QtCore import QObject, Signal
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSpinBox,
+    QWidget,
+)
+
+from ._utils import compute_dataset_statistics
+
+#: Every frame is pooled into a single phasor cloud (historic behaviour).
+POOLED = "pooled"
+#: Only the samples of the current frame are displayed and summarised.
+CURRENT = "current"
+
+#: Human-readable labels for the two modes, used by the mode combobox.
+MODE_LABELS = {
+    POOLED: "All timepoints",
+    CURRENT: "Current timepoint",
+}
+
+
+def stack_axes(layer):
+    """Return the non-spatial (stack) axes of *layer*.
+
+    The last two axes of an image layer are always spatial; anything before
+    them is a stack axis the user can step through (time, Z, channel, ...).
+
+    Parameters
+    ----------
+    layer : napari.layers.Image
+        Layer to inspect.
+
+    Returns
+    -------
+    list of int
+        Layer-axis indices, empty for plain 2-D data.
+    """
+    data = getattr(layer, "data", None)
+    if data is None:
+        return []
+    return list(range(max(0, data.ndim - 2)))
+
+
+class FrameContext(QObject):
+    """Track which frame of a time-lapse the phasor plot is showing.
+
+    The context owns the display *mode* (pooled or per-frame), the layer axis
+    treated as the frame axis, and the current frame index.  It mirrors the
+    napari dims slider so that the viewer and the phasor plot never disagree
+    about which timepoint is on screen.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        Viewer whose dims sliders drive (and are driven by) the frame index.
+    layers_provider : callable
+        Zero-argument callable returning the currently selected image layers.
+        Passed as a callable rather than a list so the context always sees
+        the live selection.
+    parent : QObject, optional
+        Qt parent.
+    """
+
+    #: Emitted with the new frame index whenever the current frame changes.
+    frameChanged = Signal(int)
+    #: Emitted with :data:`POOLED` or :data:`CURRENT` when the mode changes.
+    modeChanged = Signal(str)
+    #: Emitted with the new layer axis when the frame axis changes.
+    axisChanged = Signal(int)
+
+    def __init__(self, viewer, layers_provider, parent=None):
+        """Create a pooled-by-default context bound to *viewer*."""
+        super().__init__(parent)
+        self.viewer = viewer
+        self._layers_provider = layers_provider
+        self._mode = POOLED
+        self._axis = 0
+        self._index = 0
+        self._n_frames = 1
+        # Guards the two-way dims sync against feedback loops.
+        self._syncing = False
+
+        with contextlib.suppress(AttributeError, RuntimeError):
+            self.viewer.dims.events.current_step.connect(
+                self._on_dims_current_step
+            )
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+
+    @property
+    def mode(self):
+        """Current display mode, either :data:`POOLED` or :data:`CURRENT`."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        """Set the display mode, emitting :attr:`modeChanged` on a change."""
+        value = CURRENT if value == CURRENT else POOLED
+        if value == self._mode:
+            return
+        self._mode = value
+        if value == CURRENT:
+            self.sync_from_dims()
+        self.modeChanged.emit(value)
+
+    @property
+    def is_per_frame(self):
+        """True when only the current frame should be displayed."""
+        return self._mode == CURRENT
+
+    @property
+    def axis(self):
+        """Layer axis treated as the frame axis."""
+        return self._axis
+
+    @axis.setter
+    def axis(self, value):
+        """Set the frame axis, resyncing the index from the viewer."""
+        value = int(value)
+        if value == self._axis:
+            return
+        self._axis = value
+        self.refresh_bounds()
+        self.sync_from_dims()
+        self.axisChanged.emit(value)
+
+    @property
+    def index(self):
+        """Current frame index along :attr:`axis`."""
+        return self._index
+
+    @index.setter
+    def index(self, value):
+        """Set the current frame and push it to the napari dims slider."""
+        value = int(np.clip(int(value), 0, max(0, self._n_frames - 1)))
+        if value == self._index:
+            return
+        self._index = value
+        self.push_to_dims()
+        self.frameChanged.emit(value)
+
+    @property
+    def n_frames(self):
+        """Number of frames along :attr:`axis` for the current selection."""
+        return self._n_frames
+
+    # ------------------------------------------------------------------
+    # Layer / viewer introspection
+    # ------------------------------------------------------------------
+
+    def _layers(self):
+        """Return the selected layers that carry array data."""
+        try:
+            layers = list(self._layers_provider() or [])
+        except (AttributeError, RuntimeError, TypeError):
+            return []
+        return [
+            layer
+            for layer in layers
+            if getattr(layer, "data", None) is not None
+        ]
+
+    def reference_layer(self):
+        """Return the selected layer with the most dimensions, or None.
+
+        Using the deepest layer means the axis choices stay available even
+        when a plain 2-D layer is selected alongside a stack.
+        """
+        layers = self._layers()
+        if not layers:
+            return None
+        return max(layers, key=lambda layer: layer.data.ndim)
+
+    def available_axes(self):
+        """Return the frame axes offered for the current selection."""
+        layer = self.reference_layer()
+        if layer is None:
+            return []
+        return stack_axes(layer)
+
+    def axis_label(self, axis):
+        """Return a display name for *axis*, preferring napari's dims label.
+
+        Falls back to ``"Axis <n>"`` when the viewer has no meaningful label
+        for that axis (napari defaults to labels like ``"-3"``).
+        """
+        world_axis = self._world_axis(axis)
+        if world_axis is not None:
+            with contextlib.suppress(AttributeError, IndexError, TypeError):
+                label = str(self.viewer.dims.axis_labels[world_axis])
+                if label and not label.lstrip("-").isdigit():
+                    return label
+        return f"Axis {axis}"
+
+    def _world_axis(self, axis=None):
+        """Map a layer axis to the corresponding napari world axis.
+
+        napari right-aligns a layer's axes onto the world dims, so the offset
+        is ``viewer.dims.ndim - layer.data.ndim``.
+        """
+        axis = self._axis if axis is None else axis
+        layer = self.reference_layer()
+        if layer is None:
+            return None
+        try:
+            offset = self.viewer.dims.ndim - layer.data.ndim
+        except (AttributeError, RuntimeError):
+            return None
+        world_axis = offset + axis
+        if world_axis < 0 or world_axis >= self.viewer.dims.ndim:
+            return None
+        return world_axis
+
+    def refresh_bounds(self):
+        """Recompute :attr:`n_frames` and clamp the index into range.
+
+        Returns
+        -------
+        bool
+            True when the current selection has a usable frame axis.
+        """
+        axes = self.available_axes()
+        if not axes:
+            self._n_frames = 1
+            self._index = 0
+            return False
+
+        if self._axis not in axes:
+            self._axis = axes[0]
+
+        layer = self.reference_layer()
+        n_frames = int(layer.data.shape[self._axis])
+
+        world_axis = self._world_axis()
+        if world_axis is not None:
+            with contextlib.suppress(AttributeError, IndexError, TypeError):
+                n_frames = max(
+                    n_frames, int(self.viewer.dims.nsteps[world_axis])
+                )
+
+        self._n_frames = max(1, n_frames)
+        self._index = int(np.clip(self._index, 0, self._n_frames - 1))
+        return True
+
+    # ------------------------------------------------------------------
+    # napari dims synchronisation
+    # ------------------------------------------------------------------
+
+    def disconnect_viewer(self):
+        """Stop listening to the viewer's dims events (called on teardown)."""
+        with contextlib.suppress(
+            AttributeError, RuntimeError, TypeError, ValueError
+        ):
+            self.viewer.dims.events.current_step.disconnect(
+                self._on_dims_current_step
+            )
+
+    def _on_dims_current_step(self, event=None):
+        """Adopt the viewer's slider position as the current frame."""
+        if self._syncing:
+            return
+        self.sync_from_dims()
+
+    def sync_from_dims(self):
+        """Pull the current frame index from the napari dims slider."""
+        world_axis = self._world_axis()
+        if world_axis is None:
+            return
+        try:
+            step = int(self.viewer.dims.current_step[world_axis])
+        except (AttributeError, IndexError, TypeError):
+            return
+
+        self.refresh_bounds()
+        step = int(np.clip(step, 0, max(0, self._n_frames - 1)))
+        if step == self._index:
+            return
+        self._index = step
+        self.frameChanged.emit(step)
+
+    def push_to_dims(self):
+        """Move the napari dims slider to the current frame index."""
+        world_axis = self._world_axis()
+        if world_axis is None:
+            return
+        self._syncing = True
+        try:
+            self.viewer.dims.set_current_step(world_axis, self._index)
+        except (AttributeError, IndexError, RuntimeError, TypeError):
+            pass
+        finally:
+            self._syncing = False
+
+    # ------------------------------------------------------------------
+    # Sample filtering
+    # ------------------------------------------------------------------
+
+    def axis_for_shape(self, shape):
+        """Return the frame axis valid for *shape*, or None.
+
+        The axis must exist and must not be one of the two trailing spatial
+        axes of the array. Unlike :meth:`frame_mask` this ignores the display
+        mode and the current index, so callers can iterate every frame of an
+        array (e.g. to compute a range shared by all of them).
+        """
+        ndim = len(shape)
+        if ndim < 3:
+            return None
+        axis = self._axis
+        if axis < 0 or axis >= ndim - 2:
+            return None
+        if shape[axis] <= 1:
+            return None
+        return axis
+
+    def _usable_axis_for(self, shape):
+        """Return the frame axis to slice *shape* with, or None."""
+        if not self.is_per_frame:
+            return None
+        return self.axis_for_shape(shape)
+
+    def frame_mask(self, shape):
+        """Return a broadcastable mask selecting the current frame.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            Shape of the array to be filtered (spatial shape of a layer).
+
+        Returns
+        -------
+        np.ndarray or None
+            A boolean array broadcastable against *shape* that is True only
+            on the current frame, or None when no filtering applies (pooled
+            mode, 2-D data, or an axis that does not exist for this shape).
+        """
+        axis = self._usable_axis_for(shape)
+        if axis is None:
+            return None
+        index = int(np.clip(self._index, 0, shape[axis] - 1))
+        broadcast_shape = [1] * len(shape)
+        broadcast_shape[axis] = shape[axis]
+        return np.arange(shape[axis]).reshape(broadcast_shape) == index
+
+    def flat_frame_mask(self, shape):
+        """Return the current-frame mask flattened to match ``array.ravel()``.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            Shape of the array whose ravelled form should be filtered.
+
+        Returns
+        -------
+        np.ndarray or None
+            1-D boolean array of ``np.prod(shape)`` elements, or None when no
+            filtering applies.
+        """
+        mask = self.frame_mask(shape)
+        if mask is None:
+            return None
+        return np.broadcast_to(mask, shape).ravel()
+
+    def filter_valid(self, valid, shape=None):
+        """Restrict a validity mask to the current frame.
+
+        Parameters
+        ----------
+        valid : np.ndarray
+            Boolean mask, either shaped like the data or already ravelled.
+        shape : tuple of int, optional
+            Data shape, required when *valid* is already flat.
+
+        Returns
+        -------
+        np.ndarray
+            *valid* itself in pooled mode, otherwise a copy restricted to the
+            current frame.
+        """
+        shape = tuple(valid.shape) if shape is None else tuple(shape)
+        if valid.ndim == 1 and len(shape) > 1:
+            mask = self.flat_frame_mask(shape)
+        else:
+            mask = self.frame_mask(shape)
+        if mask is None:
+            return valid
+        return valid & mask
+
+    def slice_array(self, array):
+        """Return *array* reduced to the current frame.
+
+        Used for the per-layer scalar arrays that feed the 1-D histogram,
+        which are shaped exactly like ``layer.data``.
+
+        Parameters
+        ----------
+        array : np.ndarray
+            Array shaped like the layer data.
+
+        Returns
+        -------
+        np.ndarray
+            The current frame in per-frame mode, otherwise *array* unchanged.
+        """
+        array = np.asarray(array)
+        axis = self._usable_axis_for(array.shape)
+        if axis is None:
+            return array
+        index = int(np.clip(self._index, 0, array.shape[axis] - 1))
+        return np.take(array, index, axis=axis)
+
+    def state_key(self):
+        """Return a hashable snapshot of the frame state, for cache keys."""
+        if not self.is_per_frame:
+            return (POOLED,)
+        return (CURRENT, self._axis, self._index)
+
+
+def slice_datasets(frame_context, datasets):
+    """Restrict a ``{name: array}`` mapping to the current frame.
+
+    Convenience wrapper used by the analysis tabs, which all feed the 1-D
+    histogram one array per layer shaped like ``layer.data``.
+
+    Parameters
+    ----------
+    frame_context : FrameContext or None
+        Context to slice with. ``None`` (or pooled mode) returns *datasets*
+        unchanged, so callers need no branching of their own.
+    datasets : dict
+        ``{name: np.ndarray}`` mapping.
+
+    Returns
+    -------
+    dict
+        Either *datasets* itself or a new mapping of current-frame slices.
+    """
+    if frame_context is None or not frame_context.is_per_frame:
+        return datasets
+    return {
+        name: frame_context.slice_array(data)
+        for name, data in datasets.items()
+    }
+
+
+class TimelapseControlBar(QWidget):
+    """Compact controls for how a time-lapse is shown in the phasor plot.
+
+    Deliberately minimal: a mode selector, a frame-axis selector (only when
+    the data has more than one stack axis) and an export button. Stepping
+    through frames, playback and the frame readout are left to napari's own
+    dimension slider, which this bar's :class:`FrameContext` stays in sync
+    with — duplicating them here would just be a second set of controls for
+    the same state. The whole bar hides itself when the current layer
+    selection has no stack axis.
+
+    Parameters
+    ----------
+    frame_context : FrameContext
+        Context this bar drives.
+    parent : QWidget, optional
+        Qt parent.
+    """
+
+    #: Emitted when the user clicks the "Export…" button.
+    exportRequested = Signal()
+
+    def __init__(self, frame_context, parent=None):
+        """Build the control row bound to *frame_context*."""
+        super().__init__(parent)
+        self.frame_context = frame_context
+        self._updating = False
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(5)
+
+        self.mode_label = QLabel("Frames:")
+        layout.addWidget(self.mode_label)
+
+        self.mode_combobox = QComboBox()
+        self.mode_combobox.addItem(MODE_LABELS[POOLED], POOLED)
+        self.mode_combobox.addItem(MODE_LABELS[CURRENT], CURRENT)
+        self.mode_combobox.setToolTip(
+            "Show every timepoint pooled into one phasor plot, or only the "
+            "timepoint currently displayed in the viewer."
+        )
+        layout.addWidget(self.mode_combobox)
+
+        self.axis_label = QLabel("Axis:")
+        layout.addWidget(self.axis_label)
+        self.axis_combobox = QComboBox()
+        self.axis_combobox.setToolTip(
+            "Which dimension to step through when showing one timepoint."
+        )
+        layout.addWidget(self.axis_combobox)
+
+        self.export_button = QPushButton("Export Animation…")
+        self.export_button.setToolTip(
+            "Export the phasor plot and/or histogram as an animated GIF"
+        )
+        layout.addWidget(self.export_button)
+
+        layout.addStretch(1)
+
+        self.mode_combobox.currentIndexChanged.connect(self._on_mode_changed)
+        self.axis_combobox.currentIndexChanged.connect(self._on_axis_changed)
+        self.export_button.clicked.connect(self.exportRequested)
+
+        frame_context.modeChanged.connect(self._on_context_mode_changed)
+
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Refresh
+    # ------------------------------------------------------------------
+
+    def refresh(self):
+        """Rebuild the axis choices from the context.
+
+        Hides the whole bar when the selection has no stack axis, which keeps
+        the plain 2-D layout untouched.
+        """
+        ctx = self.frame_context
+        axes = ctx.available_axes()
+
+        if not axes:
+            self.setVisible(False)
+            return
+
+        self.setVisible(True)
+        ctx.refresh_bounds()
+
+        self._updating = True
+        try:
+            self.axis_combobox.clear()
+            for axis in axes:
+                self.axis_combobox.addItem(ctx.axis_label(axis), axis)
+            axis_index = axes.index(ctx.axis) if ctx.axis in axes else 0
+            self.axis_combobox.setCurrentIndex(axis_index)
+            # A single stack axis needs no picker.
+            show_axis_picker = len(axes) > 1
+            self.axis_label.setVisible(show_axis_picker)
+            self.axis_combobox.setVisible(show_axis_picker)
+
+            mode_index = self.mode_combobox.findData(ctx.mode)
+            if mode_index >= 0:
+                self.mode_combobox.setCurrentIndex(mode_index)
+        finally:
+            self._updating = False
+
+        self._update_enabled_state()
+
+    def _update_enabled_state(self):
+        """Animations can only be exported frame by frame."""
+        self.export_button.setEnabled(self.frame_context.is_per_frame)
+
+    # ------------------------------------------------------------------
+    # Signal handlers
+    # ------------------------------------------------------------------
+
+    def _on_mode_changed(self, _index):
+        """Push the selected mode into the context."""
+        if self._updating:
+            return
+        self.frame_context.mode = self.mode_combobox.currentData()
+
+    def _on_axis_changed(self, _index):
+        """Push the selected frame axis into the context."""
+        if self._updating:
+            return
+        axis = self.axis_combobox.currentData()
+        if axis is not None:
+            self.frame_context.axis = int(axis)
+            self.refresh()
+
+    def _on_context_mode_changed(self, _mode):
+        """Mirror an externally driven mode change onto the combobox."""
+        self.refresh()
+
+
+class AnimationExportDialog(QDialog):
+    """Ask what to render into the exported GIF.
+
+    Parameters
+    ----------
+    n_frames : int
+        Number of frames available in the current stack.
+    histogram_available : bool
+        Whether a 1-D histogram with data is currently shown.
+    fps : int, optional
+        Initial frame rate, by default 5.
+    parent : QWidget, optional
+        Qt parent.
+    """
+
+    def __init__(self, n_frames, histogram_available, fps=5, parent=None):
+        """Build the export options dialog."""
+        super().__init__(parent)
+        self.setWindowTitle("Export Time-lapse Animation")
+
+        layout = QFormLayout(self)
+
+        self.phasor_checkbox = QCheckBox("Phasor plot")
+        self.phasor_checkbox.setChecked(True)
+        layout.addRow(self.phasor_checkbox)
+
+        self.histogram_checkbox = QCheckBox("Histogram")
+        self.histogram_checkbox.setEnabled(histogram_available)
+        self.histogram_checkbox.setChecked(False)
+        if not histogram_available:
+            self.histogram_checkbox.setToolTip(
+                "No histogram with data is currently displayed."
+            )
+        layout.addRow(self.histogram_checkbox)
+
+        self.first_spinbox = QSpinBox()
+        self.first_spinbox.setRange(1, max(1, n_frames))
+        self.first_spinbox.setValue(1)
+        layout.addRow("First frame:", self.first_spinbox)
+
+        self.last_spinbox = QSpinBox()
+        self.last_spinbox.setRange(1, max(1, n_frames))
+        self.last_spinbox.setValue(max(1, n_frames))
+        layout.addRow("Last frame:", self.last_spinbox)
+
+        self.fps_spinbox = QDoubleSpinBox()
+        self.fps_spinbox.setRange(0.5, 60.0)
+        self.fps_spinbox.setSingleStep(0.5)
+        self.fps_spinbox.setValue(float(fps))
+        layout.addRow("Frame rate (fps):", self.fps_spinbox)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+    def get_options(self):
+        """Return the chosen options as a dictionary.
+
+        Returns
+        -------
+        dict
+            Keys ``include_phasor``, ``include_histogram``, ``frames``
+            (a list of 0-based frame indices) and ``fps``.
+        """
+        first = self.first_spinbox.value() - 1
+        last = self.last_spinbox.value() - 1
+        if last < first:
+            first, last = last, first
+        return {
+            "include_phasor": self.phasor_checkbox.isChecked(),
+            "include_histogram": self.histogram_checkbox.isChecked(),
+            "frames": list(range(first, last + 1)),
+            "fps": self.fps_spinbox.value(),
+        }
+
+
+def figure_to_rgb(figure):
+    """Render a Matplotlib figure to an ``(H, W, 3)`` uint8 array.
+
+    Parameters
+    ----------
+    figure : matplotlib.figure.Figure
+        Figure to render. Its canvas is drawn synchronously.
+
+    Returns
+    -------
+    np.ndarray or None
+        RGB image, or None when the figure has no usable canvas.
+    """
+    canvas = getattr(figure, "canvas", None)
+    if canvas is None:
+        return None
+    canvas.draw()
+    if hasattr(canvas, "buffer_rgba"):
+        buffer = np.asarray(canvas.buffer_rgba())
+    elif hasattr(canvas, "tostring_rgb"):  # pragma: no cover - old mpl
+        width, height = canvas.get_width_height()
+        buffer = np.frombuffer(canvas.tostring_rgb(), dtype=np.uint8).reshape(
+            height, width, 3
+        )
+    else:  # pragma: no cover - unexpected backend
+        return None
+    return np.ascontiguousarray(buffer[..., :3])
+
+
+def _pad_to(image, height, width, fill=255):
+    """Centre *image* inside a ``(height, width)`` canvas of colour *fill*."""
+    if image.shape[0] == height and image.shape[1] == width:
+        return image
+    padded = np.full((height, width, 3), fill, dtype=np.uint8)
+    top = (height - image.shape[0]) // 2
+    left = (width - image.shape[1]) // 2
+    padded[top : top + image.shape[0], left : left + image.shape[1]] = image
+    return padded
+
+
+def combine_frames(images):
+    """Stack rendered figures side by side into a single frame.
+
+    Images of differing heights are padded (not scaled) so that no frame is
+    resampled.
+
+    Parameters
+    ----------
+    images : list of np.ndarray
+        RGB arrays to combine, left to right.
+
+    Returns
+    -------
+    np.ndarray or None
+        The combined frame, or None when *images* is empty.
+    """
+    images = [image for image in images if image is not None]
+    if not images:
+        return None
+    if len(images) == 1:
+        return images[0]
+    height = max(image.shape[0] for image in images)
+    padded = [_pad_to(image, height, image.shape[1]) for image in images]
+    return np.hstack(padded)
+
+
+def export_animation(path, frames, fps):
+    """Write rendered *frames* to an animated GIF.
+
+    ``imageio`` is imported lazily — it ships with napari but is not a hard
+    dependency of this plugin, mirroring how ``_batch_analysis`` handles it.
+
+    Parameters
+    ----------
+    path : str
+        Output file path.
+    frames : list of np.ndarray
+        RGB frames, all of the same shape.
+    fps : float
+        Frame rate of the resulting animation.
+
+    Returns
+    -------
+    bool
+        True on success, False when the file could not be written (a napari
+        error notification is shown in that case).
+    """
+    if not frames:
+        notifications.show_error("No frames were rendered; nothing to export.")
+        return False
+
+    try:
+        import imageio.v3 as iio
+    except ImportError:
+        notifications.show_error(
+            "Exporting animations requires the 'imageio' package. "
+            "Install it with: pip install imageio"
+        )
+        return False
+
+    height = max(frame.shape[0] for frame in frames)
+    width = max(frame.shape[1] for frame in frames)
+    padded = [_pad_to(frame, height, width) for frame in frames]
+
+    try:
+        iio.imwrite(
+            path,
+            np.stack(padded),
+            duration=1000.0 / max(0.5, float(fps)),
+            loop=0,
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        notifications.show_error(f"Could not write the animation: {exc}")
+        return False
+    return True
+
+
+def build_frame_statistics_rows(
+    datasets, frame_context, bin_edges=None, bin_centers=None
+):
+    """Compute per-frame statistics rows for a set of named datasets.
+
+    Each dataset is sliced along the frame axis and summarised with the same
+    maths the on-screen statistics table uses
+    (:func:`napari_phasors._utils.compute_dataset_statistics`), so exported
+    numbers always match what is displayed.
+
+    Parameters
+    ----------
+    datasets : dict
+        ``{name: np.ndarray}`` mapping labels to arrays shaped like the
+        corresponding layer data.
+    frame_context : FrameContext
+        Provides the frame axis. The context's own index is not used — every
+        frame is visited.
+    bin_edges, bin_centers : np.ndarray, optional
+        Histogram binning used for the centre-of-mass column. When omitted,
+        the centre of mass falls back to the mean.
+
+    Returns
+    -------
+    list of dict
+        One row per (frame, dataset) with keys ``Frame``, ``Name``,
+        ``Center of Mass``, ``Mean``, ``Median`` and ``Std Dev``.
+    """
+    rows = []
+    for name, data in datasets.items():
+        array = np.asarray(data)
+        axis = None
+        if array.ndim >= 3:
+            candidate = frame_context.axis
+            if 0 <= candidate < array.ndim - 2 and array.shape[candidate] > 1:
+                axis = candidate
+
+        if axis is None:
+            stats = compute_dataset_statistics(
+                array, bin_centers=bin_centers, bin_edges=bin_edges
+            )
+            rows.append({"Frame": 0, "Name": name, **stats})
+            continue
+
+        for frame in range(array.shape[axis]):
+            stats = compute_dataset_statistics(
+                np.take(array, frame, axis=axis),
+                bin_centers=bin_centers,
+                bin_edges=bin_edges,
+            )
+            rows.append({"Frame": frame, "Name": name, **stats})
+
+    rows.sort(key=lambda row: (row["Frame"], str(row["Name"])))
+    return rows

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -2502,6 +2502,13 @@ class HistogramWidget(QWidget):
         # Raw pooled data (for central tendency computation)
         self._raw_valid_data = None
 
+        # Full (un-sliced) per-layer arrays plus the time-lapse frame context
+        # they were sliced with. Set by the analysis tabs via
+        # :meth:`set_frame_source`; used only to export per-timepoint
+        # statistics, never to render.
+        self._frame_context = None
+        self._frame_source_datasets = {}
+
         # Display settings
         self._display_mode = (
             "Merged"  # "Merged", "Individual layers", "Grouped"
@@ -2947,6 +2954,31 @@ class HistogramWidget(QWidget):
             if self.counts is not None:
                 self._render()
             self.dataChanged.emit()
+
+    def set_frame_source(self, frame_context, datasets) -> None:
+        """Record the un-sliced per-layer arrays behind the displayed data.
+
+        The analysis tabs call this just before feeding the histogram so the
+        statistics dock can export per-timepoint numbers without having to
+        recompute the analysis. It never affects what is rendered.
+
+        Parameters
+        ----------
+        frame_context : napari_phasors._timelapse.FrameContext or None
+            Context used to slice the data, or None when the plugin has no
+            time-lapse context (e.g. in headless batch analysis).
+        datasets : dict
+            ``{label: np.ndarray}`` of full arrays shaped like the layer data.
+        """
+        self._frame_context = frame_context
+        self._frame_source_datasets = dict(datasets or {})
+
+    def has_frame_source(self) -> bool:
+        """Return True when per-timepoint statistics can be exported."""
+        context = self._frame_context
+        if context is None or not self._frame_source_datasets:
+            return False
+        return bool(context.available_axes())
 
     def update_data(self, data: np.ndarray, label: str = "Layer") -> None:
         """Compute histogram from *data* and render.
@@ -3675,6 +3707,13 @@ class CollapsibleSection(QWidget):
         self._content.setVisible(self._toggle_button.isChecked())
         self._update_button_text()
 
+    def set_title(self, title):
+        """Change the section header text."""
+        if title == self._title:
+            return
+        self._title = title
+        self._update_button_text()
+
     def add_widget(self, widget):
         """Add a widget to the collapsible content area."""
         self._content_layout.addWidget(widget)
@@ -3684,6 +3723,286 @@ class CollapsibleSection(QWidget):
         self._toggle_button.setChecked(visible)
         self._content.setVisible(visible)
         self._update_button_text()
+
+
+def write_rows_to_csv(file_path, rows, float_format="{:.6f}"):
+    """Write a list of uniform dict rows to a CSV file.
+
+    Column order follows the keys of the first row.
+
+    Parameters
+    ----------
+    file_path : str
+        Destination path.
+    rows : list of dict
+        Rows to write; must share the same keys.
+    float_format : str, optional
+        Format applied to float values, by default six decimals.
+    """
+    import csv
+
+    if not rows:
+        return
+
+    headers = list(rows[0].keys())
+    with open(file_path, 'w', newline='', encoding='utf-8') as handle:
+        writer = csv.writer(handle)
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow(
+                [
+                    (
+                        float_format.format(row[header])
+                        if isinstance(row[header], float)
+                        else row[header]
+                    )
+                    for header in headers
+                ]
+            )
+
+
+def patch_biaplotter_capture_selection_geometry():
+    """Make biaplotter's selectors remember the region the user drew.
+
+    biaplotter's selectors turn the drawn shape into indices into the data
+    that is *currently plotted* and then discard the geometry. That is enough
+    while the phasor plot shows every timepoint at once, but when it shows a
+    single time-lapse frame the indices only cover that frame, so a selection
+    could never be applied to the rest of the stack.
+
+    Wrapping the geometry-only ``on_select`` of each base selector records
+    the call on the instance, which lets
+    :func:`active_selection_region` replay it against any other set of
+    points — reusing biaplotter's own maths for every shape rather than
+    reimplementing it here.
+
+    Safe to call repeatedly; the patch installs at most once.
+    """
+    try:
+        from biaplotter.selectors import (
+            BaseEllipseSelector,
+            BaseLassoSelector,
+            BaseRectangleSelector,
+        )
+    except ImportError:  # pragma: no cover - biaplotter is a hard dependency
+        return
+
+    for selector_class in (
+        BaseRectangleSelector,
+        BaseEllipseSelector,
+        BaseLassoSelector,
+    ):
+        if getattr(
+            selector_class, "_napari_phasors_capture_geometry_patch", False
+        ):
+            continue
+
+        original_on_select = selector_class.on_select
+
+        def _on_select_recording(self, *args, _original=original_on_select):
+            self._napari_phasors_region = (_original, args)
+            return _original(self, *args)
+
+        selector_class.on_select = _on_select_recording
+        selector_class._napari_phasors_capture_geometry_patch = True
+
+
+def patch_biaplotter_fixed_histogram_range():
+    """Let a 2D histogram keep one colour scale across time-lapse frames.
+
+    biaplotter derives the histogram's colour normalisation from the counts
+    it is currently drawing. That is right for a static plot, but when the
+    phasor plot shows one timepoint at a time it rescales on every frame, so
+    the same colour — and the colorbar beside it — means a different number
+    of pixels at each timepoint.
+
+    The patch honours an optional ``_napari_phasors_fixed_counts_range``
+    attribute on the artist, pinning vmin/vmax for the histogram (never for
+    the selection overlay). When the attribute is absent or None,
+    biaplotter's own behaviour is used unchanged.
+
+    Safe to call repeatedly; the patch installs at most once.
+    """
+    try:
+        from biaplotter.artists import Histogram2D
+    except ImportError:  # pragma: no cover - biaplotter is a hard dependency
+        return
+
+    if getattr(Histogram2D, "_napari_phasors_fixed_range_patch", False):
+        return
+
+    original_get_normalization = Histogram2D._get_normalization
+
+    def _get_normalization_fixed(self, values, is_overlay: bool = True):
+        fixed = getattr(self, "_napari_phasors_fixed_counts_range", None)
+        if is_overlay or fixed is None:
+            return original_get_normalization(
+                self, values, is_overlay=is_overlay
+            )
+
+        method = self._histogram_color_normalization_method
+        norm_class = self._normalization_methods.get(method)
+        if norm_class is None or method not in ("linear", "log"):
+            return original_get_normalization(
+                self, values, is_overlay=is_overlay
+            )
+
+        vmin, vmax = (float(fixed[0]), float(fixed[1]))
+        if method == "log":
+            # LogNorm cannot represent a non-positive floor.
+            vmin = max(vmin, 0.01)
+            vmax = max(vmax, vmin * 1.000001)
+        elif vmax <= vmin:
+            vmax = vmin + 1.0
+        return norm_class(vmin=vmin, vmax=vmax)
+
+    Histogram2D._get_normalization = _get_normalization_fixed
+    Histogram2D._napari_phasors_fixed_range_patch = True
+
+
+def active_selection_region(canvas_widget):
+    """Return a predicate for the region last drawn on *canvas_widget*.
+
+    Requires :func:`patch_biaplotter_capture_selection_geometry` to have been
+    applied (it is, on importing the plotter module).
+
+    Parameters
+    ----------
+    canvas_widget : biaplotter.plotter.CanvasWidget
+        Canvas whose active selector should be inspected.
+
+    Returns
+    -------
+    callable or None
+        A function mapping an ``(N, 2)`` array of ``(G, S)`` points to a
+        boolean mask of the points inside the drawn region, or None when no
+        region has been drawn (or the geometry could not be captured).
+    """
+    selector = getattr(canvas_widget, "active_selector", None)
+    recorded = getattr(selector, "_napari_phasors_region", None)
+    if recorded is None:
+        return None
+    original_on_select, args = recorded
+
+    def region_contains(points):
+        """Return a boolean mask of *points* inside the drawn region."""
+        points = np.asarray(points, dtype=float)
+        mask = np.zeros(len(points), dtype=bool)
+        if len(points) == 0:
+            return mask
+        previous_data = selector._data
+        try:
+            selector._data = points
+            indices = original_on_select(selector, *args)
+        except (AttributeError, IndexError, TypeError, ValueError):
+            return None
+        finally:
+            selector._data = previous_data
+        if indices is None:
+            return mask
+        indices = np.asarray(indices, dtype=int)
+        if indices.size:
+            mask[indices] = True
+        return mask
+
+    return region_contains
+
+
+def compute_dataset_statistics(data, bin_centers=None, bin_edges=None):
+    """Summarise a scalar dataset the way the statistics table displays it.
+
+    Shared by :class:`StatisticsTableWidget` and the CSV exporters so the
+    exported numbers can never drift from the ones on screen.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Scalar data of any shape; flattened internally. NaN and infinite
+        values are discarded.
+    bin_centers : np.ndarray, optional
+        Bin centres used for the centre-of-mass computation.
+    bin_edges : np.ndarray, optional
+        Bin edges used for the centre-of-mass computation. When either
+        binning argument is missing, the centre of mass falls back to the
+        mean.
+
+    Returns
+    -------
+    dict
+        Keys ``"Center of Mass"``, ``"Mean"``, ``"Median"`` and
+        ``"Std Dev"``, all floats (NaN when there is no valid data).
+    """
+    flat = np.asarray(data).ravel()
+    valid = flat[~np.isnan(flat) & np.isfinite(flat)]
+
+    if len(valid) == 0:
+        nan = float("nan")
+        return {
+            "Center of Mass": nan,
+            "Mean": nan,
+            "Median": nan,
+            "Std Dev": nan,
+        }
+
+    mean_val = float(np.mean(valid))
+    median_val = float(np.median(valid))
+    std_val = float(np.std(valid))
+
+    if bin_centers is not None and bin_edges is not None:
+        counts, _ = np.histogram(valid, bins=bin_edges)
+        if counts.sum() > 0:
+            com_val = float(np.average(bin_centers, weights=counts))
+        else:
+            com_val = float("nan")
+    else:
+        com_val = mean_val
+
+    return {
+        "Center of Mass": com_val,
+        "Mean": mean_val,
+        "Median": median_val,
+        "Std Dev": std_val,
+    }
+
+
+def pooled_histogram_bins(datasets, bins, hist_range=None):
+    """Return ``(bin_centers, bin_edges)`` spanning every dataset pooled.
+
+    Per-frame statistics are only comparable to each other if every frame is
+    binned identically, so the centre-of-mass column uses bins derived from
+    the whole acquisition rather than from the frame currently displayed.
+
+    Parameters
+    ----------
+    datasets : dict
+        ``{label: np.ndarray}`` of the full (un-sliced) arrays.
+    bins : int
+        Number of bins to use.
+    hist_range : tuple, optional
+        ``(min, max)`` range the histogram is clipped to by its range
+        slider. Passing it keeps the per-frame centre of mass on the same
+        convention as the pooled row, which bins over that same range.
+
+    Returns
+    -------
+    tuple
+        ``(bin_centers, bin_edges)``, or ``(None, None)`` when there is no
+        finite data to bin.
+    """
+    values = []
+    for data in datasets.values():
+        flat = np.asarray(data, dtype=float).ravel()
+        values.append(flat[np.isfinite(flat)])
+
+    if not values:
+        return None, None
+
+    pooled = np.concatenate(values)
+    if pooled.size == 0:
+        return None, None
+
+    edges = np.histogram_bin_edges(pooled, bins=bins, range=hist_range)
+    return (edges[:-1] + edges[1:]) / 2, edges
 
 
 class StatisticsTableWidget(QTableWidget):
@@ -3698,6 +4017,10 @@ class StatisticsTableWidget(QTableWidget):
     """
 
     COLUMNS = ["Name", "Center of Mass", "Mean", "Median", "Std Dev"]
+    #: Column layout used when one row is shown per time-lapse frame.
+    FRAME_COLUMNS = ["Frame", *COLUMNS]
+    #: Background of the row for the frame currently on screen.
+    CURRENT_FRAME_COLOR = QColor(74, 111, 165, 120)
 
     def __init__(self, parent=None):
         """Build the read-only statistics table with its fixed columns."""
@@ -3798,33 +4121,77 @@ class StatisticsTableWidget(QTableWidget):
         bin_edges : np.ndarray, optional
             Bin edges for center-of-mass computation.
         """
+        self._apply_columns(self.COLUMNS)
         self.setRowCount(len(datasets))
         for row, (name, data) in enumerate(datasets.items()):
-            flat = np.asarray(data).ravel()
-            valid = flat[~np.isnan(flat) & np.isfinite(flat)]
-
-            if len(valid) > 0:
-                mean_val = float(np.mean(valid))
-                median_val = float(np.median(valid))
-                std_val = float(np.std(valid))
-
-                if bin_centers is not None and bin_edges is not None:
-                    counts, _ = np.histogram(valid, bins=bin_edges)
-                    if counts.sum() > 0:
-                        com_val = np.average(bin_centers, weights=counts)
-                    else:
-                        com_val = float("nan")
-                else:
-                    com_val = mean_val
-            else:
-                mean_val = median_val = com_val = std_val = float("nan")
+            stats = compute_dataset_statistics(data, bin_centers, bin_edges)
 
             # Columns: [Name, Center of Mass, Mean, Median, Std Dev]
             self.setItem(row, 0, QTableWidgetItem(str(name)))
-            self.setItem(row, 1, QTableWidgetItem(f"{com_val:.4f}"))
-            self.setItem(row, 2, QTableWidgetItem(f"{mean_val:.4f}"))
-            self.setItem(row, 3, QTableWidgetItem(f"{median_val:.4f}"))
-            self.setItem(row, 4, QTableWidgetItem(f"{std_val:.4f}"))
+            for col, column_name in enumerate(self.COLUMNS[1:], start=1):
+                self.setItem(
+                    row,
+                    col,
+                    QTableWidgetItem(f"{stats[column_name]:.4f}"),
+                )
+
+    def _apply_columns(self, columns):
+        """Switch the table to *columns*, leaving it alone if already set."""
+        current = [
+            (
+                self.horizontalHeaderItem(index).text()
+                if self.horizontalHeaderItem(index) is not None
+                else ""
+            )
+            for index in range(self.columnCount())
+        ]
+        if current == list(columns):
+            return
+        self.setColumnCount(len(columns))
+        self.setHorizontalHeaderLabels(list(columns))
+
+    def update_frame_statistics(self, rows, current_frame=None):
+        """Show one row per time-lapse frame, highlighting the current one.
+
+        Parameters
+        ----------
+        rows : list of dict
+            Rows as produced by
+            :func:`napari_phasors._timelapse.build_frame_statistics_rows`,
+            each with a ``"Frame"`` and ``"Name"`` key plus the statistic
+            columns.
+        current_frame : int, optional
+            Frame displayed in the viewer; its row is highlighted and
+            scrolled into view.
+        """
+        self._apply_columns(self.FRAME_COLUMNS)
+        self.setRowCount(len(rows))
+
+        highlight_row = None
+        for row_index, row in enumerate(rows):
+            is_current = (
+                current_frame is not None and row["Frame"] == current_frame
+            )
+            if is_current and highlight_row is None:
+                highlight_row = row_index
+
+            values = [str(row["Frame"]), str(row["Name"])]
+            values += [f"{row[column]:.4f}" for column in self.COLUMNS[1:]]
+
+            for col, text in enumerate(values):
+                item = QTableWidgetItem(text)
+                if is_current:
+                    item.setBackground(self.CURRENT_FRAME_COLOR)
+                    font = item.font()
+                    font.setBold(True)
+                    item.setFont(font)
+                self.setItem(row_index, col, item)
+
+        if highlight_row is not None:
+            self.scrollToItem(
+                self.item(highlight_row, 0),
+                QAbstractItemView.PositionAtCenter,
+            )
 
     def update_group_statistics(
         self,
@@ -3970,9 +4337,56 @@ class StatisticsDockWidget(QWidget):
 
         histogram_widget.dataChanged.connect(self._update_statistics)
 
+    def _shows_per_frame_rows(self):
+        """True when the table should list one row per time-lapse frame."""
+        hw = self.histogram_widget
+        context = hw._frame_context
+        return (
+            context is not None
+            and context.is_per_frame
+            and hw.has_frame_source()
+        )
+
+    def _pooled_bins(self):
+        """Bins spanning the whole acquisition, matching the histogram's."""
+        hw = self.histogram_widget
+        hist_range = hw.get_range() if hw._range_slider_enabled else None
+        return pooled_histogram_bins(
+            hw._frame_source_datasets, hw.bins, hist_range
+        )
+
+    def _frame_statistics_rows(self):
+        """Return per-frame rows plus the bins they were computed with."""
+        from ._timelapse import build_frame_statistics_rows
+
+        hw = self.histogram_widget
+        bin_centers, bin_edges = self._pooled_bins()
+        rows = build_frame_statistics_rows(
+            hw._frame_source_datasets,
+            hw._frame_context,
+            bin_edges,
+            bin_centers,
+        )
+        return rows, bin_centers, bin_edges
+
     def _update_statistics(self):
         """Recompute the statistics tables from the histogram's data."""
         hw = self.histogram_widget
+
+        if self._shows_per_frame_rows():
+            rows, _centers, _edges = self._frame_statistics_rows()
+            if rows:
+                self.layer_stats_table.update_frame_statistics(
+                    rows, hw._frame_context.index
+                )
+                self.layer_stats_section.set_title("Statistics per Frame")
+                self.layer_stats_section.setVisible(True)
+                # Group statistics stay a pooled, per-layer concept.
+                self.group_stats_section.setVisible(False)
+                self.export_csv_button.setEnabled(True)
+                return
+
+        self.layer_stats_section.set_title("Layer Statistics")
 
         has_multi = bool(hw._datasets)
         has_single = (
@@ -4009,7 +4423,31 @@ class StatisticsDockWidget(QWidget):
         self.export_csv_button.setEnabled(has_multi or has_single)
 
     def _export_table_csv_impl(self):
-        """Export the visible statistics table(s) to CSV file(s)."""
+        """Export the statistics to CSV, offering per-timepoint for stacks.
+
+        For plain 2D data this writes the tables exactly as displayed. For a
+        time-lapse the user is asked whether to export the current view, the
+        whole acquisition pooled, or one row per timepoint.
+        """
+        export_mode = "current"
+        if self.histogram_widget.has_frame_source():
+            menu = QMenu(self)
+            current_action = menu.addAction("Current view")
+            pooled_action = menu.addAction("All timepoints pooled")
+            per_frame_action = menu.addAction("Per timepoint")
+            chosen = menu.exec_(
+                self.export_csv_button.mapToGlobal(
+                    self.export_csv_button.rect().bottomLeft()
+                )
+            )
+            if chosen is None:
+                return
+            if chosen is pooled_action:
+                export_mode = "pooled"
+            elif chosen is per_frame_action:
+                export_mode = "per_frame"
+            del current_action
+
         file_path, _ = QFileDialog.getSaveFileName(
             self,
             "Export Statistics as CSV",
@@ -4023,12 +4461,49 @@ class StatisticsDockWidget(QWidget):
         if not file_path.endswith('.csv'):
             file_path += '.csv'
 
+        if export_mode != "current":
+            self._write_frame_statistics_to_csv(file_path, export_mode)
+            return
+
         if self.layer_stats_section.isVisible():
             self._write_table_to_csv(self.layer_stats_table, file_path)
 
         if self.group_stats_section.isVisible():
             group_file = file_path.replace('.csv', '_groups.csv')
             self._write_table_to_csv(self.group_stats_table, group_file)
+
+    def _write_frame_statistics_to_csv(self, file_path, export_mode):
+        """Write pooled or per-timepoint statistics for the whole stack.
+
+        Parameters
+        ----------
+        file_path : str
+            Destination path.
+        export_mode : {"pooled", "per_frame"}
+            Whether to summarise the whole acquisition in one row per layer
+            or to emit one row per timepoint per layer.
+        """
+        hw = self.histogram_widget
+        datasets = hw._frame_source_datasets
+        # Bin over the whole acquisition so every frame's centre of mass is
+        # computed on the same bins, matching the on-screen per-frame table.
+        bin_centers, bin_edges = self._pooled_bins()
+
+        if export_mode == "per_frame":
+            rows, bin_centers, bin_edges = self._frame_statistics_rows()
+        else:
+            rows = [
+                {
+                    "Frame": "all",
+                    "Name": name,
+                    **compute_dataset_statistics(
+                        data, bin_centers=bin_centers, bin_edges=bin_edges
+                    ),
+                }
+                for name, data in datasets.items()
+            ]
+
+        write_rows_to_csv(file_path, rows, float_format="{:.4f}")
 
     def _write_table_to_csv(self, table: QTableWidget, file_path: str):
         """Write a QTableWidget to a CSV file.

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -49,6 +49,7 @@ from qtpy.QtWidgets import (
     QWidgetAction,
 )
 
+from ._timelapse import slice_datasets
 from ._utils import (
     CheckableComboBox,
     HistogramWidget,
@@ -5581,14 +5582,17 @@ class ComponentsWidget(QWidget):
         Returns
         -------
         dict
-            ``{analysis_layer_name: flattened np.ndarray}``.
+            ``{analysis_layer_name: np.ndarray}``. The arrays keep the shape
+            of the source layer — :class:`HistogramWidget` flattens them
+            itself, and preserving the shape is what lets a time-lapse be
+            sliced per frame.
         """
         labeled = {}
         for img_name, data in data_by_image.items():
             label = self._histogram_label_for_image(
                 img_name, fraction_layers_map, selected_text, invert
             )
-            labeled[label] = np.asarray(data, dtype=float).ravel()
+            labeled[label] = np.asarray(data, dtype=float)
         return labeled
 
     def _histogram_label_for_image(
@@ -5766,6 +5770,7 @@ class ComponentsWidget(QWidget):
         per_layer = self._label_fraction_datasets(
             clipped_data, fraction_layers_map, selected_text, invert
         )
+        per_layer = self._slice_datasets_for_frame(per_layer)
         if len(per_layer) > 1:
             self.histogram_widget.update_multi_data(per_layer)
         else:
@@ -5877,6 +5882,9 @@ class ComponentsWidget(QWidget):
         per_layer = self._label_fraction_datasets(
             raw_data, fraction_layers_map, selected_text, invert
         )
+        # In per-frame mode only the displayed timepoint is summarised; the
+        # slider bounds above stay pooled so they don't jump while playing.
+        per_layer = self._slice_datasets_for_frame(per_layer)
         if len(per_layer) > 1:
             self.histogram_widget.update_multi_data(per_layer)
         else:
@@ -5884,6 +5892,26 @@ class ComponentsWidget(QWidget):
             self.histogram_widget.update_data(data, label=label)
 
         self.histogram_widget.show()
+
+    def _frame_context(self):
+        """Return the plotter's time-lapse frame context, if available."""
+        return getattr(self.parent_widget, 'frame_context', None)
+
+    def _slice_datasets_for_frame(self, datasets):
+        """Restrict per-layer datasets to the displayed time-lapse frame.
+
+        The un-sliced arrays are handed to the histogram widget as well, so
+        the statistics dock can export per-timepoint numbers.
+        """
+        frame_context = self._frame_context()
+        self.histogram_widget.set_frame_source(frame_context, datasets)
+        return slice_datasets(frame_context, datasets)
+
+    def refresh_for_frame_change(self):
+        """Re-feed the histogram after the displayed frame changed."""
+        if not self.histogram_component_combobox.currentText():
+            return
+        self.update_component_histogram()
 
     def closeEvent(self, event):
         """Clean up signal connections before closing."""

--- a/src/napari_phasors/components_tab.py
+++ b/src/napari_phasors/components_tab.py
@@ -1168,7 +1168,7 @@ class ComponentsWidget(QWidget):
     def _update_components_setting_in_metadata(self, key_path, value):
         """Update a specific component setting in the current layer's metadata."""
         layer_name = self.parent_widget.get_primary_layer_name()
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return
 
         layer = self.viewer.layers[layer_name]
@@ -1197,7 +1197,7 @@ class ComponentsWidget(QWidget):
 
         layer_name = self.parent_widget.get_primary_layer_name()
 
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return
 
         layer = self.viewer.layers[layer_name]
@@ -1339,7 +1339,7 @@ class ComponentsWidget(QWidget):
 
         layer_name = self.parent_widget.get_primary_layer_name()
 
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return
 
         layer = self.viewer.layers[layer_name]
@@ -4455,7 +4455,7 @@ class ComponentsWidget(QWidget):
         self._update_lifetime_inputs_visibility()
 
         layer_name = self.parent_widget.get_primary_layer_name()
-        if layer_name:
+        if layer_name and layer_name in self.viewer.layers:
             self._reconnect_existing_fraction_layers(layer_name)
 
             self._restore_components_ui_only_from_metadata()

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -29,6 +29,7 @@ from qtpy.QtWidgets import (
 )
 from superqt import QToggleSwitch
 
+from ._timelapse import slice_datasets
 from ._utils import (
     CheckableComboBox,
     CurrentPageStackedWidget,
@@ -1327,7 +1328,10 @@ class FretWidget(QWidget):
     def _restore_fret_settings_from_metadata(self):
         """Restore all FRET settings from the current layer's metadata."""
         layer_name = self.parent_widget.get_primary_layer_name()
-        if not layer_name:
+        # The combobox can still hold a name whose layer has already been
+        # removed (a deferred tab update queued before the removal), so guard
+        # the lookup as the components tab does.
+        if not layer_name or layer_name not in self.viewer.layers:
             self.background_positions_by_harmonic = {}
             return
 
@@ -1602,15 +1606,17 @@ class FretWidget(QWidget):
         all_data = []
         for layer in self.fret_layers:
             if layer in self.viewer.layers:
-                data = layer.data.ravel()
-                all_data.append(data)
-                per_layer[layer.name] = data
+                all_data.append(layer.data.ravel())
+                per_layer[layer.name] = layer.data
 
         if not all_data:
             self.histogram_widget.hide()
             return
 
+        # ``merged`` stays pooled so the range slider spans the whole
+        # acquisition; only the histogram datasets follow the current frame.
         merged = np.concatenate(all_data)
+        per_layer = self._slice_datasets_for_frame(per_layer)
 
         # Update range slider to match data extent
         valid = merged[~np.isnan(merged) & np.isfinite(merged)]
@@ -1638,10 +1644,28 @@ class FretWidget(QWidget):
         if len(per_layer) > 1:
             self.histogram_widget.update_multi_data(per_layer)
         else:
-            self.histogram_widget.update_data(
-                merged,
-                label=next(iter(per_layer), "Layer"),
-            )
+            label, data = next(iter(per_layer.items()), ("Layer", merged))
+            self.histogram_widget.update_data(data, label=label)
+
+    def _frame_context(self):
+        """Return the plotter's time-lapse frame context, if available."""
+        return getattr(self.parent_widget, 'frame_context', None)
+
+    def _slice_datasets_for_frame(self, datasets):
+        """Restrict per-layer datasets to the displayed time-lapse frame.
+
+        The un-sliced arrays are handed to the histogram widget as well, so
+        the statistics dock can export per-timepoint numbers.
+        """
+        frame_context = self._frame_context()
+        self.histogram_widget.set_frame_source(frame_context, datasets)
+        return slice_datasets(frame_context, datasets)
+
+    def refresh_for_frame_change(self):
+        """Re-feed the histogram after the displayed frame changed."""
+        if not self.fret_layers:
+            return
+        self._update_fret_histogram()
 
     def _on_fret_range_changed(self, min_val, max_val):
         """Handle range slider changes – clip FRET layers and update histogram."""
@@ -1666,11 +1690,11 @@ class FretWidget(QWidget):
         all_data = []
         for layer in self.fret_layers:
             if layer in self.viewer.layers:
-                data = layer.data.ravel()
-                all_data.append(data)
-                per_layer[layer.name] = data
+                all_data.append(layer.data.ravel())
+                per_layer[layer.name] = layer.data
         if all_data:
             merged = np.concatenate(all_data)
+            per_layer = self._slice_datasets_for_frame(per_layer)
             self.histogram_widget.update_colormap(
                 colormap_colors=self.fret_colormap,
                 contrast_limits=[min_val, max_val],
@@ -1679,10 +1703,8 @@ class FretWidget(QWidget):
             if len(per_layer) > 1:
                 self.histogram_widget.update_multi_data(per_layer)
             else:
-                self.histogram_widget.update_data(
-                    merged,
-                    label=next(iter(per_layer), "Layer"),
-                )
+                label, data = next(iter(per_layer.items()), ("Layer", merged))
+                self.histogram_widget.update_data(data, label=label)
 
         self.plot_donor_trajectory()
 

--- a/src/napari_phasors/fret_tab.py
+++ b/src/napari_phasors/fret_tab.py
@@ -531,9 +531,13 @@ class FretWidget(QWidget):
                 ] = {'real': real, 'imag': imag}
 
                 layer_name = self.parent_widget.get_primary_layer_name()
-                if layer_name and (
-                    not hasattr(self, '_updating_settings')
-                    or not self._updating_settings
+                if (
+                    layer_name
+                    and layer_name in self.viewer.layers
+                    and (
+                        not hasattr(self, '_updating_settings')
+                        or not self._updating_settings
+                    )
                 ):
                     current_layer = self.viewer.layers[layer_name]
                     if 'settings' not in current_layer.metadata:
@@ -1307,7 +1311,7 @@ class FretWidget(QWidget):
             return
 
         layer_name = self.parent_widget.get_primary_layer_name()
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return
 
         layer = self.viewer.layers[layer_name]
@@ -1328,9 +1332,6 @@ class FretWidget(QWidget):
     def _restore_fret_settings_from_metadata(self):
         """Restore all FRET settings from the current layer's metadata."""
         layer_name = self.parent_widget.get_primary_layer_name()
-        # The combobox can still hold a name whose layer has already been
-        # removed (a deferred tab update queued before the removal), so guard
-        # the lookup as the components tab does.
         if not layer_name or layer_name not in self.viewer.layers:
             self.background_positions_by_harmonic = {}
             return
@@ -1475,7 +1476,7 @@ class FretWidget(QWidget):
     def _recreate_fret_from_metadata(self):
         """Recreate FRET analysis from metadata if it was previously performed."""
         layer_name = self.parent_widget.get_primary_layer_name()
-        if layer_name:
+        if layer_name and layer_name in self.viewer.layers:
             layer = self.viewer.layers[layer_name]
             if (
                 'settings' in layer.metadata

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -1000,7 +1000,7 @@ class PhasorMappingWidget(QWidget):
         none yet.
         """
         layer_name = self.parent_widget.get_primary_layer_name()
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return None
         layer = self.viewer.layers[layer_name]
         return self._get_phasor_mapping_settings(layer, create=create)
@@ -1283,7 +1283,7 @@ class PhasorMappingWidget(QWidget):
             return
 
         layer_name = self.parent_widget.get_primary_layer_name()
-        if layer_name:
+        if layer_name and layer_name in self.viewer.layers:
             layer = self.viewer.layers[layer_name]
             mapping_settings = self._get_phasor_mapping_settings(
                 layer, create=True
@@ -1304,7 +1304,7 @@ class PhasorMappingWidget(QWidget):
     def _restore_lifetime_settings_from_metadata(self):
         """Restore all lifetime settings from the current layer's metadata."""
         layer_name = self.parent_widget.get_primary_layer_name()
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return
 
         layer = self.viewer.layers[layer_name]
@@ -2113,7 +2113,7 @@ class PhasorMappingWidget(QWidget):
     def _restore_lifetime_range_from_metadata(self):
         """Restore lifetime range from metadata after calculation."""
         layer_name = self.parent_widget.get_primary_layer_name()
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             return
 
         layer = self.viewer.layers[layer_name]

--- a/src/napari_phasors/phasor_mapping_tab.py
+++ b/src/napari_phasors/phasor_mapping_tab.py
@@ -30,6 +30,7 @@ from scipy.ndimage import gaussian_filter
 from scipy.stats import binned_statistic_2d
 from superqt import QRangeSlider, QToggleSwitch
 
+from ._timelapse import slice_datasets
 from ._utils import (
     LIFETIME_OUTPUT_TYPES,
     HistogramWidget,
@@ -1764,13 +1765,39 @@ class PhasorMappingWidget(QWidget):
             f"{output_type}: {name}": data
             for name, data in (self.per_layer_metric_data or {}).items()
         }
+        # In per-frame mode only the displayed timepoint is summarised. The
+        # range slider keeps using the pooled extent (set elsewhere) so the
+        # contrast limits don't jump around while playing.
+        named = self._slice_datasets_for_frame(named)
         if len(named) > 1:
             self.histogram_widget.update_multi_data(named)
+        elif named:
+            label, data = next(iter(named.items()))
+            self.histogram_widget.update_data(data, label=label)
         else:
             self.histogram_widget.update_data(
-                self.current_metric_data,
-                label=next(iter(named), "Layer"),
+                self.current_metric_data, label="Layer"
             )
+
+    def _frame_context(self):
+        """Return the plotter's time-lapse frame context, if available."""
+        return getattr(self.parent_widget, 'frame_context', None)
+
+    def _slice_datasets_for_frame(self, datasets):
+        """Restrict per-layer datasets to the displayed time-lapse frame.
+
+        The un-sliced arrays are handed to the histogram widget as well, so
+        the statistics dock can export per-timepoint numbers.
+        """
+        frame_context = self._frame_context()
+        self.histogram_widget.set_frame_source(frame_context, datasets)
+        return slice_datasets(frame_context, datasets)
+
+    def refresh_for_frame_change(self):
+        """Re-feed the histogram after the displayed frame changed."""
+        if self.current_metric_data is None:
+            return
+        self.plot_lifetime_histogram()
 
     def rename_layer(self, old_name: str, new_name: str):
         """Update internal dictionaries and rename derived layers when a layer is renamed."""

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -20,6 +20,7 @@ from phasorpy.phasor import phasor_to_polar
 from qtpy.QtCore import QEvent, Qt, QTimer
 from qtpy.QtGui import QColor, QCursor
 from qtpy.QtWidgets import (
+    QApplication,
     QCheckBox,
     QComboBox,
     QDialog,
@@ -33,6 +34,7 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMenu,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -44,6 +46,16 @@ from qtpy.QtWidgets import (
 )
 from superqt import QToggleSwitch
 
+from ._timelapse import CURRENT as FRAME_MODE_CURRENT
+from ._timelapse import POOLED as FRAME_MODE_POOLED
+from ._timelapse import (
+    AnimationExportDialog,
+    FrameContext,
+    TimelapseControlBar,
+    combine_frames,
+    export_animation,
+    figure_to_rgb,
+)
 from ._update_check import maybe_check_for_update
 from ._utils import (
     CheckableComboBox,
@@ -62,11 +74,14 @@ from ._utils import (
     make_section,
     make_solid_contour_cmap,
     normalize_rgb,
+    patch_biaplotter_capture_selection_geometry,
+    patch_biaplotter_fixed_histogram_range,
     populate_colormap_combobox,
     read_ome_tiff_settings,
     resolve_colormap_by_name,
     save_groups_to_layer_metadata,
     update_frequency_in_metadata,
+    write_rows_to_csv,
 )
 from .calibration_tab import CalibrationWidget
 from .components_tab import ComponentsWidget
@@ -242,6 +257,8 @@ def _patch_biaplotter_safe_toggle_sender():
 
 _patch_nap_plot_tools_safe_disconnect()
 _patch_biaplotter_safe_toggle_sender()
+patch_biaplotter_capture_selection_geometry()
+patch_biaplotter_fixed_histogram_range()
 
 
 def _apply_label_colors_to_combo(combo, labels_layer, unique_labels):
@@ -1487,6 +1504,15 @@ class PhasorCenterStatisticsWidget(QWidget):
         main_layout.addWidget(self.group_stats_section)
         self.group_stats_section.setVisible(False)
 
+        self.export_csv_button = QPushButton("Export Centers as CSV")
+        self.export_csv_button.setMinimumWidth(140)
+        self.export_csv_button.setEnabled(False)
+        self.export_csv_button.setToolTip(
+            "Export the phasor centers. For a time-lapse you can export one "
+            "row per timepoint."
+        )
+        main_layout.addWidget(self.export_csv_button)
+
         main_layout.addStretch()
 
     def update_centers(self, centers):
@@ -1499,6 +1525,7 @@ class PhasorCenterStatisticsWidget(QWidget):
         """
         self._update_table(self._layer_table, centers)
         self.layer_stats_section.setVisible(bool(centers))
+        self.export_csv_button.setEnabled(bool(centers))
 
     def update_group_centers(self, centers):
         """Update the group centers table.
@@ -1637,6 +1664,11 @@ class PlotterWidget(QWidget):
         self._last_histogram_norm = None
         self._last_histogram_color_indices = None
         self._last_scatter_color_indices = None
+
+        # Bin grid and count range shared by every time-lapse frame, so the
+        # 2D histogram's colours and colorbar stay put while stepping.
+        self._frame_histogram_cache = None
+        self._frame_histogram_cache_key = None
 
         # Cleared only on fresh layer load.
         self._user_axes_limits = None
@@ -1882,6 +1914,21 @@ class PlotterWidget(QWidget):
         self.controls_container.layout().addLayout(
             harmonics_and_mask_container
         )
+
+        # Time-lapse controls: pooled vs per-frame display, frame slider,
+        # playback and animation export. The bar hides itself when the
+        # selected layers have no non-spatial axis, so 2D data is unaffected.
+        self.frame_context = FrameContext(
+            self.viewer, self.get_selected_layers, parent=self
+        )
+        self.timelapse_bar = TimelapseControlBar(self.frame_context)
+        self.timelapse_bar.exportRequested.connect(
+            self._on_export_animation_clicked
+        )
+        self.frame_context.frameChanged.connect(self._on_frame_changed)
+        self.frame_context.modeChanged.connect(self._on_frame_mode_changed)
+        self.frame_context.axisChanged.connect(self._on_frame_axis_changed)
+        self.controls_container.layout().addWidget(self.timelapse_bar)
 
         # Dynamic buttons to re-open closed dock widgets
         dock_buttons_layout = QHBoxLayout()
@@ -2368,6 +2415,9 @@ class PlotterWidget(QWidget):
         self._phasor_center_stats_widget = PhasorCenterStatisticsWidget()
         self._phasor_center_stats_page_idx = self._statistics_stack.addWidget(
             self._phasor_center_stats_widget
+        )
+        self._phasor_center_stats_widget.export_csv_button.clicked.connect(
+            self._export_phasor_center_statistics
         )
 
         # Initialize phasor center UI visibility
@@ -2860,6 +2910,8 @@ class PlotterWidget(QWidget):
             'phasor_center_group_assignments': {},
             'phasor_center_group_colors': {},
             'phasor_center_group_names': {},
+            'timelapse_mode': FRAME_MODE_POOLED,
+            'timelapse_axis': 0,
         }
 
     def _initialize_plot_settings_in_metadata(self, layer):
@@ -2936,6 +2988,19 @@ class PlotterWidget(QWidget):
             # Restore harmonic
             if 'harmonic' in settings:
                 self.harmonic_spinbox.setValue(settings['harmonic'])
+
+            # Restore the time-lapse display mode / frame axis. The frame
+            # index itself is intentionally not persisted — it always comes
+            # from the napari dims slider.
+            if 'timelapse_axis' in settings:
+                with contextlib.suppress(TypeError, ValueError):
+                    self.frame_context.axis = int(settings['timelapse_axis'])
+            if 'timelapse_mode' in settings:
+                self.frame_context.mode = (
+                    FRAME_MODE_CURRENT
+                    if settings['timelapse_mode'] == FRAME_MODE_CURRENT
+                    else FRAME_MODE_POOLED
+                )
 
             # Only restore if explicitly set in metadata
             if 'white_background' in settings:
@@ -3697,7 +3762,20 @@ class PlotterWidget(QWidget):
         self.canvas_widget.figure.canvas.draw_idle()
 
     def _run_deferred_tab_update(self, current_tab):
-        """Run deferred _on_image_layer_changed for the given tab."""
+        """Run deferred _on_image_layer_changed for the given tab.
+
+        A deferred update can still be pending when the primary layer has
+        already been removed (the tab-change event is delivered after the
+        removal, e.g. during teardown). The restore paths look the layer up
+        by name, so skip the update entirely rather than let each of them
+        raise ``KeyError``.
+        """
+        if self._is_closing:
+            return
+        layer_name = self.get_primary_layer_name()
+        if layer_name and layer_name not in self.viewer.layers:
+            return
+
         deferrable_tabs = []
         for attr in (
             'phasor_mapping_tab',
@@ -3953,6 +4031,161 @@ class PlotterWidget(QWidget):
             self._update_plot_elements()
         if hasattr(self, 'selection_tab'):
             self.selection_tab.on_harmonic_changed()
+
+    # ------------------------------------------------------------------
+    # Time-lapse (frame) handling
+    # ------------------------------------------------------------------
+
+    def _refresh_timelapse_controls(self):
+        """Rebuild the time-lapse bar for the current layer selection."""
+        bar = getattr(self, 'timelapse_bar', None)
+        if bar is None:
+            return
+        with contextlib.suppress(RuntimeError):
+            bar.refresh()
+
+    def _replot_for_frame_state(self):
+        """Redraw the phasor plot and dependent tabs for the frame state.
+
+        The merged-features cache is keyed on the frame state, so it expires
+        on its own here — invalidating explicitly would also throw away the
+        per-frame histogram range, which is frame-independent and expensive
+        to recompute.
+
+        Skipped while settings are being restored from layer metadata — the
+        restore path replots once at the end.
+        """
+        if getattr(self, '_updating_settings', False):
+            return
+        self.refresh_current_plot()
+        self._update_plot_elements()
+        self._refresh_frame_dependent_tabs()
+
+    def _on_frame_changed(self, _index):
+        """Replot everything that depends on the current time-lapse frame."""
+        if self._is_closing or not self.frame_context.is_per_frame:
+            return
+        self._replot_for_frame_state()
+
+    def _on_frame_mode_changed(self, mode):
+        """Handle switching between pooled and per-frame display."""
+        if self._is_closing:
+            return
+        self._update_setting_in_metadata('timelapse_mode', mode)
+        self._refresh_timelapse_controls()
+        self._replot_for_frame_state()
+
+    def _on_frame_axis_changed(self, axis):
+        """Handle a change of which axis is stepped through."""
+        if self._is_closing:
+            return
+        self._update_setting_in_metadata('timelapse_axis', int(axis))
+        if self.frame_context.is_per_frame:
+            self._replot_for_frame_state()
+
+    def _refresh_frame_dependent_tabs(self):
+        """Re-feed the 1-D histogram of every analysis tab that holds data.
+
+        The histogram, and therefore the statistics table it drives, is
+        rebuilt from per-layer arrays sliced by the frame context. Refreshing
+        only the *focused* tab would leave a stale histogram on screen
+        whenever the dock still shows one tab's results while another tab is
+        selected, so every populated tab is refreshed. Each tab's
+        ``refresh_for_frame_change`` returns immediately when it has no
+        analysis results, and re-feeding is only a re-bin of arrays already
+        in memory, so this stays cheap during playback.
+        """
+        for tab_attr in ('phasor_mapping_tab', 'components_tab', 'fret_tab'):
+            tab = getattr(self, tab_attr, None)
+            if tab is None or not hasattr(tab, 'refresh_for_frame_change'):
+                continue
+            with contextlib.suppress(AttributeError, RuntimeError, ValueError):
+                tab.refresh_for_frame_change()
+
+    def _active_histogram_widget(self):
+        """Return the histogram widget of the visible tab, if it has data."""
+        current_tab = self.tab_widget.currentWidget()
+        for tab_attr in ('phasor_mapping_tab', 'components_tab', 'fret_tab'):
+            tab = getattr(self, tab_attr, None)
+            if tab is not None and tab is current_tab:
+                histogram = getattr(tab, 'histogram_widget', None)
+                if histogram is not None and getattr(
+                    histogram, '_datasets', None
+                ):
+                    return histogram
+        return None
+
+    def _on_export_animation_clicked(self):
+        """Render the time-lapse to an animated GIF."""
+        ctx = self.frame_context
+        if not ctx.is_per_frame or ctx.n_frames < 2:
+            notifications.show_info(
+                "Switch the Frames control to 'Current timepoint' on a "
+                "multi-frame layer to export an animation."
+            )
+            return
+
+        histogram = self._active_histogram_widget()
+        dialog = AnimationExportDialog(
+            ctx.n_frames,
+            histogram is not None,
+            parent=self,
+        )
+        if dialog.exec_() != QDialog.Accepted:
+            return
+
+        options = dialog.get_options()
+        if not options["include_phasor"] and not options["include_histogram"]:
+            notifications.show_warning("Select at least one figure to export.")
+            return
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self, "Export Animation", "", "GIF Files (*.gif)"
+        )
+        if not file_path:
+            return
+        if not file_path.lower().endswith('.gif'):
+            file_path += '.gif'
+
+        frames = self._render_animation_frames(options, histogram)
+        if export_animation(file_path, frames, options["fps"]):
+            notifications.show_info(f"Animation saved to {file_path}")
+
+    def _render_animation_frames(self, options, histogram):
+        """Render one RGB image per requested frame.
+
+        The current frame is restored afterwards so exporting never leaves
+        the viewer on a different timepoint.
+        """
+        ctx = self.frame_context
+        original_index = ctx.index
+        images = []
+        try:
+            for frame in options["frames"]:
+                if frame < 0 or frame >= ctx.n_frames:
+                    continue
+                if ctx.index == frame:
+                    # The index setter is a no-op when the value is
+                    # unchanged, so redraw explicitly for the frame we
+                    # happened to start on.
+                    self._on_frame_changed(frame)
+                else:
+                    ctx.index = frame
+                QApplication.processEvents()
+
+                parts = []
+                if options["include_phasor"]:
+                    parts.append(figure_to_rgb(self.canvas_widget.figure))
+                if options["include_histogram"] and histogram is not None:
+                    parts.append(figure_to_rgb(histogram.fig))
+
+                combined = combine_frames(parts)
+                if combined is not None:
+                    images.append(combined)
+        finally:
+            ctx.index = original_index
+            QApplication.processEvents()
+        return images
 
     def _on_plot_type_changed(self):
         """Callback for plot type change."""
@@ -4319,8 +4552,19 @@ class PlotterWidget(QWidget):
                 artist.remove()
         self._phasor_center_artists.clear()
 
-    def _get_layer_phasor_samples(self, layer):
-        """Return flattened (intensity, G, S) arrays for one layer."""
+    def _get_layer_phasor_arrays(self, layer):
+        """Return the unflattened ``(intensity, G, S)`` arrays for one layer.
+
+        The G/S arrays are reduced to the currently selected harmonic and
+        keep the layer's own shape, so callers can slice them along a
+        time-lapse axis themselves.
+
+        Returns
+        -------
+        tuple or None
+            ``(mean, g, s)`` arrays, or None when the layer has no phasor
+            data for the current harmonic.
+        """
         g_array = layer.metadata.get("G")
         s_array = layer.metadata.get("S")
         harmonics = layer.metadata.get("harmonics")
@@ -4345,8 +4589,30 @@ class PlotterWidget(QWidget):
             g = g_array
             s = s_array
 
-        mean_data = layer.data
-        return mean_data.ravel(), g.ravel(), s.ravel()
+        return layer.data, g, s
+
+    def _get_layer_phasor_samples(self, layer):
+        """Return flattened (intensity, G, S) arrays for one layer.
+
+        In per-frame mode only the samples of the displayed timepoint are
+        returned, so phasor centers summarise what is on screen.
+        """
+        arrays = self._get_layer_phasor_arrays(layer)
+        if arrays is None:
+            return None
+        mean_data, g, s = arrays
+
+        mean_flat = mean_data.ravel()
+        g_flat = g.ravel()
+        s_flat = s.ravel()
+
+        frame_mask = self.frame_context.flat_frame_mask(g.shape)
+        if frame_mask is not None and frame_mask.shape == g_flat.shape:
+            mean_flat = mean_flat[frame_mask]
+            g_flat = g_flat[frame_mask]
+            s_flat = s_flat[frame_mask]
+
+        return mean_flat, g_flat, s_flat
 
     def _compute_center_from_samples(self, mean_flat, g_flat, s_flat):
         """Compute (g, s) center from flattened sample arrays."""
@@ -4379,6 +4645,102 @@ class PlotterWidget(QWidget):
             return None
         mean_flat, g_flat, s_flat = samples
         return self._compute_center_from_samples(mean_flat, g_flat, s_flat)
+
+    def _center_row(self, frame, name, center):
+        """Build one CSV row from a ``(g, s)`` phasor center."""
+        g_center, s_center = center
+        phase, modulation = phasor_to_polar(
+            np.array([g_center]), np.array([s_center])
+        )
+        return {
+            "Frame": frame,
+            "Name": name,
+            "G (center)": g_center,
+            "S (center)": s_center,
+            "Phase (deg)": float(np.degrees(phase[0])),
+            "Modulation": float(modulation[0]),
+        }
+
+    def _phasor_center_statistics_rows(self, per_frame):
+        """Compute phasor-center rows for every selected layer.
+
+        Parameters
+        ----------
+        per_frame : bool
+            When True, emit one row per timepoint per layer; otherwise one
+            pooled row per layer.
+
+        Returns
+        -------
+        list of dict
+            Rows ready to be written to CSV.
+        """
+        rows = []
+        for layer in self.get_selected_layers():
+            arrays = self._get_layer_phasor_arrays(layer)
+            if arrays is None:
+                continue
+            mean_data, g, s = arrays
+
+            axis = None
+            if per_frame:
+                candidate = self.frame_context.axis
+                if (
+                    g.ndim >= 3
+                    and 0 <= candidate < g.ndim - 2
+                    and g.shape[candidate] > 1
+                ):
+                    axis = candidate
+
+            if axis is None:
+                center = self._compute_center_from_samples(
+                    mean_data.ravel(), g.ravel(), s.ravel()
+                )
+                if center is not None:
+                    rows.append(self._center_row(0, layer.name, center))
+                continue
+
+            for frame in range(g.shape[axis]):
+                center = self._compute_center_from_samples(
+                    np.take(mean_data, frame, axis=axis).ravel(),
+                    np.take(g, frame, axis=axis).ravel(),
+                    np.take(s, frame, axis=axis).ravel(),
+                )
+                if center is not None:
+                    rows.append(self._center_row(frame, layer.name, center))
+
+        rows.sort(key=lambda row: (row["Frame"], str(row["Name"])))
+        return rows
+
+    def _export_phasor_center_statistics(self):
+        """Export phasor centers as CSV, pooled or one row per timepoint."""
+        per_frame = False
+        if self.frame_context.available_axes():
+            menu = QMenu(self)
+            pooled_action = menu.addAction("All timepoints pooled")
+            per_frame_action = menu.addAction("Per timepoint")
+            button = self._phasor_center_stats_widget.export_csv_button
+            chosen = menu.exec_(button.mapToGlobal(button.rect().bottomLeft()))
+            if chosen is None:
+                return
+            per_frame = chosen is per_frame_action
+            del pooled_action
+
+        rows = self._phasor_center_statistics_rows(per_frame)
+        if not rows:
+            notifications.show_warning("No phasor centers to export.")
+            return
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self, "Export Phasor Centers as CSV", "", "CSV Files (*.csv)"
+        )
+        if not file_path:
+            return
+        if not file_path.endswith('.csv'):
+            file_path += '.csv'
+
+        write_rows_to_csv(file_path, rows)
+        notifications.show_info(f"Phasor centers saved to {file_path}")
 
     def _update_phasor_centers(self):
         """Calculate and plot phasor center dots on the axes."""
@@ -6198,6 +6560,7 @@ class PlotterWidget(QWidget):
             self._g_original_array = None
             self._s_original_array = None
             self._harmonics_array = None
+            self._refresh_timelapse_controls()
             for artist in self.canvas_widget.artists.values():
                 artist._remove_artists()
                 # ``_remove_artists`` empties ``_mpl_artists`` but leaves
@@ -6258,6 +6621,7 @@ class PlotterWidget(QWidget):
 
         self._initialize_plot_settings_in_metadata(layer)
         self._restore_plot_settings_from_metadata()
+        self._refresh_timelapse_controls()
 
         if sync_frequency:
             self._sync_frequency_inputs_from_metadata()
@@ -6327,6 +6691,7 @@ class PlotterWidget(QWidget):
             selected_layers = self.get_selected_layers()
             self._update_grid_view(selected_layers)
             self._update_contour_controls_visibility()
+            self._refresh_timelapse_controls()
 
             layer_name = self.get_primary_layer_name()
             if not layer_name:
@@ -7263,6 +7628,133 @@ class PlotterWidget(QWidget):
             return g, s, valid
         return g, s
 
+    def _iter_layer_gs_arrays(self):
+        """Yield ``(g, s, frame_axis)`` for every selected layer.
+
+        ``frame_axis`` is None for layers with no stack axis (a plain 2-D
+        layer selected alongside a stack), which contribute all their samples
+        to every frame — matching what :meth:`get_merged_features` does.
+        """
+        for layer in self.get_selected_layers():
+            arrays = self._get_layer_phasor_arrays(layer)
+            if arrays is None:
+                continue
+            _mean, g, s = arrays
+            yield g, s, self.frame_context.axis_for_shape(g.shape)
+
+    @staticmethod
+    def _finite_gs(g, s):
+        """Return the flattened, finite ``(g, s)`` pairs of two arrays."""
+        g_flat = g.ravel()
+        s_flat = s.ravel()
+        valid = np.isfinite(g_flat) & np.isfinite(s_flat)
+        return g_flat[valid], s_flat[valid]
+
+    def _frame_histogram_reference(self):
+        """Bin edges and count range shared by every frame of the stack.
+
+        Left to itself, the 2D histogram re-bins and re-normalises on each
+        frame, so a given colour — and the colorbar beside it — stands for a
+        different number of pixels at every timepoint. Deriving one bin grid
+        and one count range from the whole acquisition (across every selected
+        layer) keeps frames directly comparable, which is the point of
+        stepping through them.
+
+        The result is cached; it only depends on the selected layers, the
+        harmonic, the bin count and the frame axis.
+
+        Returns
+        -------
+        dict or None
+            ``{"bins": [x_edges, y_edges], "vmin": float, "vmax": float}``,
+            or None when pooled or when there is nothing to compute.
+        """
+        ctx = self.frame_context
+        if not ctx.is_per_frame:
+            return None
+
+        selected_layers = self.get_selected_layers()
+        if not selected_layers:
+            return None
+
+        cache_key = (
+            tuple(layer.name for layer in selected_layers),
+            self.harmonic,
+            self.histogram_bins,
+            ctx.axis,
+            ctx.n_frames,
+        )
+        if self._frame_histogram_cache_key == cache_key:
+            return self._frame_histogram_cache
+
+        per_layer = list(self._iter_layer_gs_arrays())
+        if not per_layer:
+            return None
+
+        pooled_g = []
+        pooled_s = []
+        for g, s, _axis in per_layer:
+            layer_g, layer_s = self._finite_gs(g, s)
+            pooled_g.append(layer_g)
+            pooled_s.append(layer_s)
+
+        pooled_g = np.concatenate(pooled_g)
+        pooled_s = np.concatenate(pooled_s)
+        if pooled_g.size == 0:
+            return None
+
+        # Bin over the pooled cloud so the grid matches what "All timepoints"
+        # would draw, and stays put while stepping through frames.
+        _counts, x_edges, y_edges = np.histogram2d(
+            pooled_g, pooled_s, bins=self.histogram_bins
+        )
+
+        cmin = 1
+        vmax = 0.0
+        for frame in range(max(1, ctx.n_frames)):
+            frame_g = []
+            frame_s = []
+            for g, s, axis in per_layer:
+                if axis is None:
+                    layer_g, layer_s = self._finite_gs(g, s)
+                else:
+                    index = min(frame, g.shape[axis] - 1)
+                    layer_g, layer_s = self._finite_gs(
+                        np.take(g, index, axis=axis),
+                        np.take(s, index, axis=axis),
+                    )
+                frame_g.append(layer_g)
+                frame_s.append(layer_s)
+
+            frame_g = np.concatenate(frame_g)
+            frame_s = np.concatenate(frame_s)
+            if frame_g.size == 0:
+                continue
+
+            counts, _, _ = np.histogram2d(
+                frame_g, frame_s, bins=[x_edges, y_edges]
+            )
+            visible = counts[counts >= cmin]
+            if visible.size:
+                vmax = max(vmax, float(visible.max()))
+
+        if vmax <= 0:
+            return None
+
+        reference = {
+            "bins": [x_edges, y_edges],
+            "vmin": float(cmin),
+            "vmax": vmax,
+        }
+        self._frame_histogram_cache_key = cache_key
+        self._frame_histogram_cache = reference
+        return reference
+
+    def _invalidate_frame_histogram_cache(self):
+        """Drop the cached per-frame bin grid and count range."""
+        self._frame_histogram_cache = None
+        self._frame_histogram_cache_key = None
+
     def _invalidate_features_cache(self):
         """Invalidate the merged-features cache.
 
@@ -7273,6 +7765,7 @@ class PlotterWidget(QWidget):
         """
         self._features_cache = None
         self._features_cache_key = None
+        self._invalidate_frame_histogram_cache()
 
     def get_features(self):
         """Get the G and S features for the selected harmonic.
@@ -7311,6 +7804,7 @@ class PlotterWidget(QWidget):
         cache_key = (
             tuple(layer.name for layer in selected_layers),
             self.harmonic,
+            self.frame_context.state_key(),
         )
         if (
             self._features_cache is not None
@@ -7351,6 +7845,7 @@ class PlotterWidget(QWidget):
             g_flat = g.ravel()
             s_flat = s.ravel()
             valid = (~np.isnan(g_flat)) & (~np.isnan(s_flat))
+            valid = self.frame_context.filter_valid(valid, g.shape)
 
             all_g.append(g_flat[valid])
             all_s.append(s_flat[valid])
@@ -7750,12 +8245,40 @@ class PlotterWidget(QWidget):
             plot_data = np.column_stack((x_data, y_data))
             histogram_artist = self.canvas_widget.artists['HISTOGRAM2D']
 
+            # In per-frame mode pin the bin grid and the colour scale to the
+            # whole acquisition, so a colour means the same pixel count on
+            # every frame instead of being rescaled frame by frame.
+            frame_reference = self._frame_histogram_reference()
+            if frame_reference is None:
+                histogram_artist._napari_phasors_fixed_counts_range = None
+                bins_value = self.histogram_bins
+                bins_key = ('count', self.histogram_bins)
+            else:
+                histogram_artist._napari_phasors_fixed_counts_range = (
+                    frame_reference["vmin"],
+                    frame_reference["vmax"],
+                )
+                bins_value = frame_reference["bins"]
+                x_edges, y_edges = bins_value
+                bins_key = (
+                    'edges',
+                    len(x_edges),
+                    len(y_edges),
+                    float(x_edges[0]),
+                    float(x_edges[-1]),
+                    float(y_edges[0]),
+                    float(y_edges[-1]),
+                )
+
+            # ``data`` has to be assigned before ``bins``: biaplotter's bins
+            # setter refreshes immediately and would trip over an artist that
+            # has no data yet.
             histogram_artist.data = plot_data
             histogram_artist.cmin = 1
 
-            if self._last_histogram_bins != self.histogram_bins:
-                histogram_artist.bins = self.histogram_bins
-                self._last_histogram_bins = self.histogram_bins
+            if self._last_histogram_bins != bins_key:
+                histogram_artist.bins = bins_value
+                self._last_histogram_bins = bins_key
 
             histogram_is_solid = self._histogram_style == 'solid'
             if histogram_is_solid:
@@ -7910,6 +8433,7 @@ class PlotterWidget(QWidget):
             g_flat = g.ravel()
             s_flat = s.ravel()
             valid = (~np.isnan(g_flat)) & (~np.isnan(s_flat))
+            valid = self.frame_context.filter_valid(valid, g.shape)
             if not np.any(valid):
                 continue
 
@@ -8390,12 +8914,15 @@ class PlotterWidget(QWidget):
             if x_data is None or y_data is None:
                 features = self.get_features()
                 if features is None:
+                    self._blank_plot_for_empty_frame()
                     return
                 x_data, y_data = features
 
             if len(x_data) == 0 or len(y_data) == 0:
+                self._blank_plot_for_empty_frame()
                 return
 
+            self._unblank_plot_after_empty_frame()
             self._set_active_artist_and_plot(
                 self.plot_type, x_data, y_data, selection_id_data
             )
@@ -8416,6 +8943,32 @@ class PlotterWidget(QWidget):
                 self.canvas_widget.figure.canvas.draw_idle()
         finally:
             self._updating_plot = False
+
+    def _blank_plot_for_empty_frame(self):
+        """Blank the phasor plot when the displayed frame has no samples.
+
+        Only applies in per-frame mode. Without it, a frame that is entirely
+        masked or thresholded out would keep showing the previous frame's
+        cloud while stepping or playing through a time-lapse.
+        """
+        if not self.frame_context.is_per_frame:
+            return
+        for artist in getattr(self.canvas_widget, 'artists', {}).values():
+            if hasattr(artist, 'visible'):
+                artist.visible = False
+        self._clear_contour_plot()
+        self._frame_plot_blanked = True
+        self.canvas_widget.figure.canvas.draw_idle()
+
+    def _unblank_plot_after_empty_frame(self):
+        """Re-show the artist hidden by a previous empty frame."""
+        if not getattr(self, '_frame_plot_blanked', False):
+            return
+        self._frame_plot_blanked = False
+        active = getattr(self.canvas_widget, 'active_artist', None)
+        for artist in getattr(self.canvas_widget, 'artists', {}).values():
+            if hasattr(artist, 'visible'):
+                artist.visible = artist is active
 
     def refresh_current_plot(self):
         """Refresh the current plot with existing data."""
@@ -8553,6 +9106,8 @@ class PlotterWidget(QWidget):
             self._bins_timer.stop()
         with contextlib.suppress(AttributeError):
             self._resize_canvas_timer.stop()
+        with contextlib.suppress(AttributeError, RuntimeError):
+            self.frame_context.disconnect_viewer()
 
         # Disconnect timer callbacks to avoid queued invocations during teardown.
         with contextlib.suppress(TypeError, ValueError, AttributeError):

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -5915,7 +5915,7 @@ class PlotterWidget(QWidget):
         layer_name = (
             self.image_layer_with_phasor_features_combobox.currentText()
         )
-        if layer_name == "":
+        if layer_name == "" or layer_name not in self.viewer.layers:
             return None
         layer = self.viewer.layers[layer_name]
         if "settings" in layer.metadata:
@@ -5933,7 +5933,7 @@ class PlotterWidget(QWidget):
         layer_name = (
             self.image_layer_with_phasor_features_combobox.currentText()
         )
-        if not layer_name:
+        if not layer_name or layer_name not in self.viewer.layers:
             self._broadcast_frequency_value_across_tabs("")
             return
 
@@ -5962,7 +5962,7 @@ class PlotterWidget(QWidget):
                 layer_name = (
                     self.image_layer_with_phasor_features_combobox.currentText()
                 )
-                if layer_name:
+                if layer_name and layer_name in self.viewer.layers:
                     layer = self.viewer.layers[layer_name]
                     update_frequency_in_metadata(layer, freq_val)
         except (ValueError, TypeError):

--- a/src/napari_phasors/selection_tab.py
+++ b/src/napari_phasors/selection_tab.py
@@ -43,6 +43,7 @@ from superqt import QToggleSwitch
 
 from ._utils import (
     CurrentPageStackedWidget,
+    active_selection_region,
     analysis_section_stylesheet,
     colormap_to_dict,
     make_section,
@@ -626,7 +627,7 @@ class SelectionWidget(QWidget):
                     g = g_array
                     s = s_array
 
-                valid = np.isfinite(g.ravel()) & np.isfinite(s.ravel())
+                valid = self._frame_valid_mask(g, s)
                 selection_data = selection_map.ravel()[valid]
                 all_selection_data.append(selection_data)
 
@@ -674,6 +675,73 @@ class SelectionWidget(QWidget):
             ) or candidate_name not in combobox_selections:
                 return candidate_name
             counter += 1
+
+    def _frame_context(self):
+        """Return the plotter's time-lapse frame context, if available."""
+        return getattr(self.parent_widget, 'frame_context', None)
+
+    def _frame_valid_mask(self, g, s):
+        """Return the flat finite-sample mask used by the phasor plot.
+
+        In per-frame mode this is restricted to the displayed frame, exactly
+        as :meth:`PlotterWidget.get_merged_features` does, so the selection
+        array stays aligned with the plotted points.
+        """
+        valid = np.isfinite(g.ravel()) & np.isfinite(s.ravel())
+        frame_context = self._frame_context()
+        if frame_context is None:
+            return valid
+        return frame_context.filter_valid(valid, g.shape)
+
+    def _extend_selection_to_all_frames(
+        self, selection_map_flat, g, s, layer_selection
+    ):
+        """Apply the region drawn in the phasor plot to every frame.
+
+        Only relevant in per-frame mode: the class value the user just
+        assigned is written to every pixel of the stack whose phasor
+        coordinates fall inside the drawn shape. In pooled mode (or when the
+        drawn geometry could not be captured, e.g. a selection restored from
+        metadata) this is a no-op and the current frame keeps whatever
+        :meth:`manual_selection_changed` already wrote.
+
+        Parameters
+        ----------
+        selection_map_flat : np.ndarray
+            Flat view of the layer's selection map; modified in place.
+        g, s : np.ndarray
+            Phasor coordinates of the layer at the current harmonic.
+        layer_selection : np.ndarray or None
+            Per-point class values just applied to the current frame, or None
+            when the selection was cleared.
+        """
+        frame_context = self._frame_context()
+        if frame_context is None or not frame_context.is_per_frame:
+            return
+        if layer_selection is None or not np.any(layer_selection):
+            return
+
+        region_contains = active_selection_region(
+            self.parent_widget.canvas_widget
+        )
+        if region_contains is None:
+            return
+
+        g_flat = g.ravel()
+        s_flat = s.ravel()
+        finite = np.isfinite(g_flat) & np.isfinite(s_flat)
+        if not np.any(finite):
+            return
+
+        inside = region_contains(
+            np.column_stack((g_flat[finite], s_flat[finite]))
+        )
+        if inside is None or not np.any(inside):
+            return
+
+        class_value = int(np.max(layer_selection))
+        target = np.flatnonzero(finite)[inside]
+        selection_map_flat[target] = class_value
 
     def manual_selection_changed(self, manual_selection):
         """Update the manual selection in the layer metadata."""
@@ -746,7 +814,7 @@ class SelectionWidget(QWidget):
                         g = g_array
                         s = s_array
 
-                    valid = np.isfinite(g.ravel()) & np.isfinite(s.ravel())
+                    valid = self._frame_valid_mask(g, s)
                     layer_valid_counts.append(np.sum(valid))
                 else:
                     layer_valid_counts.append(0)
@@ -817,12 +885,19 @@ class SelectionWidget(QWidget):
                 g = g_array
                 s = s_array
 
-            valid_pixels_mask = np.isfinite(g.ravel()) & np.isfinite(s.ravel())
+            valid_pixels_mask = self._frame_valid_mask(g, s)
 
             if layer_selection is None:
                 selection_map_flat[valid_pixels_mask] = 0
             else:
                 selection_map_flat[valid_pixels_mask] = layer_selection
+
+            # A region drawn in the phasor plot is a region in G/S space, so
+            # it applies to the whole acquisition even when only one frame is
+            # displayed. Replay the drawn shape against every timepoint.
+            self._extend_selection_to_all_frames(
+                selection_map_flat, g, s, layer_selection
+            )
 
             if "settings" not in layer.metadata:
                 layer.metadata["settings"] = {}


### PR DESCRIPTION
## Summary

Adds time-lapse support to the phasor plot: the phasor plot, 1-D histogram, and statistics table can follow a single timepoint of a stack (instead of always pooling every timepoint), synchronized bidirectionally with napari's own dimension slider — including its play button. Adds GIF animation export and pooled/per-timepoint statistics export.

- **Frame following** — the phasor plot, histogram, and statistics table can switch from `All timepoints` (pooled, unchanged default behavior) to `Current timepoint`, showing only the frame napari is displaying.
- **Synced with the viewer, not duplicated** — no separate play/slider/fps controls in the plugin; napari's dimension slider is the single source of truth in both directions (`FrameContext` in `_timelapse.py`).
- **Fixed colour scale across frames** — the 2D histogram's bin grid and colour range are computed once over the whole acquisition (across all selected layers), not re-normalized per frame, so a colour means the same pixel count at every timepoint and the colorbar stops jumping around.
- **Statistics table lists every frame** — in `Current timepoint` mode the table shows one row per timepoint (per layer), with the displayed frame bolded/highlighted and auto-scrolled into view.
- **Selections apply to the whole acquisition** — a lasso/rectangle/ellipse drawn on one frame is a region in G/S space, so it's applied to every timepoint, not just the visible one.
- **Export** — animated GIF of the phasor plot and/or histogram; CSV export of statistics and phasor centers as pooled or per-timepoint.
- Zero UI change for plain 2D data — the controls are hidden entirely when the selection has no non-spatial axis.

## What changed

### New module: `src/napari_phasors/_timelapse.py`
- `FrameContext` — owns display mode (pooled/current), frame axis, and index; bidirectionally synced with `viewer.dims.current_step`.
- `TimelapseControlBar` — minimal UI: mode selector, axis picker (only shown with >1 stack axis), export button. Hidden when there's no stack axis.
- `AnimationExportDialog`, `export_animation`, `figure_to_rgb`, `combine_frames` — GIF export pipeline (phasor plot and/or histogram, side by side).
- `build_frame_statistics_rows`, `slice_datasets`, `stack_axes` — shared helpers used by the plotter and analysis tabs.

### `src/napari_phasors/plotter.py`
- Wires `FrameContext`/`TimelapseControlBar` into `PlotterWidget`; frame mode/axis persist in layer metadata (like other plot settings), frame index does not (comes from the viewer).
- `get_merged_features`, `_get_layer_phasor_samples`, `_get_selected_layer_feature_map` apply the frame mask; features cache key includes frame state.
- `_frame_histogram_reference()` computes a fixed bin grid + colour range across the whole acquisition and all selected layers, cached and invalidated on layer/harmonic/bin changes.
- Two biaplotter monkey-patches (in `_utils.py`, applied here): fixed histogram colour normalization, and capturing selector geometry so a drawn region can be replayed against every frame.
- Blanks the plot instead of showing a stale frame when the current timepoint has no valid pixels (e.g. fully masked/thresholded).

### `src/napari_phasors/_utils.py`
- `compute_dataset_statistics`, `pooled_histogram_bins`, `write_rows_to_csv` — shared statistics/export helpers.
- `StatisticsTableWidget.update_frame_statistics` — per-frame row layout with current-frame highlighting.
- `StatisticsDockWidget` — CSV export menu: current view / pooled / per-timepoint.
- `patch_biaplotter_capture_selection_geometry`, `patch_biaplotter_fixed_histogram_range`, `active_selection_region` — biaplotter interop patches.

### `phasor_mapping_tab.py`, `components_tab.py`, `fret_tab.py`
- Histogram data is sliced to the current frame before being fed to `HistogramWidget`; range sliders keep using the pooled extent so contrast limits don't jump during playback.
- Each tab exposes `refresh_for_frame_change()`, called for every populated tab (not just the focused one) when the frame changes.

### `selection_tab.py`
- Selection arrays are filtered with the same frame mask as the plotted features, so they stay length-matched.
- A drawn selection region is replayed against the pooled G/S of every frame, so manual selections apply across the whole acquisition.

### Docs
- New `docs/guides/timelapse.md`; cross-links added to `histogram_statistics.md` and `exporting.md`; `docs/api/index.md` and `docs/_toc.yml` updated; README feature bullet added.

### Tests
- New `src/napari_phasors/_tests/test_timelapse.py` — frame context/axis detection, dims sync (both directions), feature/selection slicing and caching, histogram/statistics following the frame, fixed colour scale (single- and multi-layer, log scale), per-frame table highlighting, CSV/GIF export, control bar visibility for 2D data.
