### PR TITLE
Invalidate preview cache for signal plot error handling

### DIFF
--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -2596,6 +2596,14 @@ def test_phasor_output_shape_from_signal():
         _phasor_output_shape_from_signal(fbd, ".fbd", {"phasor_axis": 10})
         is None
     )
+    # Multi-channel path with no 'H' axis falls back to axis 0.
+    fbd_no_h = xr.DataArray(np.zeros((2, 6, 7)), dims=("C", "Y", "X"))
+    assert _phasor_output_shape_from_signal(fbd_no_h, ".fbd", {}) == (7,)
+
+    # A signal without a ``.shape`` attribute is coerced via ``np.asarray``.
+    assert (
+        _phasor_output_shape_from_signal([[1, 2], [3, 4]], ".sdt", {}) is None
+    )
 
 
 def test_estimate_ptu_output_shape():
@@ -2606,8 +2614,29 @@ def test_estimate_ptu_output_shape():
     assert _estimate_ptu_output_shape(path, {"channel": 0}) == (256, 256)
     # phasor_axis override drops that axis (plus the iterated channel axis).
     assert _estimate_ptu_output_shape(path, {"phasor_axis": 0}) == (256, 132)
+    # A non-numeric dtime option is treated as 0.
+    assert _estimate_ptu_output_shape(path, {"dtime": "abc"}) == (256, 256)
     # Unreadable file -> None (caller falls back).
     assert _estimate_ptu_output_shape("/no/such/file.ptu", {}) is None
+
+
+def test_estimate_output_shape_from_options_ptu():
+    """The generic estimator uses the cheap PTU path and applies n_files."""
+    from napari_phasors._widget import _estimate_output_shape_from_options
+
+    path = get_test_file_path("test_file.ptu")
+    assert _estimate_output_shape_from_options(path, {}, [1], n_files=1) == (
+        256,
+        256,
+    )
+    # Stacking multiple files prepends the file axis.
+    assert _estimate_output_shape_from_options(path, {}, [1], n_files=3) == (
+        3,
+        256,
+        256,
+    )
+    # Unreadable PTU -> None.
+    assert _estimate_output_shape_from_options("/no/such.ptu", {}, [1]) is None
 
 
 def test_preview_signal_cache(make_viewer_model, qtbot):
@@ -2746,3 +2775,148 @@ def test_sdt_preview_signature(make_viewer_model, qtbot):
     widget.index.setText("1")
     assert widget._preview_signature() != baseline
     assert widget._extra_preview_signature() == ("index", "1")
+
+
+def test_preview_shape_and_labels_without_dims(make_viewer_model, qtbot):
+    """The axis selector derives labels for signals lacking dimension names."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    widget._compute_preview_signal_data = lambda: np.zeros((30, 40, 50))
+    widget._preview_signal_cache_key = None
+    shape, labels = widget._preview_shape_and_labels()
+    assert shape == (30, 40, 50)
+    assert len(labels) == 3
+
+
+def test_preview_signature_exception_falls_back(make_viewer_model, qtbot):
+    """A failing signature falls back to computing the preview directly."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    calls = {"n": 0}
+
+    def compute():
+        calls["n"] += 1
+        return np.zeros((2, 2))
+
+    def broken_signature():
+        raise RuntimeError("cannot build signature")
+
+    widget._compute_preview_signal_data = compute
+    widget._preview_signature = broken_signature
+    result = widget._get_preview_signal_data()
+    assert result.shape == (2, 2)
+    assert calls["n"] == 1
+
+
+def test_get_channel_preview_signal_take_fallback(make_viewer_model, qtbot):
+    """When ``isel`` fails, the channel is extracted with ``np.take``."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    class _NoIselSignal:
+        def __init__(self, arr, dims):
+            self._arr = np.asarray(arr)
+            self.dims = dims
+
+        @property
+        def shape(self):
+            return self._arr.shape
+
+        def isel(self, *args, **kwargs):
+            raise RuntimeError("isel unavailable")
+
+        def __array__(self, dtype=None):
+            return np.asarray(self._arr, dtype=dtype)
+
+    signal = _NoIselSignal(
+        np.arange(2 * 3 * 4).reshape(2, 3, 4), ("C", "Y", "X")
+    )
+    widget._compute_preview_signal_data = lambda: signal
+    widget._preview_signal_cache_key = None
+    got = widget._get_channel_preview_signal(1)
+    np.testing.assert_array_equal(np.asarray(got), np.asarray(signal)[1])
+
+
+def test_update_shape_preview_none_and_multifile(make_viewer_model, qtbot):
+    """Shape label handles an unknown shape and multi-file stacking."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    # Unknown base shape -> label reports N/A.
+    widget._estimate_base_output_shape = lambda: None
+    widget._update_shape_preview()
+    assert "N/A" in widget.shape_preview_label.text()
+
+    # Multiple stacked files prepend the file-count axis.
+    widget._estimate_base_output_shape = lambda: (512, 512)
+    widget._multi_file_paths = ["a.lsm", "b.lsm", "c.lsm"]
+    widget._update_shape_preview()
+    assert "(3, 512, 512)" in widget.shape_preview_label.text()
+
+
+def test_ptu_dtime_option_edge_cases(make_viewer_model, qtbot):
+    """dtime parsing handles empty and non-numeric input, defaulting to 0."""
+    viewer = make_viewer_model()
+    widget = PtuWidget(viewer, path=get_test_file_path("test_file.ptu"))
+
+    widget.dtime.setText("")
+    assert widget._dtime_option() == 0
+    widget.dtime.setText("not-a-number")
+    assert widget._dtime_option() == 0
+
+    # The metadata-based axis selector shape is exposed for the phasor axis.
+    widget.dtime.setText("0")
+    assert widget._preview_shape_and_labels()[1] == ("Y", "X", "C", "H")
+
+
+def test_ptu_multifile_preview_and_error(make_viewer_model, qtbot):
+    """PTU previews average grouped files and handle decode errors."""
+    viewer = make_viewer_model()
+    path = get_test_file_path("test_file.ptu")
+    widget = PtuWidget(viewer, path=path)
+
+    # Averaging across a group of files (single-channel plot path).
+    widget.reader_options["channel"] = 0
+    widget._grouped_file_paths = [path, path]
+    widget._preview_signal_cache_key = None
+    averaged = widget._get_preview_signal_data()
+    assert averaged is not None
+    single = widget._decode_preview_histogram()[0]
+    np.testing.assert_allclose(np.asarray(averaged), np.asarray(single))
+
+    # A multi-file stack uses the same averaging path.
+    widget._grouped_file_paths = None
+    widget._multi_file_paths = [path, path]
+    widget._preview_signal_cache_key = None
+    assert widget._get_preview_signal_data() is not None
+
+    # An out-of-range channel keeps the full (unindexed) histogram.
+    widget._multi_file_paths = None
+    widget._grouped_file_paths = [path, path]
+    widget.reader_options["channel"] = 999
+    widget._preview_signal_cache_key = None
+    out_of_range = widget._get_preview_signal_data()
+    assert out_of_range.shape == widget._decode_preview_histogram().shape
+
+    # Histograms of mismatched length fall back to the first signal.
+    widget.reader_options["channel"] = None
+    widget._preview_signal_cache_key = None
+    with patch.object(
+        widget,
+        "_decode_preview_histogram",
+        side_effect=[np.zeros((1, 64)), np.zeros((1, 32))],
+    ):
+        mismatched = widget._get_preview_signal_data()
+    assert mismatched.shape == (1, 64)
+
+    # A decode error is reported and yields no signal.
+    def boom(*args, **kwargs):
+        raise RuntimeError("decode failed")
+
+    widget._decode_preview_histogram = boom
+    widget._preview_signal_cache_key = None
+    with patch("napari_phasors._widget.show_error") as mock_error:
+        assert widget._get_preview_signal_data() is None
+        assert mock_error.called

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -929,6 +929,10 @@ def test_signal_plot_error_handling(make_viewer_model, qtbot):
         ),
         patch("napari_phasors._widget.show_error"),
     ):
