### PR TITLE
fix: tolerate foreign and corrupt OME-TIF descriptions (#89)

### DIFF
--- a/src/napari_phasors/_reader.py
+++ b/src/napari_phasors/_reader.py
@@ -9,6 +9,7 @@ import inspect
 import itertools
 import json
 import os
+import warnings
 from collections.abc import Callable, Sequence
 from typing import Any, Union
 
@@ -758,6 +759,93 @@ def raw_file_stack_reader(
     return stacked_layers
 
 
+#: Key under which this plugin stores its settings in the OME-TIF description.
+SETTINGS_DESCRIPTION_KEY = "napari_phasors_settings"
+
+#: Largest description string (in characters) that will be parsed. Descriptions
+#: are hand-sized JSON blobs; anything larger is treated as foreign content and
+#: ignored rather than parsed into memory.
+MAX_DESCRIPTION_CHARS = 512 * 512  # 256 KB
+
+
+def _parse_description_settings(description: Any) -> dict:
+    """Return this plugin's settings from an OME-TIF description field.
+
+    The ``description`` field of a TIFF is free-form text that any other tool
+    may legitimately write to, so it is treated as untrusted input: anything
+    that is not a well-formed napari-phasors settings payload is ignored with a
+    warning instead of raising, leaving the image data itself readable.
+
+    Parameters
+    ----------
+    description : Any
+        Raw value of the ``description`` entry of the file attributes. Normally
+        a string, but not guaranteed to be.
+
+    Returns
+    -------
+    settings : dict
+        The stored settings, or an empty dict if the description is missing,
+        oversized, malformed, or written by another application.
+    """
+    if description is None:
+        # No description entry at all: the common case for files written by
+        # other software. Nothing to warn about.
+        return {}
+
+    if not isinstance(description, str):
+        warnings.warn(
+            "Ignoring OME-TIF description: expected a string, got "
+            f"{type(description).__name__}.",
+            stacklevel=2,
+        )
+        return {}
+
+    # Guard on the raw string before parsing, so an oversized payload is never
+    # materialised as Python objects.
+    if len(description) > MAX_DESCRIPTION_CHARS:
+        warnings.warn(
+            "Ignoring OME-TIF description: it is larger than the "
+            f"{MAX_DESCRIPTION_CHARS} character limit.",
+            stacklevel=2,
+        )
+        return {}
+
+    try:
+        # tifffile may HTML-encode the description when writing it.
+        parsed = json.loads(html.unescape(description))
+    except (ValueError, TypeError):
+        # Not JSON at all: written by Fiji, Bio-Formats, or any other tool.
+        return {}
+
+    if not isinstance(parsed, dict) or SETTINGS_DESCRIPTION_KEY not in parsed:
+        # Valid JSON, but not ours. Nothing to recover, and nothing is wrong.
+        return {}
+
+    raw_settings = parsed[SETTINGS_DESCRIPTION_KEY]
+    try:
+        settings = json.loads(raw_settings)
+    except (ValueError, TypeError):
+        warnings.warn(
+            f"Ignoring corrupted '{SETTINGS_DESCRIPTION_KEY}' entry in the "
+            "OME-TIF description: it is not valid JSON.",
+            stacklevel=2,
+        )
+        return {}
+
+    if not isinstance(settings, dict):
+        warnings.warn(
+            f"Ignoring '{SETTINGS_DESCRIPTION_KEY}' entry in the OME-TIF "
+            f"description: expected an object, got {type(settings).__name__}.",
+            stacklevel=2,
+        )
+        return {}
+
+    if "calibrated" in settings:
+        settings["calibrated"] = bool(settings["calibrated"])
+    return settings
+
+
 def processed_file_reader(
     path: str,
     reader_options: dict[str, str] | None = None,
@@ -808,18 +896,7 @@ def processed_file_reader(
             "processed"
         ][file_extension](path, filtered_reader_options)
         pbr.update(1)
-        if "description" in attrs:
-            # HTML-unescape the description to handle tifffile HTML encoding
-            description_str = html.unescape(attrs["description"])
-            description = json.loads(description_str)
-            if len(json.dumps(description)) > 512 * 512:  # Threshold: 256 KB
-                raise ValueError("Description dictionary is too large.")
-            if "napari_phasors_settings" in description:
-                settings = json.loads(description["napari_phasors_settings"])
-                if "calibrated" in settings:
-                    settings["calibrated"] = bool(settings["calibrated"])
-        else:
-            settings = {}
+        settings = _parse_description_settings(attrs.get("description"))
         if "frequency" in attrs:
             settings["frequency"] = attrs["frequency"]
         harmonics_read = attrs.get("harmonic", None)

--- a/src/napari_phasors/_tests/test_reader.py
+++ b/src/napari_phasors/_tests/test_reader.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 import numpy as np
 import pytest
@@ -1025,15 +1026,160 @@ def _patch_processed(monkeypatch, mean, real, imag, attrs):
     )
 
 
-def test_processed_reader_description_too_large_raises(monkeypatch):
-    """An oversized description dictionary raises a ValueError."""
+def test_processed_reader_description_too_large_warns(monkeypatch):
+    """An oversized description is ignored with a warning, not fatal."""
     mean = np.ones((4, 4))
     real = np.zeros((1, 4, 4))
     big = {"x": "a" * 300000}
     attrs = {"description": json.dumps(big), "harmonic": [1]}
     _patch_processed(monkeypatch, mean, real, real, attrs)
-    with pytest.raises(ValueError, match="too large"):
-        reader_module.processed_file_reader("x.ome.tif")
+    with pytest.warns(UserWarning, match="larger than"):
+        layers = reader_module.processed_file_reader("x.ome.tif")
+    assert layers[0][1]["metadata"]["settings"] == {}
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        pytest.param("ImageJ=1.54f\nunit=micron", id="plain_text"),
+        pytest.param("", id="empty_string"),
+        pytest.param('{"Info": "written by another tool"}', id="foreign_json"),
+        pytest.param("[1, 2, 3]", id="json_list"),
+        pytest.param("42", id="json_scalar"),
+    ],
+)
+def test_processed_reader_foreign_description_is_ignored(
+    monkeypatch, description
+):
+    """A description written by another tool is ignored, not fatal.
+
+    Regression test for the ``UnboundLocalError`` raised when a description
+    parsed as JSON but did not contain the plugin's settings key.
+    """
+    mean = np.ones((4, 4))
+    real = np.zeros((1, 4, 4))
+    attrs = {"description": description, "harmonic": [1]}
+    _patch_processed(monkeypatch, mean, real, real, attrs)
+    layers = reader_module.processed_file_reader("x.ome.tif")
+    assert layers[0][1]["metadata"]["settings"] == {}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("{not-json", id="corrupt_json"),
+        pytest.param('"a string"', id="json_string"),
+        pytest.param("[1, 2]", id="json_list"),
+        pytest.param(17, id="not_a_string"),
+    ],
+)
+def test_processed_reader_corrupt_settings_entry_warns(monkeypatch, payload):
+    """A malformed settings entry is dropped with a warning."""
+    mean = np.ones((4, 4))
+    real = np.zeros((1, 4, 4))
+    attrs = {
+        "description": json.dumps({"napari_phasors_settings": payload}),
+        "harmonic": [1],
+    }
+    _patch_processed(monkeypatch, mean, real, real, attrs)
+    with pytest.warns(UserWarning):
+        layers = reader_module.processed_file_reader("x.ome.tif")
+    assert layers[0][1]["metadata"]["settings"] == {}
+
+
+def test_processed_reader_non_string_description_warns(monkeypatch):
+    """A non-string description is ignored with a warning."""
+    mean = np.ones((4, 4))
+    real = np.zeros((1, 4, 4))
+    attrs = {"description": {"already": "decoded"}, "harmonic": [1]}
+    _patch_processed(monkeypatch, mean, real, real, attrs)
+    with pytest.warns(UserWarning, match="expected a string"):
+        layers = reader_module.processed_file_reader("x.ome.tif")
+    assert layers[0][1]["metadata"]["settings"] == {}
+
+
+def test_processed_reader_missing_description_is_ignored(monkeypatch, recwarn):
+    """A file without any description reads cleanly and warns about nothing."""
+    mean = np.ones((4, 4))
+    real = np.zeros((1, 4, 4))
+    _patch_processed(monkeypatch, mean, real, real, {"harmonic": [1]})
+    layers = reader_module.processed_file_reader("x.ome.tif")
+    assert layers[0][1]["metadata"]["settings"] == {}
+    assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+
+def test_processed_reader_frequency_survives_bad_description(monkeypatch):
+    """``frequency`` from file attrs is kept even if the description is bad."""
+    mean = np.ones((4, 4))
+    real = np.zeros((1, 4, 4))
+    attrs = {
+        "description": "not json at all",
+        "harmonic": [1],
+        "frequency": 80.0,
+    }
+    _patch_processed(monkeypatch, mean, real, real, attrs)
+    layers = reader_module.processed_file_reader("x.ome.tif")
+    assert layers[0][1]["metadata"]["settings"]["frequency"] == 80.0
+
+
+def test_parse_description_settings_unescapes_html():
+    """HTML-encoded descriptions written by tifffile are decoded."""
+    settings = {"frequency": 80.0, "calibrated": 1}
+    description = json.dumps(
+        {"napari_phasors_settings": json.dumps(settings)}
+    ).replace('"', "&quot;")
+    parsed = reader_module._parse_description_settings(description)
+    assert parsed["frequency"] == 80.0
+    assert parsed["calibrated"] is True
+
+
+def test_parse_description_settings_at_size_limit():
+    """A description exactly at the size limit is still parsed."""
+    padding = "a" * 100
+    settings = json.dumps({"pad": padding})
+    description = json.dumps({"napari_phasors_settings": settings})
+    description += " " * (
+        reader_module.MAX_DESCRIPTION_CHARS - len(description)
+    )
+    assert len(description) == reader_module.MAX_DESCRIPTION_CHARS
+    assert reader_module._parse_description_settings(description) == {
+        "pad": padding
+    }
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        pytest.param("ImageJ=1.54f\nunit=micron", id="plain_text"),
+        pytest.param('{"Info": "written by another tool"}', id="foreign_json"),
+        pytest.param("[1, 2, 3]", id="json_list"),
+        pytest.param('{"napari_phasors_settings": "{not-json"}', id="corrupt"),
+    ],
+)
+def test_read_real_ometiff_with_foreign_description(tmp_path, description):
+    """End-to-end: a real OME-TIF with a foreign description still opens.
+
+    Exercises the full phasorpy write/read round trip rather than a patched
+    reader, so it also covers the HTML escaping tifffile applies on write.
+    """
+    from phasorpy.io import phasor_to_ometiff
+
+    path = tmp_path / "foreign.ome.tif"
+    rng = np.random.default_rng(0)
+    mean = rng.random((8, 8)).astype(np.float32)
+    real = rng.random((8, 8)).astype(np.float32)
+    imag = rng.random((8, 8)).astype(np.float32)
+    phasor_to_ometiff(
+        path, mean, real, imag, harmonic=1, description=description
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        layers = reader_module.processed_file_reader(str(path))
+
+    assert len(layers) == 1
+    assert layers[0][1]["metadata"]["settings"] == {}
+    np.testing.assert_allclose(layers[0][0], mean, rtol=1e-6)
 
 
 def test_processed_reader_calibrated_and_frequency_settings(monkeypatch):


### PR DESCRIPTION
## Summary

Closes #89.

The `description` field of a TIFF is free-form text that any tool may legitimately write to, but `processed_file_reader` treated it as guaranteed-valid plugin JSON. As a result, an otherwise perfectly good file could fail to open entirely.

Reproduced end-to-end against real `phasor_to_ometiff`-written files (all four raised before this change, all four open cleanly after):

| Description written into the file | Before |
|---|---|
| `ImageJ=1.54f\nunit=micron` (Fiji / Bio-Formats) | `JSONDecodeError` |
| `{"Info": "written by another tool"}` | **`UnboundLocalError`** |
| `[1, 2, 3]` | **`UnboundLocalError`** |
| `{"napari_phasors_settings": "{not-json"}` | `JSONDecodeError` |

## Defects fixed

- **`settings` could be unbound.** It was assigned only inside `if "napari_phasors_settings" in description:`, so any description that parsed as JSON but lacked that key fell through to `settings["frequency"] = ...` and raised `UnboundLocalError`. This is the most severe of the six — it needs nothing more exotic than another tool having written JSON to the field.
- **`json.loads(description)` was unguarded**, so a plain-text description raised `JSONDecodeError`.
- **Membership testing assumed a dict**, so a JSON scalar raised `TypeError` and a JSON list silently did the wrong test.
- **The inner settings payload was parsed unguarded**, so a truncated blob raised.
- **The size guard ran after parsing**, and measured by re-serialising the whole structure (`len(json.dumps(description))`) — an oversized payload was fully materialised before being rejected.
- **That guard raised `ValueError`**, discarding valid image data over a metadata problem.

## Approach

Parsing moves into `_parse_description_settings`, which never raises and always returns a dict:

- size-guards the **raw string** before parsing, so an oversized payload is never materialised;
- tolerates non-JSON, non-dict, and corrupt payloads;
- warns only when the content genuinely looks like ours but is unusable. An **absent or foreign description is normal and stays silent** — warning there would fire on most third-party files.

This follows the issue's stated intent: *"in case this is corrupted and can't be read, avoid using this as metadata."*

I kept the existing `napari_phasors_settings` key rather than adding begin/end tags as the issue floated. A single JSON key already delimits the payload unambiguously; sentinel tags would add a second, weaker framing mechanism and a migration burden without fixing any of the failures above. Happy to revisit if you'd prefer the tag approach.

`warnings.warn` is used rather than `napari.utils.notifications.show_warning` because the reader runs outside any Qt/GUI context and warnings are directly assertable in tests. Widget modules keep using notifications as before.

## Behaviour change

`test_processed_reader_description_too_large_raises` asserted the old fail-hard behaviour on oversized descriptions. Since the reader now degrades instead of raising, it is replaced by `test_processed_reader_description_too_large_warns`, which asserts the warning and that the image still loads with empty settings.

## Tests

16 new/updated cases covering each defect, including an end-to-end test that writes real OME-TIFs via `phasor_to_ometiff` and reads them back (this also covers the HTML escaping `tifffile` applies on write), plus a `recwarn` assertion that the common no-description path stays silent.

Full suite: **1241 passed**. `ruff`, `black`, `isort` and `pre-commit run --all-files` all clean.

## Note for reviewers

This also lays the groundwork for #167 — once the reader tolerates unknown and oversized description content, manual selections can be added as a separate sibling key that degrades gracefully instead of breaking the file. I'll open that separately once this lands.