+        # Invalidate the preview cache so the failing decode is actually
+        # exercised (a cached signal from construction would otherwise be
+        # reused because the options are unchanged).
+        widget._preview_signal_cache_key = None
         # Should not raise; the plot must end up with no data lines.
         widget._update_signal_plot()
         assert len(widget.ax.get_lines()) == 0

--- a/src/napari_phasors/_tests/test_widget.py
+++ b/src/napari_phasors/_tests/test_widget.py
@@ -33,6 +33,9 @@ from napari_phasors._widget import (
     PtuWidget,
     SdtWidget,
     WriterWidget,
+    _estimate_ptu_output_shape,
+    _phasor_output_shape_from_signal,
+    _reduce_ptu_signal_dims,
 )
 
 TEST_FORMATS = [
@@ -2504,3 +2507,242 @@ def test_fbd_widget_stack_z_spacing_and_harmonic_edits(
         widget.harmonic_start_edit.setText("abc")
         widget._on_harmonic_edit_changed()
         assert len(widget.harmonics) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for the preview-signal caching and shape-estimation optimizations.
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_ptu_signal_dims():
+    """PTU signal dims are reduced from metadata without decoding."""
+    shape = (5, 256, 256, 2, 133)
+    dims = ("T", "Y", "X", "C", "H")
+    bins = 132
+
+    # channel=None keeps the C axis; dtime=0 -> H is the number of period bins.
+    assert _reduce_ptu_signal_dims(shape, dims, bins, None, 0) == (
+        (256, 256, 2, 132),
+        ("Y", "X", "C", "H"),
+    )
+    # A selected channel drops the C axis.
+    assert _reduce_ptu_signal_dims(shape, dims, bins, 0, 0) == (
+        (256, 256, 132),
+        ("Y", "X", "H"),
+    )
+    # dtime > 0 sets the histogram length, clamped to the number of bins.
+    assert _reduce_ptu_signal_dims(shape, dims, bins, 0, 64)[0] == (
+        256,
+        256,
+        64,
+    )
+    assert _reduce_ptu_signal_dims(shape, dims, bins, 0, 1000)[0] == (
+        256,
+        256,
+        132,
+    )
+    # dtime < 0 integrates the delay-time axis away.
+    assert _reduce_ptu_signal_dims(shape, dims, bins, 0, -1) == (
+        (256, 256),
+        ("Y", "X"),
+    )
+
+
+def test_phasor_output_shape_from_signal():
+    """Output shape is derived from a decoded signal like the reader would."""
+    # Guard cases return None so the caller falls back to the reader.
+    assert _phasor_output_shape_from_signal(None, ".lsm", {}) is None
+    assert _phasor_output_shape_from_signal(np.array(3.0), ".lsm", {}) is None
+    # No dimension labels + no override + not TIFF -> cannot derive.
+    assert (
+        _phasor_output_shape_from_signal(np.zeros((4, 5)), ".sdt", {}) is None
+    )
+
+    # Plain TIFF uses axis 0 by convention even without dims.
+    assert _phasor_output_shape_from_signal(
+        np.zeros((10, 20, 30)), ".tif", {}
+    ) == (20, 30)
+
+    # Single-layer path: histogram axis 'H' is collapsed.
+    sdt = xr.DataArray(np.zeros((7, 8, 9)), dims=("Y", "X", "H"))
+    assert _phasor_output_shape_from_signal(sdt, ".sdt", {}) == (7, 8)
+
+    # Single-layer path: spectral 'C' axis is collapsed (LSM/CZI, iter None).
+    lsm = xr.DataArray(np.zeros((30, 40, 50)), dims=("C", "Y", "X"))
+    assert _phasor_output_shape_from_signal(lsm, ".lsm", {}) == (40, 50)
+    # phasor_axis override selects the collapsed axis.
+    assert _phasor_output_shape_from_signal(
+        lsm, ".lsm", {"phasor_axis": 1}
+    ) == (30, 50)
+    # An out-of-range override cannot be derived.
+    assert (
+        _phasor_output_shape_from_signal(lsm, ".lsm", {"phasor_axis": 9})
+        is None
+    )
+
+    # Fallback to axis 0 when neither 'H' nor 'C' is present.
+    misc = xr.DataArray(np.zeros((3, 4)), dims=("A", "B"))
+    assert _phasor_output_shape_from_signal(misc, ".bin", {}) == (4,)
+
+    # Multi-channel path: iteration axis 'C' and histogram 'H' both dropped.
+    fbd = xr.DataArray(np.zeros((2, 6, 7, 8)), dims=("C", "Y", "X", "H"))
+    assert _phasor_output_shape_from_signal(fbd, ".fbd", {}) == (6, 7)
+    # Override selects the histogram axis within the per-channel signal.
+    assert _phasor_output_shape_from_signal(
+        fbd, ".fbd", {"phasor_axis": 0}
+    ) == (7, 8)
+    # An out-of-range override in the multi-channel path returns None.
+    assert (
+        _phasor_output_shape_from_signal(fbd, ".fbd", {"phasor_axis": 10})
+        is None
+    )
+
+
+def test_estimate_ptu_output_shape():
+    """PTU output shape is estimated from metadata, with a safe fallback."""
+    path = get_test_file_path("test_file.ptu")
+
+    assert _estimate_ptu_output_shape(path, {}) == (256, 256)
+    assert _estimate_ptu_output_shape(path, {"channel": 0}) == (256, 256)
+    # phasor_axis override drops that axis (plus the iterated channel axis).
+    assert _estimate_ptu_output_shape(path, {"phasor_axis": 0}) == (256, 132)
+    # Unreadable file -> None (caller falls back).
+    assert _estimate_ptu_output_shape("/no/such/file.ptu", {}) is None
+
+
+def test_preview_signal_cache(make_viewer_model, qtbot):
+    """The preview signal is decoded once and reused across consumers."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    calls = {"n": 0}
+
+    def counting():
+        calls["n"] += 1
+        return np.zeros((3, 3))
+
+    widget._compute_preview_signal_data = counting
+    widget._preview_signal_cache_key = None
+
+    first = widget._get_preview_signal_data()
+    second = widget._get_preview_signal_data()
+    assert calls["n"] == 1  # second call served from cache
+    assert first is second
+
+    # Changing an option that affects the decoded signal invalidates the cache.
+    widget.reader_options["frame"] = 0
+    widget._get_preview_signal_data()
+    assert calls["n"] == 2
+
+    # 'phasor_axis' does not affect the decoded signal, so it is excluded from
+    # the cache key and must not trigger a re-decode.
+    widget.reader_options["phasor_axis"] = 1
+    widget._get_preview_signal_data()
+    assert calls["n"] == 2
+
+
+def test_get_channel_preview_signal_slice_and_fallback(
+    make_viewer_model, qtbot
+):
+    """Multi-channel preview slices one decode; falls back without dims."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    # Slice path: an all-channel signal with a 'C' axis is sliced per channel.
+    all_channels = xr.DataArray(
+        np.arange(2 * 4 * 5).reshape(2, 4, 5), dims=("C", "Y", "X")
+    )
+    widget._compute_preview_signal_data = lambda: all_channels
+    widget._preview_signal_cache_key = None
+    sliced = widget._get_channel_preview_signal(1)
+    np.testing.assert_array_equal(
+        np.asarray(sliced), np.asarray(all_channels)[1]
+    )
+    # The channel option is restored after slicing.
+    assert widget.reader_options.get("channel") is None
+
+    # Fallback path: without dims the requested channel is decoded directly.
+    seen = {}
+
+    def compute_nodims():
+        seen["channel"] = widget.reader_options.get("channel")
+        return np.zeros((4, 5))
+
+    widget._compute_preview_signal_data = compute_nodims
+    widget._preview_signal_cache_key = None
+    widget._get_channel_preview_signal(1)
+    assert seen["channel"] == 1
+
+
+def test_estimate_base_output_shape_derive_and_fallback(
+    make_viewer_model, qtbot
+):
+    """Base shape derives from the signal, falling back to the reader."""
+    viewer = make_viewer_model()
+    widget = LsmWidget(viewer, path=get_test_file_path("test_file.lsm"))
+
+    # Derived directly from the decoded (dims-carrying) preview signal.
+    assert widget._estimate_base_output_shape() == (512, 512)
+
+    # A dims-less signal cannot be derived, so the reader fallback is used and
+    # still returns the correct shape.
+    widget._compute_preview_signal_data = lambda: np.zeros((30, 512, 512))
+    widget._preview_signal_cache_key = None
+    assert widget._estimate_base_output_shape() == (512, 512)
+
+
+def test_ptu_preview_histogram_cache(make_viewer_model, qtbot):
+    """PTU previews use a cheap cached histogram and metadata-based shape."""
+    viewer = make_viewer_model()
+    widget = PtuWidget(viewer, path=get_test_file_path("test_file.ptu"))
+
+    # The histogram is cached (same object) until an option changes it.
+    hist_a = widget._decode_preview_histogram()
+    hist_b = widget._decode_preview_histogram()
+    assert hist_a is hist_b
+
+    # Changing dtime invalidates the histogram cache and limits the bins.
+    widget.dtime.setText("64")
+    hist_c = widget._decode_preview_histogram()
+    assert hist_c is not hist_a
+    assert hist_c.shape[-1] == 64
+
+    # dtime is part of the preview signature so the signal cache tracks it.
+    assert widget._extra_preview_signature() == ("dtime", 64)
+
+    # The output shape and signal dims come from metadata (no image decode).
+    widget.dtime.setText("0")
+    assert widget._estimate_base_output_shape() == (256, 256)
+    assert widget._preview_signal_dims()[1] == ("Y", "X", "C", "H")
+
+
+def test_fbd_preview_defaults_and_signature(make_viewer_model, qtbot):
+    """FBD sets reader defaults before previewing and tracks laser_factor."""
+    viewer = make_viewer_model()
+    widget = FbdWidget(viewer, path=get_test_file_path("test_file$EI0S.fbd"))
+
+    # Frame integration is applied before the first preview decode so the
+    # preview matches the final transform.
+    assert widget.reader_options["frame"] == -1
+    # Estimated shape derived without a second full decode + transform.
+    assert widget._estimate_base_output_shape() == (256, 256)
+
+    # laser_factor is part of the preview cache signature.
+    baseline = widget._preview_signature()
+    widget.laser_factor.setText("0.00022")
+    assert widget._preview_signature() != baseline
+    assert widget._extra_preview_signature() == ("laser_factor", "0.00022")
+
+
+def test_sdt_preview_signature(make_viewer_model, qtbot):
+    """SDT tracks the dataset index in the preview cache signature."""
+    viewer = make_viewer_model()
+    widget = SdtWidget(
+        viewer,
+        path=get_test_file_path("seminal_receptacle_FLIM_single_image.sdt"),
+    )
+
+    baseline = widget._preview_signature()
+    widget.index.setText("1")
+    assert widget._preview_signature() != baseline
+    assert widget._extra_preview_signature() == ("index", "1")

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -2029,8 +2029,6 @@ class PtuWidget(AdvancedOptionsWidget):
                 )
                 for path in paths_to_average
             ]
-            if not signals:
-                return None
             try:
                 return np.mean(np.stack(signals, axis=0), axis=0)
             except ValueError:

--- a/src/napari_phasors/_widget.py
+++ b/src/napari_phasors/_widget.py
@@ -42,6 +42,7 @@ from superqt import QRangeSlider
 
 from ._reader import (
     _get_filename_extension,
+    iter_index_mapping,
     napari_get_reader,
     raw_file_stack_reader,
 )
@@ -562,24 +563,28 @@ class AdvancedOptionsWidget(QWidget):
                     val = val_str
                 options[key] = val
 
+    def _preview_shape_and_labels(self):
+        """Return ``(shape, labels)`` describing the decoded signal axes.
+
+        Used to populate the phasor-axis selector. The default implementation
+        decodes the preview signal, but subclasses may override this to derive
+        the shape from file metadata instead, avoiding large memory
+        allocations (see :class:`PtuWidget`).
+        """
+        preview = self._get_preview_signal_data()
+        if preview is None:
+            return (), []
+        if hasattr(preview, 'dims'):
+            return tuple(preview.shape), [str(d).upper() for d in preview.dims]
+        arr = np.asarray(preview)
+        return arr.shape, _default_axis_labels(len(arr.shape))
+
     def _update_axis_options(self):
         """Refresh axis options based on preview signal shape and dims."""
         if not hasattr(self, 'axis_combo'):
             return
 
-        preview = self._get_preview_signal_data()
-        # Determine shape and labels
-        if preview is None:
-            shape = ()
-            labels = []
-        else:
-            if hasattr(preview, 'dims'):
-                labels = [str(d).upper() for d in preview.dims]
-                shape = tuple(preview.shape)
-            else:
-                arr = np.asarray(preview)
-                shape = arr.shape
-                labels = _default_axis_labels(len(shape))
+        shape, labels = self._preview_shape_and_labels()
 
         # Build items: prefer dimension name, show size
         items = ["Auto"]
@@ -652,12 +657,13 @@ class AdvancedOptionsWidget(QWidget):
         else:
             n_files = 1
 
-        shape = _estimate_output_shape_from_options(
-            self.path,
-            self.reader_options,
-            self.harmonics,
-            n_files=n_files,
-        )
+        base_shape = self._estimate_base_output_shape()
+        if base_shape is None:
+            shape = None
+        elif n_files > 1:
+            shape = (n_files,) + tuple(base_shape)
+        else:
+            shape = tuple(base_shape)
 
         axis_order = getattr(self, '_stack_axis_order', None)
         axis_labels = getattr(self, '_stack_axis_labels', None)
@@ -688,8 +694,69 @@ class AdvancedOptionsWidget(QWidget):
             f"Estimated output shape: {shape_text}"
         )
 
+    def _extra_preview_signature(self):
+        """Format-specific option fields affecting the preview signal.
+
+        Subclasses that read options from extra widgets (e.g. ``dtime``,
+        ``laser_factor``, ``index``) override this so the preview cache is
+        invalidated when those change. Returns a hashable value.
+        """
+        return ()
+
+    def _preview_signature(self):
+        """Hashable key identifying the inputs of the current preview signal.
+
+        Lets the plot, axis-selector, and shape-estimate consumers share a
+        single decode within a refresh while still invalidating when the user
+        changes an option (path, channel, extra fields, ...).
+        """
+        multi = tuple(getattr(self, '_multi_file_paths', None) or ())
+        grouped = tuple(getattr(self, '_grouped_file_paths', None) or ())
+        # 'phasor_axis' only affects which axis is transformed, not the decoded
+        # signal, so it is excluded to avoid needless cache invalidation.
+        opts = tuple(
+            sorted(
+                (k, repr(v))
+                for k, v in self.reader_options.items()
+                if k != 'phasor_axis'
+            )
+        )
+        kwargs = tuple(
+            (key_edit.text(), val_edit.text())
+            for key_edit, val_edit, _ in getattr(self, 'kwargs_widgets', [])
+        )
+        return (
+            self.path,
+            multi,
+            grouped,
+            opts,
+            kwargs,
+            self._extra_preview_signature(),
+        )
+
     def _get_preview_signal_data(self):
-        """Return preview signal, averaging across selected stack/grouped files."""
+        """Return the preview signal, decoding at most once per option set.
+
+        Wraps :meth:`_compute_preview_signal_data` with a single-entry cache
+        keyed on :meth:`_preview_signature`, so the signal-preview plot, the
+        phasor-axis selector, and the output-shape estimate reuse one decode
+        instead of decoding the file two or three times per refresh.
+        """
+        try:
+            signature = self._preview_signature()
+        except Exception:  # noqa: BLE001
+            return self._compute_preview_signal_data()
+
+        if getattr(self, '_preview_signal_cache_key', None) == signature:
+            return self._preview_signal_cache
+
+        signal = self._compute_preview_signal_data()
+        self._preview_signal_cache_key = signature
+        self._preview_signal_cache = signal
+        return signal
+
+    def _compute_preview_signal_data(self):
+        """Decode the preview signal, averaging across stack/grouped files."""
         multi_paths = getattr(self, '_multi_file_paths', None)
         grouped_paths = getattr(self, '_grouped_file_paths', None)
 
@@ -723,6 +790,56 @@ class AdvancedOptionsWidget(QWidget):
         except ValueError:
             return signals[0]
 
+    def _estimate_base_output_shape(self):
+        """Return the estimated per-file mean-intensity output shape.
+
+        Derives the shape from the cached preview signal when possible so no
+        second decode + phasor transform is needed; falls back to running the
+        reader when the signal lacks the metadata required to derive it.
+        """
+        _, extension = _get_filename_extension(self.path)
+        shape = _phasor_output_shape_from_signal(
+            self._get_preview_signal_data(), extension, self.reader_options
+        )
+        if shape is not None:
+            return shape
+        return _estimate_output_shape_from_options(
+            self.path, self.reader_options, self.harmonics, n_files=1
+        )
+
+    def _get_channel_preview_signal(self, channel_idx):
+        """Return the preview signal for one channel.
+
+        Decodes the all-channel signal once (shared via the preview cache) and
+        slices out the requested channel, so previewing an N-channel file costs
+        a single decode instead of N. Falls back to decoding the channel
+        directly if the channel axis cannot be located.
+        """
+        original_channel = self.reader_options.get("channel")
+        self.reader_options["channel"] = None
+        try:
+            signal = self._get_preview_signal_data()
+        finally:
+            self.reader_options["channel"] = original_channel
+
+        dims = getattr(signal, "dims", None)
+        if signal is not None and dims is not None and "C" in dims:
+            c_axis = list(dims).index("C")
+            if channel_idx < signal.shape[c_axis]:
+                try:
+                    return signal.isel({"C": channel_idx})
+                except Exception:  # noqa: BLE001
+                    return np.take(
+                        np.asarray(signal), channel_idx, axis=c_axis
+                    )
+
+        # Fallback: decode the requested channel directly.
+        self.reader_options["channel"] = channel_idx
+        try:
+            return self._get_preview_signal_data()
+        finally:
+            self.reader_options["channel"] = original_channel
+
     def _update_signal_plot(self):
         """Update the signal plot based on current parameters."""
         try:
@@ -742,10 +859,7 @@ class AdvancedOptionsWidget(QWidget):
                 colors = plt.cm.tab10(np.linspace(0, 1, self.all_channels))
 
                 for channel_idx in range(self.all_channels):
-                    original_channel = self.reader_options.get("channel")
-                    self.reader_options["channel"] = channel_idx
-                    signal = self._get_preview_signal_data()
-                    self.reader_options["channel"] = original_channel
+                    signal = self._get_channel_preview_signal(channel_idx)
 
                     if signal is None:
                         continue
@@ -1445,6 +1559,152 @@ def _estimate_result_shape(file_paths):
         return None
 
 
+def _reduce_ptu_signal_dims(
+    ptu_shape, ptu_dims, bins_in_period, channel, dtime
+):
+    """Return ``(shape, dims)`` of a decoded PTU signal from metadata only.
+
+    Mirrors the axis reduction of :func:`phasorpy.io.signal_from_ptu` with
+    ``keepdims=False`` for the import widget's options: the time axis is always
+    integrated away (``frame=-1``), the channel axis is kept only when no
+    channel is selected, and ``dtime`` sets the histogram length.
+    """
+    out_shape, out_dims = [], []
+    for size, dim in zip(ptu_shape, ptu_dims, strict=False):
+        dim = str(dim).upper()
+        if dim == "T":
+            continue
+        if dim == "C":
+            if channel is None:
+                out_shape.append(int(size))
+                out_dims.append(dim)
+            continue
+        if dim == "H":
+            if dtime < 0:
+                continue
+            out_shape.append(
+                min(dtime, bins_in_period) if dtime > 0 else bins_in_period
+            )
+            out_dims.append(dim)
+            continue
+        out_shape.append(int(size))
+        out_dims.append(dim)
+    return tuple(out_shape), tuple(out_dims)
+
+
+def _estimate_ptu_output_shape(path, reader_options):
+    """Estimate the per-layer mean-intensity shape of a PTU file from metadata.
+
+    Avoids running the full reader (decode + phasor transform), which can
+    allocate tens of GB for large files. The phasor transform collapses the
+    histogram axis and the channel axis is iterated into separate layers, so
+    both are dropped from the returned spatial shape.
+    """
+    import ptufile
+
+    reader_options = reader_options or {}
+    channel = reader_options.get("channel")
+    try:
+        dtime = int(float(reader_options.get("dtime", 0)))
+    except (TypeError, ValueError):
+        dtime = 0
+
+    try:
+        with _silence_ptufile_logger():
+            with ptufile.PtuFile(path) as ptu:
+                shape = tuple(int(s) for s in ptu.shape)
+                dims = tuple(str(d).upper() for d in ptu.dims)
+                bins = int(ptu.number_bins_in_period)
+    except Exception:  # noqa: BLE001
+        return None
+
+    sig_shape, sig_dims = _reduce_ptu_signal_dims(
+        shape, dims, bins, channel, dtime
+    )
+
+    drop = set()
+    phasor_axis = reader_options.get("phasor_axis")
+    if phasor_axis is not None and 0 <= phasor_axis < len(sig_dims):
+        drop.add(phasor_axis)
+    else:
+        drop.update(i for i, d in enumerate(sig_dims) if d == "H")
+    drop.update(i for i, d in enumerate(sig_dims) if d == "C")
+
+    return tuple(s for i, s in enumerate(sig_shape) if i not in drop)
+
+
+def _phasor_output_shape_from_signal(signal, extension, reader_options):
+    """Derive the per-layer mean-intensity shape from a decoded signal.
+
+    Mirrors the axis selection of :func:`napari_phasors._reader.raw_file_reader`
+    so the estimated output shape can be computed from the already-decoded
+    preview signal instead of running the full reader (decode + phasor
+    transform) a second time. Returns ``None`` if the shape cannot be derived,
+    so callers can fall back to the reader.
+    """
+    if signal is None:
+        return None
+    reader_options = reader_options or {}
+    axis_override = reader_options.get("phasor_axis")
+
+    has_dims = hasattr(signal, "dims")
+    dims = tuple(signal.dims) if has_dims else ()
+    try:
+        shape = tuple(int(s) for s in signal.shape)
+    except (AttributeError, TypeError):
+        shape = tuple(int(s) for s in np.asarray(signal).shape)
+    ndim = len(shape)
+    if ndim == 0:
+        return None
+
+    # Without dimension labels the histogram/channel axes cannot be located
+    # reliably, except for plain TIFF (axis 0 by convention) or an explicit
+    # phasor-axis override. Bail out so the caller falls back to the reader.
+    if (
+        not has_dims
+        and axis_override is None
+        and extension
+        not in (
+            ".tif",
+            ".tiff",
+        )
+    ):
+        return None
+
+    iter_axis = iter_index_mapping.get(extension)
+
+    if iter_axis is None or iter_axis not in dims:
+        # Single-layer path.
+        if axis_override is not None:
+            axis = axis_override
+        elif extension in (".tif", ".tiff"):
+            axis = 0
+        elif has_dims and "H" in dims:
+            axis = dims.index("H")
+        elif has_dims and "C" in dims:
+            axis = dims.index("C")
+        else:
+            axis = 0
+        if not 0 <= axis < ndim:
+            return None
+        return tuple(s for i, s in enumerate(shape) if i != axis)
+
+    # Multi-channel path: the channel axis is iterated into separate layers,
+    # and each layer's phasor axis (H) is collapsed.
+    iter_index = dims.index(iter_axis)
+    reduced_dims = tuple(d for i, d in enumerate(dims) if i != iter_index)
+    reduced_shape = tuple(s for i, s in enumerate(shape) if i != iter_index)
+    if axis_override is not None:
+        hist_axis = axis_override
+    elif "H" in reduced_dims:
+        hist_axis = reduced_dims.index("H")
+    else:
+        hist_axis = 0
+    if not 0 <= hist_axis < len(reduced_shape):
+        return None
+    return tuple(s for i, s in enumerate(reduced_shape) if i != hist_axis)
+
+
 def _estimate_output_shape_from_options(
     path,
     reader_options,
@@ -1454,6 +1714,15 @@ def _estimate_output_shape_from_options(
     """Estimate output shape with current reader options and harmonics."""
     try:
         _, extension = _get_filename_extension(path)
+
+        if extension == ".ptu":
+            base_shape = _estimate_ptu_output_shape(path, reader_options)
+            if base_shape is None:
+                return None
+            if n_files > 1:
+                return (n_files,) + base_shape
+            return base_shape
+
         reader = napari_get_reader(
             path,
             reader_options=reader_options,
@@ -1462,11 +1731,7 @@ def _estimate_output_shape_from_options(
         if reader is None:
             return None
 
-        if extension == ".ptu":
-            with _silence_ptufile_logger():
-                layers = reader(path)
-        else:
-            layers = reader(path)
+        layers = reader(path)
         if not layers:
             return None
         base_shape = tuple(np.shape(layers[0][0]))
@@ -1496,6 +1761,12 @@ class FbdWidget(AdvancedOptionsWidget):
 
     def initUI(self):
         """Initialize the user interface."""
+        # Match the reader defaults (integrate frames, keep all channels) before
+        # the first preview decode so the preview and estimated shape are
+        # consistent with the final transform.
+        self.reader_options["frame"] = -1
+        self.reader_options.setdefault("channel", None)
+
         self.mainLayout = QVBoxLayout()
         self.setLayout(self.mainLayout)
 
@@ -1555,6 +1826,10 @@ class FbdWidget(AdvancedOptionsWidget):
             show_error(f"Error reading FBD signal: {str(e)}")
             return None
 
+    def _extra_preview_signature(self):
+        """Include ``laser_factor`` so the preview cache tracks it."""
+        return ("laser_factor", self.laser_factor.text())
+
     def _on_frames_combobox_changed(self, index):
         """Callback whenever the frames combobox changes."""
         super()._on_frames_combobox_changed(index)
@@ -1584,6 +1859,12 @@ class PtuWidget(AdvancedOptionsWidget):
             with ptufile.PtuFile(path) as ptu:
                 self.all_frames = ptu.shape[0]
                 self.all_channels = ptu.shape[-2]
+                # Cache metadata so preview/estimation paths can derive shapes
+                # without decoding the full image (which can allocate tens of
+                # GB for large files).
+                self._ptu_shape = tuple(int(s) for s in ptu.shape)
+                self._ptu_dims = tuple(str(d).upper() for d in ptu.dims)
+                self._bins_in_period = int(ptu.number_bins_in_period)
 
         super().__init__(viewer, path)
         self.reader_options["frame"] = -1
@@ -1642,6 +1923,120 @@ class PtuWidget(AdvancedOptionsWidget):
             return signal
         except Exception as e:  # noqa: BLE001
             show_error(f"Error reading PTU signal: {str(e)}")
+            return None
+
+    def _dtime_option(self):
+        """Return the current ``dtime`` option as an int (0 if unset)."""
+        text = self.dtime.text().strip() if self.dtime.text() else ""
+        if not text:
+            return 0
+        try:
+            return int(float(text))
+        except ValueError:
+            return 0
+
+    def _preview_signal_dims(self):
+        """Return ``(shape, dims)`` of the decoded signal for current options.
+
+        Derived from cached PTU metadata rather than by decoding the image, so
+        it is instantaneous and allocates no memory. Mirrors the axis reduction
+        performed by :func:`phasorpy.io.signal_from_ptu` (``keepdims=False``)
+        for the widget's options (``frame=-1`` integrates the time axis, the
+        channel is selected/kept, and ``dtime`` sets the histogram length).
+        """
+        return _reduce_ptu_signal_dims(
+            self._ptu_shape,
+            self._ptu_dims,
+            self._bins_in_period,
+            self.reader_options.get("channel"),
+            self._dtime_option(),
+        )
+
+    def _preview_shape_and_labels(self):
+        """Derive the phasor-axis selector shape from metadata (no decode)."""
+        return self._preview_signal_dims()
+
+    def _extra_preview_signature(self):
+        """Include ``dtime`` so the preview cache tracks the histogram length."""
+        return ("dtime", self._dtime_option())
+
+    def _estimate_base_output_shape(self):
+        """Estimate the output shape from PTU metadata (no image decode)."""
+        options = dict(self.reader_options)
+        options["dtime"] = self._dtime_option()
+        return _estimate_ptu_output_shape(self.path, options)
+
+    def _decode_preview_histogram(self, path=None):
+        """Return the per-channel TCSPC histogram summed over all pixels.
+
+        Uses :meth:`ptufile.PtuFile.decode_histogram`, which builds a ``(C, H)``
+        array directly from the photon records without materializing the full
+        ``(T, Y, X, C, H)`` image. Decoding the whole image only to sum it away
+        for the preview plot can allocate tens of GB for large PTU files; this
+        keeps the preview at a few kilobytes. Cached per ``(path, dtime)`` so
+        the per-channel plotting loop decodes each file only once.
+        """
+        import ptufile
+
+        path = path or self.path
+        dtime = self._dtime_option()
+        cache_key = (path, dtime)
+        if getattr(self, "_preview_hist_cache_key", None) == cache_key:
+            return self._preview_hist_cache
+
+        with _silence_ptufile_logger():
+            with ptufile.PtuFile(path) as ptu:
+                hist = np.asarray(
+                    ptu.decode_histogram(dtype="uint32", dtime=dtime)
+                )
+
+        self._preview_hist_cache_key = cache_key
+        self._preview_hist_cache = hist
+        return hist
+
+    def _compute_preview_signal_data(self):
+        """Return a lightweight preview signal for the plot.
+
+        Overrides the base implementation (which decodes the full image via
+        :func:`signal_from_ptu`) with the pixel-summed histogram, so selecting a
+        large PTU file in the import widget no longer exhausts memory. The full
+        image is only decoded when the user runs the phasor transform.
+        """
+        multi_paths = getattr(self, "_multi_file_paths", None)
+        grouped_paths = getattr(self, "_grouped_file_paths", None)
+        paths_to_average = None
+        if grouped_paths and len(grouped_paths) > 1:
+            paths_to_average = grouped_paths
+        elif multi_paths and len(multi_paths) > 1:
+            paths_to_average = multi_paths
+
+        channel = self.reader_options.get("channel")
+
+        def _select_channel(hist):
+            if channel is None:
+                return hist
+            if 0 <= channel < hist.shape[0]:
+                return hist[channel]
+            return hist
+
+        try:
+            if paths_to_average is None:
+                return _select_channel(self._decode_preview_histogram())
+
+            signals = [
+                np.asarray(
+                    _select_channel(self._decode_preview_histogram(path))
+                )
+                for path in paths_to_average
+            ]
+            if not signals:
+                return None
+            try:
+                return np.mean(np.stack(signals, axis=0), axis=0)
+            except ValueError:
+                return signals[0]
+        except Exception as e:  # noqa: BLE001
+            show_error(f"Error reading PTU signal preview: {str(e)}")
             return None
 
     def _on_frames_combobox_changed(self, index):
@@ -1861,6 +2256,10 @@ class SdtWidget(AdvancedOptionsWidget):
         except Exception as e:  # noqa: BLE001
             show_error(f"Error reading SDT signal: {str(e)}")
             return None
+
+    def _extra_preview_signature(self):
+        """Include the dataset ``index`` so the preview cache tracks it."""
+        return ("index", self.index.text())
 
     def _on_click(self, path, reader_options, harmonics):
         """Callback whenever the calculate phasor button is clicked."""


### PR DESCRIPTION
## Summary

This PR optimizes memory usage and performance in the `napari-phasors` import widget by introducing a single-entry caching mechanism for preview signals and leveraging header metadata to avoid full image decodes for `.ptu` files during preview and shape estimation steps.

Previously, updating UI components (such as the signal preview plot, phasor-axis dropdown, and output shape preview) could trigger multiple redundant full-image decodes. For large datasets—especially multi-gigabyte `.ptu` TCSPC files—this resulted in massive memory allocations (often tens of GBs) and sluggish UI response times.


## Key Changes

### 1. Preview Signal Caching (`_widget.py`)
* **Single-Entry Cache:** Replaced direct `_get_preview_signal_data()` calls with a cached wrapper around `_compute_preview_signal_data()`. Caching is keyed via `_preview_signature()`, which tracks path selections, reader options, custom `kwargs`, and format-specific parameters.
* **Efficient Channel Extraction:** Added `_get_channel_preview_signal(channel_idx)`, which decodes all channels once and slices out requested channels in-memory rather than issuing $N$ separate decodes.
* **Format-Specific Cache Keys:** Introduced `_extra_preview_signature()` across subclasses (`FbdWidget`, `PtuWidget`, `SdtWidget`) to track changes to specific input fields (e.g., `laser_factor`, `dtime`, `index`).

### 2. Low-Memory PTU Preview & Metadata-Based Shape Inference
* **Histogram-Only Preview Decoding:** Overrode `_compute_preview_signal_data()` in `PtuWidget` to utilize `ptufile.PtuFile.decode_histogram()`. This constructs pixel-summed $(C, H)$ histograms directly from photon records, drastically cutting memory consumption from gigabytes to kilobytes.
* **Header-Based Shape Estimation:** Implemented `_reduce_ptu_signal_dims()` and `_estimate_ptu_output_shape()` to calculate expected output shapes directly from cached metadata (`ptu.shape`, `ptu.dims`, `bins_in_period`) without running full transform pipelines.
* **Cached Signal Shape Inference:** Added `_phasor_output_shape_from_signal()` to derive output dimensions directly from already-decoded preview signals for other file types before falling back to full reader initialization.

### 3. Test Updates (`test_widget.py`)
* Updated `test_signal_plot_error_handling` to explicitly set `widget._preview_signal_cache_key = None`, ensuring error-handling behavior actually triggers a re-decode rather than serving stale cached data.


## Technical Impact

* **Memory Usage:** Prevents multi-gigabyte memory spikes when selecting or tweaking options on large `.ptu` datasets in the widget.
* **Responsiveness:** Signal plot updates, channel slicing, and axis-selector refreshes operate instantly by sharing cached preview signatures.
